### PR TITLE
fix(dropdown/basic): style dropdown basic to be more like monolith

### DIFF
--- a/components/dropdown/basic/src/index.scss
+++ b/components/dropdown/basic/src/index.scss
@@ -18,11 +18,11 @@
     @include media-breakpoint-down(s) {
       background-color: $c-white;
       color: $c-text-base;
-      padding: $p-v-large $p-h;
+      padding: $p-xl $p-l;
       width: 100%;
     }
     @include media-breakpoint-up(m) {
-      padding: $p-v $p-h;
+      padding: $p-xl $p-l;
 
       .is-expanded & {
         background-color: $bgc-dropdown-button-hover;
@@ -76,7 +76,7 @@
       }
 
       &:not(:last-child) {
-        margin-right: $m-h-small;
+        margin-right: $m-m;
       }
     }
   }
@@ -138,7 +138,7 @@
 
       &Item {
         @include media-breakpoint-down(s) {
-          margin-bottom: $m-v-large;
+          margin-bottom: $m-l;
           &:not(:last-child) {
             margin-bottom: $m-xl;
           }

--- a/components/dropdown/basic/src/index.scss
+++ b/components/dropdown/basic/src/index.scss
@@ -10,7 +10,9 @@
   @include media-breakpoint-up(m) {
     display: inline-block;
   }
-
+  &.is-expanded {
+    border-bottom: 1px solid $c-gray-light;
+  }
   &-button {
     @include reset-button;
     @include media-breakpoint-down(s) {
@@ -111,21 +113,21 @@
       }
       @include media-breakpoint-down(s) {
         &:not(:last-child) {
-          margin-bottom: $m-v;
+          margin-bottom: $m-xxxl;
         }
       }
     }
 
     &-title {
       @include media-breakpoint-down(s) {
-        margin-top: $m-v-large;
+        margin: $m-m 0;
       }
       @include media-breakpoint-up(m) {
         border-bottom: 1px solid $c-gray-light;
       }
       color: $c-gray;
       font-weight: $fw-bold;
-      margin-bottom: $m-v;
+      margin-bottom: $m-l;
       padding-bottom: $p-v;
       text-transform: uppercase;
     }
@@ -134,18 +136,26 @@
       @include reset-list;
 
       &Item {
-        &:not(:first-child) {
-          margin-top: $m-v;
+        @include media-breakpoint-down(s) {
+          margin-bottom: $m-v-large;
+          &:not(:last-child) {
+            margin-bottom: $m-xl;
+          }
         }
+        margin-bottom: $m-l;
       }
 
       &Link {
         @include reset-link;
+        @include media-breakpoint-down(s) {
+          font-size: $fz-l;
+          margin-left: $m-l;
+        }
         @include media-breakpoint-up(m) {
           white-space: nowrap;
         }
         display: block;
-
+        padding-right: $p-xl;
         &:hover {
           color: $c-accent;
         }

--- a/components/dropdown/basic/src/index.scss
+++ b/components/dropdown/basic/src/index.scss
@@ -22,7 +22,7 @@
       width: 100%;
     }
     @include media-breakpoint-up(m) {
-      padding: $p-m $p-l;
+      padding: $p-m;
 
       .is-expanded & {
         background-color: $bgc-dropdown-button-hover;

--- a/components/dropdown/basic/src/index.scss
+++ b/components/dropdown/basic/src/index.scss
@@ -101,6 +101,7 @@
       border-top: $bdt-dropdown-menu;
       display: block;
       padding: $gutter;
+      padding-bottom: $gutter-s;
     }
 
     &-item {

--- a/components/dropdown/basic/src/index.scss
+++ b/components/dropdown/basic/src/index.scss
@@ -18,11 +18,11 @@
     @include media-breakpoint-down(s) {
       background-color: $c-white;
       color: $c-text-base;
-      padding: $p-xl $p-l;
+      padding: $p-l;
       width: 100%;
     }
     @include media-breakpoint-up(m) {
-      padding: $p-xl $p-l;
+      padding: $p-m $p-l;
 
       .is-expanded & {
         background-color: $bgc-dropdown-button-hover;
@@ -129,7 +129,7 @@
       color: $c-gray;
       font-weight: $fw-bold;
       margin-bottom: $m-l;
-      padding-bottom: $p-v;
+      padding-bottom: $p-m;
       text-transform: uppercase;
     }
 


### PR DESCRIPTION
Modification of dropdown basic to be more like the monolith dropdown.

**mobile size:** 

Current react 
<img width="328" alt="current-react" src="https://user-images.githubusercontent.com/26300965/32002147-08acec4c-b99c-11e7-823b-5aa7391ffc26.png">


Current w/ modifications

<img width="329" alt="current" src="https://user-images.githubusercontent.com/26300965/32002309-7cfa89ba-b99c-11e7-9925-2731e3b986ae.png">


Current monolith

<img width="334" alt="current-modification" src="https://user-images.githubusercontent.com/26300965/32002374-a677c6f4-b99c-11e7-9ba5-113d46e5e5b0.png">

**desktop size:** 

Current react

<img width="377" alt="captura de pantalla 2017-10-25 a las 16 03 50" src="https://user-images.githubusercontent.com/26300965/32003012-2f5c8e86-b99e-11e7-9165-80d104455063.png">


Current w modif

<img width="416" alt="captura de pantalla 2017-10-25 a las 16 06 29" src="https://user-images.githubusercontent.com/26300965/32003135-8ca11bca-b99e-11e7-83a3-00e9289ddfde.png">



Current monolith

<img width="598" alt="captura de pantalla 2017-10-25 a las 16 03 41" src="https://user-images.githubusercontent.com/26300965/32003067-54410952-b99e-11e7-9d27-018fa07e3cc8.png">



