### PR TITLE
feat(card/subscription): simplify compoment according to responses types

### DIFF
--- a/components/card/subscription/README.md
+++ b/components/card/subscription/README.md
@@ -4,7 +4,7 @@
 SUI `CArdSubscription` component is a card with a title, an image, an input and a button.
 
 By submitting the form, a handler is triggered via prop and receives the input value.
-In case of `validationErrorMessage`, the component will render this message next to the form and will flag the input with class `has-error`. Otherwise `responseContent` will replace the component.
+In case of `responseError`, the component will render the `responseContent` next to the form and will flag the input with class `has-error`. Otherwise `responseContent` will replace the component.
 
 ## Installation
 ```
@@ -15,49 +15,47 @@ $ npm install --save @schibstedspain/sui-card-subscription
 ```js
 import React, { Component } from 'react'
 import CardSubscription from '@schibstedspain/sui-card-subscription'
-
 const errorEmail = 'error@test.com'
+const placeholder = 'Escribe tu email'
+const title = 'Recibe todas las novedades'
 
-const responseContent = () => (
-    <p>Success message</p>
+const responseOk = () => (
+  <p style={successStyles}>Hello! This is a success message</p>
 )
-const validationErrorMessage = () => (
-  <p>Error message</p>
+
+const responseKo = () => (
+  <p style={errorStyles}>This is an error message</p>
 )
+
+
 
 class MyCardSubscription extends React.Component {
   constructor (...args) {
     super(...args)
     this.state = {
-      responseContent: null,
-      validationErrorMessage: null
+      responseContent: null
     }
   }
 
   _handleSubmit = (value) => {
-    if (value === errorEmail) {
-      this.setState({
-        validationErrorMessage: validationErrorMessage,
-        responseContent: null
-      })
-    } else {
-      this.setState({
-        validationErrorMessage: null,
-        responseContent: responseContent
-      })
-    }
+    this.setState({
+      responseContent: value === errorEmail ? responseKo : responseOk,
+      responseError: value === errorEmail ? true : false
+    })
   }
 
   render () {
     return (
-      <CardSubscription
-        iconButton={ArrowRight}
-        onSubmit={this._handleSubmit}
-        placeholder={placeholder}
-        responseContent={this.state.responseContent}
-        validationErrorMessage={this.state.validationErrorMessage}
-        title={title}
-      />
+      <div>
+        <CardSubscription
+          iconButton={ArrowRight}
+          onSubmit={this._handleSubmit}
+          placeholder={placeholder}
+          responseContent={this.state.responseContent}
+          responseError={this.state.responseError}
+          title={title}
+        />
+      </div>
     )
   }
 }

--- a/components/card/subscription/README.md
+++ b/components/card/subscription/README.md
@@ -40,7 +40,7 @@ class MyCardSubscription extends React.Component {
   _handleSubmit = (value) => {
     this.setState({
       responseContent: value === errorEmail ? responseKo : responseOk,
-      responseError: value === errorEmail ? true : false
+      responseError: value === errorEmail
     })
   }
 

--- a/components/card/subscription/src/index.js
+++ b/components/card/subscription/src/index.js
@@ -12,18 +12,16 @@ export default class CardSubscription extends Component {
   }
 
   _printCardContent = () => {
-    const { placeholder, iconButton, validationErrorMessage } = this.props
+    const { placeholder, iconButton, responseError } = this.props
     const IconAngle = iconButton || Chevronright
     const inputClassName = cx('sui-CardSubscription-input', {
-      'has-error': !!validationErrorMessage
+      'has-error': !!responseError
     })
     return (
       <form onSubmit={this._handleSubmit} className='sui-CardSubscription-form'>
         <input
           className={inputClassName} placeholder={placeholder}
-          type='email'
           ref={node => { this.input = node }}
-          required
         />
         <button type='submit' className='sui-CardSubscription-button'>
           <IconAngle svgClass='sui-CardSubscription-buttonIcon' />
@@ -35,23 +33,23 @@ export default class CardSubscription extends Component {
   render () {
     const {
       responseContent: ResponseContent,
-      validationErrorMessage: ValidationErrorMessage,
+      responseError,
       title
     } = this.props
     return (
       <div>
-        {!ResponseContent &&
+        {(!ResponseContent || !!responseError) &&
           <div className='sui-CardSubscription'>
             <div className='sui-CardSubscription-content'>
               <p className='sui-CardSubscription-title'>{title}</p>
               {this._printCardContent()}
-              {ValidationErrorMessage &&
-                <ValidationErrorMessage />
+              {(ResponseContent && responseError) &&
+                <ResponseContent />
               }
             </div>
           </div>
         }
-        {ResponseContent &&
+        {(ResponseContent && !responseError) &&
           <ResponseContent />
         }
       </div>
@@ -86,9 +84,9 @@ CardSubscription.propTypes = {
   responseContent: PropTypes.element,
 
   /**
-   * Response error message
+   * Response error flag
    */
-  validationErrorMessage: PropTypes.element
+  responseError: PropTypes.bool
 }
 
 CardSubscription.displayName = 'CardSubscription'

--- a/components/card/subscription/src/index.scss
+++ b/components/card/subscription/src/index.scss
@@ -53,7 +53,7 @@
   }
 
   &-button {
-    @include sui-button--custom($c-card-subscription-button);
+    @include sui-button($type-card-subscription-button);
     border-bottom-left-radius: 0;
     border-top-left-radius: 0;
 

--- a/components/card/subscription/src/index.scss
+++ b/components/card/subscription/src/index.scss
@@ -12,6 +12,7 @@
     content: '';
     height: $h-card-subscription-image;
     position: absolute;
+    top: $t-card-subscription-image;
     width: 100%;
   }
 

--- a/components/card/subscription/src/index.scss
+++ b/components/card/subscription/src/index.scss
@@ -53,7 +53,7 @@
   }
 
   &-button {
-    @include sui-button;
+    @include sui-button--custom($c-card-subscription-button);
     border-bottom-left-radius: 0;
     border-top-left-radius: 0;
 

--- a/components/card/subscription/src/index.scss
+++ b/components/card/subscription/src/index.scss
@@ -54,6 +54,8 @@
 
   &-button {
     @include sui-button;
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
 
     &Icon {
       fill: $c-card-subscription-icon !important;

--- a/demo/card/subscription/playground
+++ b/demo/card/subscription/playground
@@ -21,35 +21,29 @@ const helpStyles = {
   marginTop: '10px',
   marginBottom: '0'
 }
-const responseContent = () => (
-  <p style={successStyles}>Hello! This is a success message</p>
-)
-const validationErrorMessage = () => (
-  <p style={errorStyles}>This is an error message</p>
-)
+const responseList = {
+  ok: () => (
+    <p style={successStyles}>Hello! This is a success message</p>
+  ),
+  ko: () => (
+    <p style={errorStyles}>This is an error message</p>
+  )
+}
 
 class MyCardSubscription extends React.Component {
   constructor (...args) {
     super(...args)
     this.state = {
-      responseContent: null,
-      validationErrorMessage: null
+      responseContent: null
     }
     this._handleSubmit = this._handleSubmit.bind(this)
   }
 
   _handleSubmit (value) {
-    if (value === errorEmail) {
-      this.setState({
-        validationErrorMessage: validationErrorMessage,
-        responseContent: null
-      })
-    } else {
-      this.setState({
-        validationErrorMessage: null,
-        responseContent: responseContent
-      })
-    }
+    this.setState({
+      responseContent: value === errorEmail ? responseList.ko : responseList.ok,
+      responseError: value === errorEmail ? true : false
+    })
   }
 
   render () {
@@ -60,7 +54,7 @@ class MyCardSubscription extends React.Component {
           onSubmit={this._handleSubmit}
           placeholder={placeholder}
           responseContent={this.state.responseContent}
-          validationErrorMessage={this.state.validationErrorMessage}
+          responseError={this.state.responseError}
           title={title}
         />
         <p style={helpStyles}>Use '{errorEmail}' to show the error message, or  any other email address to submit the form.</p>


### PR DESCRIPTION
Given the number of success and error responses, i've been refactoring the component to easily manage the responses.
From now on, the response (either successful or error) is sent as `responseContent`.
The flag `responseError` will indicate if there is an error on the response. 
This error can be: 
- Already subscripted
- Invalid email format
- input empty
...
