### PR TITLE
fix(thumbnail/basic): add width 100%

### DIFF
--- a/components/thumbnail/basic/src/index.scss
+++ b/components/thumbnail/basic/src/index.scss
@@ -7,10 +7,12 @@
   display: inline-block;
   padding: $p-thumbnail-basic;
   position: relative;
+  width: 100%;
 
   &-image {
     display: block;
     vertical-align: bottom;
+    width: 100%;
   }
 
   &-caption {


### PR DESCRIPTION
We need a `width` so that the image fit to their container