### PR TITLE
Deploy to now sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,14 @@ node_js:
   - '6'
 before_install:
   - npm i -g npm@^3.0.0
-  - npm i -g surge
   - npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
 before_deploy:
+  - npm i -g now@7
   - npm run build
 deploy:
   skip_cleanup: true
-  provider: surge
-  project: ./public/
-  domain: sui-components.surge.sh
+  provider: script
+  script: npm run deploy
 env:
   global:
     - secure: >-

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint:js": "sui-lint js",
     "lint:sass": "sui-lint sass",
     "lint": "npm run lint:js && npm run lint:sass",
+    "postinstall": "sui-studio run-all npm i",
     "start": "sui-studio start",
     "test": "jest",
     "precommit": "sui-precommit run",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "lint:js": "sui-lint js",
     "lint:sass": "sui-lint sass",
     "lint": "npm run lint:js && npm run lint:sass",
-    "postinstall": "sui-studio run-all npm i",
     "start": "sui-studio start",
     "test": "jest",
     "precommit": "sui-precommit run",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "private": true,
   "scripts": {
     "phoenix": "rm -Rf node_modules && npm i && sui-studio clean-modules && sui-studio run-all npm i",
-    "build": "sui-studio build && cp public/index.html public/200.html",
-    "deploy": "npm run build && surge public/ -d sui-components.surge.sh",
+    "build": "sui-studio build",
+    "deploy": "sui-studio deploy --name=sui-components",
     "co": "sui-studio commit",
     "lint:js": "sui-lint js",
     "lint:sass": "sui-lint sass",


### PR DESCRIPTION
Use new feature developed [sui-studio deploy](https://github.com/SUI-Components/sui/pull/96) to deploy to now.sh.

Now.sh allows https and enables studios to work as PWAs.

Deployment was made at now: [sui-components.now.sh](https://sui-components.now.sh/)
Once this PR is approved, sui-components.surge.sh content will be replaced by a link to sui-components.now.sh

@SUI-Components/developers please review.
