### PR TITLE
fix(modal/basic): use classname instead direct styles in body

### DIFF
--- a/components/modal/basic/src/index.js
+++ b/components/modal/basic/src/index.js
@@ -39,7 +39,7 @@ class ModalBasic extends Component {
   }
 
   _toggleWindowScroll (disableScroll) {
-    window.document.body.style.overflowY = disableScroll ? 'hidden' : ''
+    window.document.body.classList.toggle('is-modal-open', disableScroll)
   }
 
   _handleCloseClick = () => {

--- a/components/modal/basic/src/index.scss
+++ b/components/modal/basic/src/index.scss
@@ -1,5 +1,9 @@
 @import '~@schibstedspain/theme-basic/lib/index';
 
+body.is-modal-open {
+  overflow-y: hidden;
+}
+
 .sui-ModalBasic  {
   background-color: $bg-modal-basic;
   bottom: 0;


### PR DESCRIPTION
@miduga @davecarter please review. Now instead of setting direct styles to body, use a css class