### PR TITLE
feat(ad/smartbanner): include smartbanner button color

### DIFF
--- a/components/ad/smartbanner/src/index.scss
+++ b/components/ad/smartbanner/src/index.scss
@@ -36,7 +36,7 @@
   &-button {
 
     &Install {
-      @include sui-button('primary')
+      @include sui-button('custom', $background-color: $bgc-ad-smartbanner-button-install)
     }
 
     &Close {


### PR DESCRIPTION
include `$bgc-ad-smartbanner-button-install` in background color button definition.
this variable was defined in `sui-theme` but not used. 