### PR TITLE
feat(card/article): get tag chip as a prop

### DIFF
--- a/components/card/article/src/index.js
+++ b/components/card/article/src/index.js
@@ -148,7 +148,11 @@ CardArticle.propTypes = {
   lazyLoad: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.object
-  ])
+  ]),
+  /**
+   * Tag chip component
+   */
+  tagChip: PropTypes.func
 }
 
 CardArticle.defaultProps = {

--- a/components/card/article/src/index.js
+++ b/components/card/article/src/index.js
@@ -3,7 +3,7 @@ import React, { PropTypes } from 'react'
 import cx from 'classnames'
 import Commentsquare from '@schibstedspain/sui-svgiconset/lib/Commentsquare'
 import ImageLazyLoad from '@schibstedspain/sui-image-lazy-load'
-import TagChip from '@schibstedspain/sui-tag-chip'
+import SuiTagChip from '@schibstedspain/sui-tag-chip'
 
 const CardArticleMedia = ({ src, alt = '' }) => (
   <div className='sui-CardArticle-media'>
@@ -33,6 +33,7 @@ export default function CardArticle ({
   title,
   description,
   tag,
+  tagChip: TagChip,
   comments,
   lazyLoad,
   tagClassName,
@@ -151,6 +152,7 @@ CardArticle.propTypes = {
 }
 
 CardArticle.defaultProps = {
+  tagChip: SuiTagChip,
   featured: false,
   linkFactory: ({ href, className, children }) =>
     <a href={href} className={className}>{children}</a>


### PR DESCRIPTION
include tag-chip as a prop, so other components will be able to pass specific tag-chip-component.