### PR TITLE
release(ad/smartbanner): removes fixed positioning in favor of static

### DIFF
--- a/components/ad/smartbanner/package.json
+++ b/components/ad/smartbanner/package.json
@@ -16,7 +16,6 @@
   "license": "ISC",
   "dependencies": {
     "@schibstedspain/sui-svgiconset": "1",
-    "@schibstedspain/suistudio-fatigue-deps": "github:SUI-Components/suistudio-fatigue-deps",
-    "classnames": "2.2.5"
+    "@schibstedspain/suistudio-fatigue-deps": "github:SUI-Components/suistudio-fatigue-deps"
   }
 }

--- a/components/ad/smartbanner/package.json
+++ b/components/ad/smartbanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibstedspain/sui-ad-smartbanner",
-  "version": "2.0.0",
+  "version": "1.2.0",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -16,6 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "@schibstedspain/sui-svgiconset": "1",
-    "@schibstedspain/suistudio-fatigue-deps": "github:SUI-Components/suistudio-fatigue-deps"
+    "@schibstedspain/suistudio-fatigue-deps": "github:SUI-Components/suistudio-fatigue-deps",
+    "classnames": "2.2.5"
   }
 }

--- a/components/ad/smartbanner/package.json
+++ b/components/ad/smartbanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibstedspain/sui-ad-smartbanner",
-  "version": "1.2.0",
+  "version": "1.1.0",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/components/ad/smartbanner/package.json
+++ b/components/ad/smartbanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibstedspain/sui-ad-smartbanner",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/components/ad/smartbanner/src/index.js
+++ b/components/ad/smartbanner/src/index.js
@@ -2,7 +2,7 @@ import React, {Component, PropTypes} from 'react'
 import IconCloseDefault from '@schibstedspain/sui-svgiconset/lib/X'
 import cx from 'classnames'
 
-export default class AdSmartbanner extends Component {
+class AdSmartbanner extends Component {
   IconClose = this.props.icon || IconCloseDefault
 
   _handleClick = (event) => {
@@ -18,8 +18,9 @@ export default class AdSmartbanner extends Component {
   }
 
   render () {
+    const { imageUrl, title, text, buttonText, staticPosition } = this.props
     const className = cx('sui-AdSmartbanner', {
-      'sui-AdSmartbanner-static': this.props.static
+      'sui-AdSmartbanner-static': staticPosition
     })
 
     return (
@@ -28,13 +29,13 @@ export default class AdSmartbanner extends Component {
           <this.IconClose svgClass='sui-AdSmartbanner-buttonCloseIcon' />
         </button>
         <div className='sui-AdSmartbanner-primary'>
-          <img src={this.props.imageUrl} className='sui-AdSmartbanner-logo' />
+          <img src={imageUrl} className='sui-AdSmartbanner-logo' />
         </div>
         <div className='sui-AdSmartbanner-secondary'>
-          <h3 className='sui-AdSmartbanner-title'>{this.props.title}</h3>
-          <p className='sui-AdSmartbanner-text'>{this.props.text}</p>
+          <h3 className='sui-AdSmartbanner-title'>{title}</h3>
+          <p className='sui-AdSmartbanner-text'>{text}</p>
         </div>
-        <button className='sui-AdSmartbanner-buttonInstall' onClick={this._handleClick}>{this.props.buttonText}</button>
+        <button className='sui-AdSmartbanner-buttonInstall' onClick={this._handleClick}>{buttonText}</button>
       </div>
     )
   }
@@ -48,7 +49,13 @@ AdSmartbanner.propTypes = {
   title: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired,
   buttonText: PropTypes.string.isRequired,
-  static: PropTypes.bool
+  staticPosition: PropTypes.bool
+}
+
+AdSmartbanner.defaultProps = {
+  staticPosition: false
 }
 
 AdSmartbanner.displayName = 'AdSmartbanner'
+
+export default AdSmartbanner

--- a/components/ad/smartbanner/src/index.js
+++ b/components/ad/smartbanner/src/index.js
@@ -18,12 +18,12 @@ export default class AdSmartbanner extends Component {
   }
 
   render () {
-    const positioning = cx('sui-AdSmartbanner', {
+    const className = cx('sui-AdSmartbanner', {
       'sui-AdSmartbanner-static': this.props.static
     })
 
     return (
-      <div className={positioning}>
+      <div className={className}>
         <button className='sui-AdSmartbanner-buttonClose' onClick={this._handleClose}>
           <this.IconClose svgClass='sui-AdSmartbanner-buttonCloseIcon' />
         </button>

--- a/components/ad/smartbanner/src/index.js
+++ b/components/ad/smartbanner/src/index.js
@@ -20,7 +20,7 @@ class AdSmartbanner extends Component {
   render () {
     const { imageUrl, title, text, buttonText, staticPosition } = this.props
     const className = cx('sui-AdSmartbanner', {
-      'sui-AdSmartbanner-static': staticPosition
+      'is-static': staticPosition
     })
 
     return (

--- a/components/ad/smartbanner/src/index.js
+++ b/components/ad/smartbanner/src/index.js
@@ -1,5 +1,6 @@
 import React, {Component, PropTypes} from 'react'
 import IconCloseDefault from '@schibstedspain/sui-svgiconset/lib/X'
+import cx from 'classnames'
 
 export default class AdSmartbanner extends Component {
   IconClose = this.props.icon || IconCloseDefault
@@ -17,8 +18,12 @@ export default class AdSmartbanner extends Component {
   }
 
   render () {
+    const positioning = cx('sui-AdSmartbanner', {
+      'sui-AdSmartbanner-static': this.props.static
+    })
+
     return (
-      <div className='sui-AdSmartbanner'>
+      <div className={positioning}>
         <button className='sui-AdSmartbanner-buttonClose' onClick={this._handleClose}>
           <this.IconClose svgClass='sui-AdSmartbanner-buttonCloseIcon' />
         </button>
@@ -42,7 +47,8 @@ AdSmartbanner.propTypes = {
   imageUrl: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired,
-  buttonText: PropTypes.string.isRequired
+  buttonText: PropTypes.string.isRequired,
+  static: PropTypes.bool
 }
 
 AdSmartbanner.displayName = 'AdSmartbanner'

--- a/components/ad/smartbanner/src/index.scss
+++ b/components/ad/smartbanner/src/index.scss
@@ -55,10 +55,6 @@
     margin-top: 70px;
   }
 
-  &--hidden {
-    margin-top: 0;
-  }
-
   &--static {
     position: static;
   }

--- a/components/ad/smartbanner/src/index.scss
+++ b/components/ad/smartbanner/src/index.scss
@@ -51,11 +51,11 @@
     }
   }
 
-  &--visible {
-    margin-top: 70px;
+  &.is-visible {
+    margin-top: $h-ad-smartbanner;
   }
 
-  &--static {
+  &.is-static {
     position: static;
   }
 }

--- a/components/ad/smartbanner/src/index.scss
+++ b/components/ad/smartbanner/src/index.scss
@@ -51,15 +51,15 @@
     }
   }
 
-  &-visible {
+  &--visible {
     margin-top: 70px;
   }
 
-  &-hidden {
+  &--hidden {
     margin-top: 0;
   }
 
-  &-static {
+  &--static {
     position: static;
   }
 }

--- a/components/ad/smartbanner/src/index.scss
+++ b/components/ad/smartbanner/src/index.scss
@@ -3,8 +3,14 @@
 .sui-AdSmartbanner {
   background-color: $bgc-ad-smartbanner;
   border-bottom: $bb-ad-smartbanner;
+  bottom: $b-ad-smartbanner;
   display: flex;
+  height: $h-ad-smartbanner;
+  left: $l-ad-smartbanner;
   padding: $p-ad-smartbanner-secondary;
+  position: fixed;
+  top: $t-ad-smartbanner;
+  width: 100%;
   z-index: $z-ad-smartbanner;
 
   &-logo {
@@ -51,5 +57,9 @@
 
   &-hidden {
     margin-top: 0;
+  }
+
+  &-static {
+    position: static;
   }
 }

--- a/components/ad/smartbanner/src/index.scss
+++ b/components/ad/smartbanner/src/index.scss
@@ -3,14 +3,8 @@
 .sui-AdSmartbanner {
   background-color: $bgc-ad-smartbanner;
   border-bottom: $bb-ad-smartbanner;
-  bottom: $b-ad-smartbanner;
   display: flex;
-  height: $h-ad-smartbanner;
-  left: $l-ad-smartbanner;
   padding: $p-ad-smartbanner-secondary;
-  position: fixed;
-  top: $t-ad-smartbanner;
-  width: 100%;
   z-index: $z-ad-smartbanner;
 
   &-logo {


### PR DESCRIPTION
In order to avoid unwanted interactions with the new mobile actionBar the SmartBanner positioning has to change from absolute to static.

Instead of simply remove one style positioning with the other, I'm adding a prop `static` to define the component layout.

Please review @SUI-Components/developers 