### PR TITLE
feat(form/autocompleted): execute handleSubmit on press return

### DIFF
--- a/components/form/autocompleted/src/index.js
+++ b/components/form/autocompleted/src/index.js
@@ -56,6 +56,8 @@ export default class FormAutocompleted extends Component {
       const value = suggest.literal || suggest.content
       this.setState({ value })
       this._handleSelect(suggest)
+    } else {
+      this._handleSubmit()
     }
   }
 


### PR DESCRIPTION
This PR will allow users to execute handleSubmit on press `return`.