### PR TITLE
Feature/add name prop to form elements

### DIFF
--- a/components/form/checkbox/src/index.js
+++ b/components/form/checkbox/src/index.js
@@ -13,7 +13,7 @@ const getCheckboxIcon = (checked, customIcons) => {
   return icon
 }
 
-const FormCheckbox = ({checked, className, errorMessage, label, onChange, svgIcons}) => {
+const FormCheckbox = ({checked, className, errorMessage, label, name, onChange, svgIcons}) => {
   const CheckboxIcon = getCheckboxIcon(checked, svgIcons)
   return (
     <div className={cx('sui-FormCheckbox', className)}>
@@ -21,6 +21,7 @@ const FormCheckbox = ({checked, className, errorMessage, label, onChange, svgIco
         <input
           checked={checked}
           className={cx('sui-FormCheckbox-input', {'is-checked': checked})}
+          name={name}
           onChange={onChange}
           type='checkbox' />
         <CheckboxIcon svgClass='sui-FormCheckbox-icon' />
@@ -53,6 +54,10 @@ FormCheckbox.propTypes = {
    * Text to display as a description message on the right side of the chechbox input.
    */
   label: PropTypes.node,
+  /**
+   * Specifies the name of the checkbox element.
+   */
+  name: PropTypes.string.isRequired,
   /**
    * Custom callback function to execute when the checked/uncheched status of the checkbox has changed.
    */

--- a/components/form/checkbox/src/index.scss
+++ b/components/form/checkbox/src/index.scss
@@ -1,6 +1,13 @@
 // sass-lint:disable no-important
-@import '~@schibstedspain/sui-theme/lib/settings-compat-v7/index';
 @import '~@schibstedspain/sui-theme/lib/index';
+
+$c-form-checkbox-icon: $c-primary !default;
+$c-form-checkbox-text-label: $c-gray-dark !default;
+$fz-form-checkbox-text-label: $fz-m !default;
+$fw-form-checkbox-text-label: $fw-regular !default;
+$c-form-checkbox-error-message: $c-error !default;
+$fz-form-checkbox-error-message: $fz-m !default;
+$fw-form-checkbox-error-message: $fw-regular !default;
 
 .sui-FormCheckbox {
   &-input {
@@ -10,7 +17,7 @@
   &-icon {
     @include sui-icon--small;
     cursor: pointer;
-    fill: $c-primary !important;
+    fill: $c-form-checkbox-icon !important;
   }
 
   &-label {
@@ -18,20 +25,20 @@
     cursor: pointer;
     display: inline-flex;
     font-size: $fz-form-checkbox-text-label;
-    font-weight: $fw-regular;
-    padding-left: $p-xxsmall;
+    font-weight: $fw-form-checkbox-text-label;
+    padding-left: $p-s;
     vertical-align: top;
   }
 
   &-errorMessage {
     cursor: default;
-    margin: $m-v-small 0 0 $m-h;
-    padding-left: $p-xxsmall;
+    margin: $m-s 0 0 $m-l;
+    padding-left: $p-s;
 
     &Label {
       color: $c-form-checkbox-error-message;
       font-size: $fz-form-checkbox-error-message;
-      font-weight: $fw-light;
+      font-weight: $fw-form-checkbox-error-message;
     }
   }
 }

--- a/components/form/textInput/src/index.js
+++ b/components/form/textInput/src/index.js
@@ -7,10 +7,11 @@ const renderErrorMessage = error => (
   </div>
 )
 
-const FormTextInput = ({className, errorMessage, onChange, placeholder, value}) => (
+const FormTextInput = ({className, errorMessage, name, onChange, placeholder, value}) => (
   <div className={cx('sui-FormTextInput', className)}>
     <input
       className='sui-FormTextInput-value'
+      name={name}
       type='text'
       placeholder={placeholder}
       value={value}
@@ -30,6 +31,10 @@ FormTextInput.propTypes = {
    * Error message text to show below the input.
    */
   errorMessage: PropTypes.string,
+  /**
+   * Specifies the name of the input element.
+   */
+  name: PropTypes.string.isRequired,
   /**
    * Custom callback function to execute when the value of the text input has changed.
    */

--- a/components/form/textInput/src/index.scss
+++ b/components/form/textInput/src/index.scss
@@ -1,5 +1,12 @@
-@import '~@schibstedspain/sui-theme/lib/settings-compat-v7/index';
 @import '~@schibstedspain/sui-theme/lib/index';
+
+$c-form-text-input-placeholder: $c-gray-light !default;
+$c-form-text-input-inner-text: $c-gray-dark !default;
+$fz-form-text-input-inner-text: $fz-m !default;
+$fw-form-text-input-inner-text: $fw-regular !default;
+$c-form-text-input-error-message: $c-error !default;
+$fz-form-text-input-error-message: $fz-m !default;
+$fw-form-text-input-error-message: $fw-regular !default;
 
 .sui-FormTextInput {
   &-value {
@@ -9,10 +16,10 @@
     }
     border: 0;
     border-bottom: 1px solid $c-gray-light;
-    color: $c-form-text-input-value;
+    color: $c-form-text-input-inner-text;
     font-size: $fz-form-text-input-inner-text;
     font-weight: $fw-form-text-input-inner-text;
-    padding-bottom: $p-v-small;
+    padding-bottom: $p-s;
     white-space: nowrap;
     width: 100%;
 
@@ -22,12 +29,12 @@
   }
 
   &-errorMessage {
-    margin-top: $m-v-small;
+    margin-top: $m-s;
 
     &Label {
       color: $c-form-text-input-error-message;
-      font-size: $fz-s;
-      font-weight: $fw-light;
+      font-size: $fz-form-text-input-error-message;
+      font-weight: $fw-form-text-input-error-message;
     }
   }
 }

--- a/components/form/textarea/src/index.js
+++ b/components/form/textarea/src/index.js
@@ -1,12 +1,13 @@
 import React, {PropTypes} from 'react'
 import cx from 'classnames'
 
-const FormTextarea = ({className, cols, label, onChange, placeholder, rows, spellCheck, value}) => (
+const FormTextarea = ({className, cols, label, name, onChange, placeholder, rows, spellCheck, value}) => (
   <div className={cx('sui-FormTextarea', className)}>
     {label && <label className='sui-FormTextarea-label'>{label}</label>}
     <textarea
       className='sui-FormTextarea-element'
       cols={cols}
+      name={name}
       onChange={onChange}
       placeholder={placeholder}
       rows={rows}
@@ -30,6 +31,10 @@ FormTextarea.propTypes = {
    * Title label to show above the text area element.
    */
   label: PropTypes.string,
+  /**
+   * Specifies the name of the text area element.
+   */
+  name: PropTypes.string.isRequired,
   /**
    * Custom function callback to execute when the value of the text area has changed.
    */

--- a/components/form/textarea/src/index.scss
+++ b/components/form/textarea/src/index.scss
@@ -1,23 +1,32 @@
-@import '~@schibstedspain/sui-theme/lib/settings-compat-v7/index';
 @import '~@schibstedspain/sui-theme/lib/index';
+
+$c-form-textarea-label: $c-gray !default;
+$fz-form-textarea-label: $fz-s !default;
+$fw-form-textarea-label: $fw-regular !default;
+
+$bgc-form-textarea: $c-gray-lightest !default;
+$bdrs-form-textarea: $bdrs-m !default;
+$c-form-textarea-inner-text: $c-gray-dark !default;
+$fz-form-textarea-inner-text: $fz-m !default;
+$fw-form-textarea-inner-text: $fw-regular !default;
 
 .sui-FormTextarea {
   &-label {
-    color: $c-gray;
-    font-size: $fz-s;
-    font-weight: $fw-regular;
+    color: $c-form-textarea-label;
+    font-size: $fz-form-textarea-label;
+    font-weight: $fw-form-textarea-label;
   }
 
   &-element {
     background-color: $bgc-form-textarea;
     border: 0;
-    border-radius: 2px;
+    border-radius: $bdrs-form-textarea;
     color: $c-form-textarea-inner-text;
     font-size: $fz-form-textarea-inner-text;
-    font-weight: $fw-light;
-    margin-top: $m-v-small;
+    font-weight: $fw-form-textarea-inner-text;
+    margin-top: $m-s;
     max-width: 100%;
-    padding: $p-v;
+    padding: $p-m;
     width: 100%;
 
     &:focus {


### PR DESCRIPTION
- Add name property to form elements (in order to have a name reference for each component in parent's form).
- Moved form element scss vars from sui-theme's settings-compat-v7 file to each component.