### PR TITLE
fix(card/collapsible): set the prop "collapsed" according to the value of the state.

### DIFF
--- a/components/card/collapsible/src/index.js
+++ b/components/card/collapsible/src/index.js
@@ -88,7 +88,7 @@ class CardCollapsible extends Component {
     return (
       <div className={cx('sui-CardCollapsible', className)}>
         {headerInfo && this._renderCardHeader(headerImage, collapsed ? headerInfo.displayWhenCollapsed : headerInfo.displayWhenExpanded)}
-        <CollapsibleBasic label={this._renderActionButton(collapsed ? expandButton : collapseButton)} icon={false}>{children}</CollapsibleBasic>
+        <CollapsibleBasic collapsed={collapsed} label={this._renderActionButton(collapsed ? expandButton : collapseButton)} icon={false}>{children}</CollapsibleBasic>
       </div>
     )
   }


### PR DESCRIPTION
The component sui-collapsible-basic has been slightly changed, and now the collapsed/expanded status should be set directly in the component's prop `collapsed`.
So, the current version of this component is failing.