### PR TITLE
Feature/modify styles and proptypes

### DIFF
--- a/components/cover/basic/src/index.scss
+++ b/components/cover/basic/src/index.scss
@@ -1,3 +1,4 @@
+// sass-lint:disable class-name-format
 @import '~@schibstedspain/theme-basic/lib/index';
 @import '~@schibstedspain/sui-button-basic/lib/index';
 
@@ -25,11 +26,12 @@
   }
 
   &-gradient:after {
-    background: linear-gradient(to bottom, rgba($c-black, 0) 25%, rgba($c-black, .75));
+    background: $c-black;
     content: '';
     display: inline-block;
     height: 100%;
     left: 0;
+    opacity: $op-cover-basic-gradient-after;
     position: absolute;
     top: 0;
     width: 100%;

--- a/components/list/tagcloud/src/index.js
+++ b/components/list/tagcloud/src/index.js
@@ -18,11 +18,11 @@ ListTagcloud.propTypes = {
     /**
      * tag text
      */
-    label: PropTypes.string.isRequired,
+    label: PropTypes.node.isRequired,
     /**
      * URL for the tab link
      */
-    link: PropTypes.string.isRequired
+    link: PropTypes.string
   })).isRequired,
   /**
    * Factory used to create navigation links

--- a/components/tag/chip/src/index.js
+++ b/components/tag/chip/src/index.js
@@ -54,7 +54,7 @@ TagChip.propTypes = {
   /**
    * tag text
    */
-  label: PropTypes.string.isRequired,
+  label: PropTypes.node.isRequired,
   /**
    * Delete custom icon
    */

--- a/components/title/multisize/src/index.js
+++ b/components/title/multisize/src/index.js
@@ -65,7 +65,7 @@ TitleMultisize.propTypes = {
   /**
    * Text to display as main title (h1).
    */
-  title: PropTypes.string.isRequired,
+  title: PropTypes.node.isRequired,
   /**
    * Size of title: xs = h5, s = h4, m = h3, l = h2, xl = h1.
    */

--- a/components/title/multisize/src/index.scss
+++ b/components/title/multisize/src/index.scss
@@ -1,34 +1,29 @@
 @import '~@schibstedspain/theme-basic/lib/index';
 
-@mixin sui-title-multisize-sizes ($fw: $fw-semi-bold, $mb: $m-v) {
+@mixin sui-title-multisize-sizes ($fw: $fw-regular, $mb: $m-v) {
   &--xs {
     @include h5;
     font-weight: $fw;
-    margin: 0 0 $mb;
   }
 
   &--s {
     @include h4;
     font-weight: $fw;
-    margin: 0 0 $mb;
   }
 
   &--m {
     @include h3;
     font-weight: $fw;
-    margin: 0 0 $mb;
   }
 
   &--l {
     @include h2;
     font-weight: $fw;
-    margin: 0 0 $mb;
   }
 
   &--xl {
     @include h1;
     font-weight: $fw;
-    margin: 0 0 $mb;
   }
 }
 
@@ -61,7 +56,7 @@
   }
 
   &-preTitle {
-    @include sui-title-multisize-element($c-title-multisize-secondary, $fw-semi-bold);
+    @include sui-title-multisize-element($c-title-multisize-secondary);
   }
 
   &-title {
@@ -69,6 +64,6 @@
   }
 
   &-postTitle {
-    @include sui-title-multisize-element($c-title-multisize-secondary, $fw-regular);
+    @include sui-title-multisize-element($c-title-multisize-secondary);
   }
 }


### PR DESCRIPTION
Modify css styles in:
- sui-cover-basic: change linear gradient background to dark gray background with opacity.
- sui-title-multisize: adjust margins and font-weights of diffrente title's sizes.

Modify proptypes in:
- list-tagcloud: Change "label" property to support nodes, in order to allow a single string or array of s strings/elements. Link is not required, as in tag-chip is not required either.
- tag-chip: Change "label" property to support nodes, in order to allow a single string or array of s strings/elements. 
-title-multisize: Change "title" property to support nodes, in order to allow a single string or array of s strings/elements. 

 