### PR TITLE
feat(form/autocompleted): allow external set of text

### DIFF
--- a/components/form/autocompleted/src/index.js
+++ b/components/form/autocompleted/src/index.js
@@ -72,6 +72,12 @@ export default class FormAutocompleted extends Component {
     this.input.focus()
   }
 
+  setValue = value => {
+    this.setState({
+      value
+    })
+  }
+
   _handleChange = (event) => {
     const value = event.target.value
     this.setState({


### PR DESCRIPTION
initialValue works as expected when you have the value to provide on the first render. But a lot of

cases will not have this since an async operation is needed in order to perform that data (last user

search for example)

Because of that, this provides an api in the same spirit of focusInput in order

to provide a initial value after the first render