### PR TITLE
fix(alert/basic): import icons in a way that not all the lib is loaded

### DIFF
--- a/components/alert/basic/src/index.js
+++ b/components/alert/basic/src/index.js
@@ -1,11 +1,9 @@
 /* eslint-disable react/prop-types */
 import React, {PropTypes} from 'react'
 import cx from 'classnames'
-import {
-  Info,
-  Bell,
-  Check
-} from '@schibstedspain/sui-svgiconset/lib/'
+import Info from '@schibstedspain/sui-svgiconset/lib/Info'
+import Bell from '@schibstedspain/sui-svgiconset/lib/Bell'
+import Check from '@schibstedspain/sui-svgiconset/lib/Check'
 
 const icons = {
   'info': Info,


### PR DESCRIPTION
This way of import ended up in something like

```
var _lib = require('@schibstedspain/sui-svgiconset/lib')
var Info = _lib.Info
```

So we where importing all the lib just for this 3 icons