### PR TITLE
fix(list/masonry): fix demo not working

### DIFF
--- a/components/list/masonry/src/index.js
+++ b/components/list/masonry/src/index.js
@@ -62,6 +62,8 @@ class ListMasonry extends React.Component {
 
 export default ListMasonry
 
+ListMasonry.displayName = 'ListMasonry'
+
 ListMasonry.propTypes = {
   children: PropTypes.node.isRequired,
   breakPoints: PropTypes.array.isRequired,


### PR DESCRIPTION
displayName is mandatory to work in prod builds of suistudio

@SUI-Components/developers please review

Fixes #150