### PR TITLE
feat(topbar/user): allow to provide a custom Call to Action in the top bar

### DIFF
--- a/components/topbar/user/src/default-call-to-action.js
+++ b/components/topbar/user/src/default-call-to-action.js
@@ -1,0 +1,20 @@
+import React, {PropTypes} from 'react'
+
+const DefaultCallToAction = ({ text, url, icon: Icon, linkFactory: Link }) =>
+  <div className='sui-TopbarUser-navCTA'>
+    <Link href={url} className='sui-TopbarUser-navCTALink' title={text}>
+      {Icon && <Icon svgClass='sui-TopbarUser-navCTAIcon' />}
+      <span>{text}</span>
+    </Link>
+  </div>
+
+DefaultCallToAction.displayName = 'DefaultCallToAction'
+
+DefaultCallToAction.propTypes = {
+  linkFactory: PropTypes.func.isRequired,
+  text: PropTypes.string.isRequired,
+  url: PropTypes.string.isRequired,
+  icon: PropTypes.func
+}
+
+export default DefaultCallToAction

--- a/components/topbar/user/src/index.js
+++ b/components/topbar/user/src/index.js
@@ -4,6 +4,7 @@ import cx from 'classnames'
 import Menu from '@schibstedspain/sui-svgiconset/lib/Menu'
 import DropdownBasic from '@schibstedspain/sui-dropdown-basic'
 import DropdownUser from '@schibstedspain/sui-dropdown-user'
+import DefaultCallToAction from './default-call-to-action'
 
 const DEFAULT_NAV_WRAP_STYLE = {
   top: 'inherit',
@@ -132,6 +133,7 @@ class TopbarUser extends Component {
   render () {
     const { menuExpanded, isToggleHidden, navWrapStyle } = this.state
     const {
+      callToActionComponent: CallToActionComponent,
       toggleIcon: ToggleIcon,
       brand,
       navMain,
@@ -176,16 +178,7 @@ class TopbarUser extends Component {
                 expandOnMouseOver
               />
             </div>
-            {navCTA &&
-              <div className='sui-TopbarUser-navCTA'>
-                <Link href={navCTA.url} className='sui-TopbarUser-navCTALink' title={navCTA.text}>
-                  {navCTA.icon &&
-                    <navCTA.icon svgClass='sui-TopbarUser-navCTAIcon' />
-                  }
-                  <span>{navCTA.text}</span>
-                </Link>
-              </div>
-            }
+            {navCTA && <CallToActionComponent url={navCTA.url} text={navCTA.text} icon={navCTA.icon} linkFactory={Link} />}
           </div>
         </div>
       </div>
@@ -213,6 +206,10 @@ TopbarUser.propTypes = {
      */
     name: PropTypes.string.isRequired
   }).isRequired,
+  /**
+   * Component to use as Call to Action
+   */
+  callToActionComponent: PropTypes.func,
   /**
    * Main navigation containing an array of dropdown menus.
    */
@@ -303,6 +300,7 @@ TopbarUser.propTypes = {
 
 TopbarUser.defaultProps = {
   toggleIcon: Menu,
+  callToActionComponent: DefaultCallToAction,
   linkFactory: ({ href, className, children, title }) =>
     <a href={href} className={className} title={title}>{children}</a>
 }


### PR DESCRIPTION
@SUI-Components/developers 

Motor needs to provide custom behaviour on the CTA component.

This PR allows that in a compatible way.

I was thinking if releasing a major and removing the need to add `navCTA` in the props of the top bar. But I have the idea of doing the same for other parts of the nav. so maybe that can be done in the future and do a major only once.