### PR TITLE
fix(breadcrumb/basic): linkfactory to the rescue

### DIFF
--- a/components/breadcrumb/basic/src/index.js
+++ b/components/breadcrumb/basic/src/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, {PropTypes} from 'react'
 import Chevronright from '@schibstedspain/sui-svgiconset/lib/Chevronright'
 
@@ -6,15 +7,16 @@ export default function BreadcrumbBasic (props) {
     links,
     icon
   } = props
+  const Link = props.linkFactory
   const IconAngle = icon || Chevronright
   const numLinks = links.length - 1
   return (
     <ul className='sui-BreadcrumbBasic'>
-      {links.map(({link, label}, index) =>
-        <li className='sui-BreadcrumbBasic-listItem'>
-          <a key={index} href={link} className='sui-BreadcrumbBasic-link'>
+      {links.map(({url, label}, index) =>
+        <li className='sui-BreadcrumbBasic-listItem' key={index}>
+          <Link href={url} className='sui-BreadcrumbBasic-link'>
             {label}
-          </a>
+          </Link>
           { index < numLinks && <IconAngle svgClass='sui-BreadcrumbBasic-icon' /> }
         </li>
       )}
@@ -35,10 +37,15 @@ BreadcrumbBasic.propTypes = {
     /**
      * URL for the link
      */
-    link: PropTypes.string.isRequired
+    url: PropTypes.string.isRequired
   })).isRequired,
   /**
    * Comments custom icon (React component).
    */
   icon: PropTypes.func
+}
+
+BreadcrumbBasic.defaultProps = {
+  linkFactory: ({ href, className, children }) =>
+    <a href={href} className={className}>{children}</a>
 }

--- a/demo/breadcrumb/basic/playground
+++ b/demo/breadcrumb/basic/playground
@@ -3,23 +3,23 @@ const ArrowRight = ({ svgClass }) => <svg viewBox="0 0 24 24" width='24' height=
 const links = [
   {
     label: 'accusantium',
-    link: 'https://github.com/SUI-Components/sui-components'
+    url: 'https://github.com/SUI-Components/sui-components'
   },
   {
     label: 'et quibusdam',
-    link: 'https://github.com/SUI-Components/sui-components'
+    url: 'https://github.com/SUI-Components/sui-components'
   },
   {
     label: 'dolores vitae',
-    link: 'https://github.com/SUI-Components/sui-components'
+    url: 'https://github.com/SUI-Components/sui-components'
   },
   {
     label: 'reprehenderit',
-    link: 'https://github.com/SUI-Components/sui-components'
+    url: 'https://github.com/SUI-Components/sui-components'
   },
   {
     label: 'ullam hic',
-    link: 'https://github.com/SUI-Components/sui-components'
+    url: 'https://github.com/SUI-Components/sui-components'
   }
 ]
 


### PR DESCRIPTION
- Replace standard link with linkfactory
- Replace property `link` by `url` :P