### PR TITLE
Bugfix/mouse over before interactive dom

### DIFF
--- a/components/dropdown/basic/src/index.js
+++ b/components/dropdown/basic/src/index.js
@@ -35,16 +35,20 @@ class DropdownBasic extends Component {
    * Mouser over event handler.
    */
   _onMouseOver = () => {
-    this._toggleMenu()
-    this.setState({ collapseByTouch: true })
+    this.setState({
+      expanded: true,
+      collapseByTouch: true
+    })
   }
 
   /**
    * Mouser out event handler.
    */
   _onMouseOut = () => {
-    this._toggleMenu()
-    this.setState({ collapseByTouch: false })
+    this.setState({
+      expanded: false,
+      collapseByTouch: false
+    })
   }
 
   /**

--- a/components/dropdown/user/src/index.js
+++ b/components/dropdown/user/src/index.js
@@ -21,13 +21,17 @@ class DropdownUser extends Component {
   }
 
   _onMouseOver = () => {
-    this._toggleMenu()
-    this.setState({ collapseByTouch: true })
+    this.setState({
+      expanded: true,
+      collapseByTouch: true
+    })
   }
 
   _onMouseOut = () => {
-    this._toggleMenu()
-    this.setState({ collapseByTouch: false })
+    this.setState({
+      expanded: false,
+      collapseByTouch: false
+    })
   }
 
   _renderLink = ({ text, url, icon: Icon }, index) => {


### PR DESCRIPTION
This PR Fixes an issue present in the current drop downs.

If you keep your mouse on the menu item that should be displayed the `expanded` state gets inverted.
This is because we where using `_toggleMenu` who does not care about the previous state.

The change ensures that `onMouseOver` expandend is always `true` and in `onMouseOut` expanded is always `false`