### PR TITLE
fix/image-placeholder

### DIFF
--- a/components/image/placeholder/README.md
+++ b/components/image/placeholder/README.md
@@ -19,12 +19,14 @@ return (
     src='https://satyr.io/1000'
     alt='1000x1000'
     placeholder={
-      <svg viewBox='0 0 1 1'>
-        <rect width='100%' height='100%' />
-      </svg>
+      src: '...',
+      alt: '...'
+      ...imageTagAttributes
     }
     fallback={
-      <img src='https://satyr.io/500' className='some-important-class' alt='500x500' />
+      src: '...',
+      alt: '...'
+      ...imageTagAttributes
     }
   />
 )

--- a/components/image/placeholder/src/index.js
+++ b/components/image/placeholder/src/index.js
@@ -1,6 +1,7 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
+import {filterObjectKeys} from './libs'
 
 class ImagePlaceholder extends Component {
   static IMAGE_CLASS = 'sui-ImagePlaceholder-image'
@@ -24,25 +25,6 @@ class ImagePlaceholder extends Component {
     this.props.onError && this.props.onError()
   }
 
-  /**
-   * Clones a component updating its props
-   * @param {Object} component
-   * @return {Object}
-   */
-  _clone (component) {
-    const props = Object.assign(
-      {},
-      component.props,
-      {
-        className: `${this._imageClasses} ${component.props.className}`,
-        onLoad: this.onLoad,
-        onError: this.onError
-      }
-    )
-
-    return React.cloneElement(component, props)
-  }
-
   get _classNames () {
     return classnames(
       'sui-ImagePlaceholder',
@@ -50,7 +32,7 @@ class ImagePlaceholder extends Component {
     )
   }
 
-  get _imageClasses () {
+  get _imageClassNames () {
     return classnames(
       ImagePlaceholder.IMAGE_CLASS,
       this.state.imageLoaded || `${ImagePlaceholder.IMAGE_CLASS}--hidden`
@@ -58,31 +40,38 @@ class ImagePlaceholder extends Component {
   }
 
   get _imageProps () {
-    let props = Object.assign(
-      {},
-      this.props
+    const imageProps = Object.keys(htmlImgProps)
+    return filterObjectKeys(this.props, imageProps)
+  }
+
+  _renderPlaceholder () {
+    return (
+      <img {...this.props.placeholder} />
     )
-
-    delete props.fallback
-    delete props.placeholder
-    delete props.className
-
-    return props
   }
 
   /**
-   * In case the src could not be loaded, we need to add the placeholder classes to the
-   * fallback. As those props are readonly, we clone the component setting the before
-   * mentioned classes
+   * onLoad & onError are intercepted as we need the state handling functions
+   * to do our magic
    */
+  _renderFallback () {
+    return (
+      <img className={this._imageClassNames}
+        onLoad={() => this.onLoad()}
+        onError={() => this.onError()}
+        {...this.props.fallback}
+      />
+    )
+  }
+
   render () {
     return (
       <div className={this._classNames}>
         {
           this.state.error
-            ? this.props.fallback && this._clone(this.props.fallback)
+            ? this.props.fallback && this._renderFallback()
             : (
-              <img className={this._imageClasses}
+              <img className={this._imageClassNames}
                 onLoad={() => this.onLoad()}
                 onError={() => this.onError()}
                 {...this._imageProps}
@@ -90,7 +79,7 @@ class ImagePlaceholder extends Component {
             )
         }
         {
-          this.state.imageLoaded || this.props.placeholder
+          this.state.imageLoaded || this._renderPlaceholder()
         }
       </div>
     )
@@ -100,70 +89,44 @@ class ImagePlaceholder extends Component {
 ImagePlaceholder.displayName = 'ImagePlaceholder'
 
 /**
- * Most props are the <img> props, https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img
+ * <img> props, https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img
  */
+const htmlImgProps = {
+  alt: PropTypes.string.isRequired,
+  crossorigin: PropTypes.string,
+  height: PropTypes.string,
+  ismap: PropTypes.bool,
+  longdesc: PropTypes.string,
+  referrerpolicy: PropTypes.string,
+  sizes: PropTypes.string,
+  src: PropTypes.string.isRequired,
+  srcset: PropTypes.string,
+  usemap: PropTypes.string,
+  width: PropTypes.string
+}
+
 ImagePlaceholder.propTypes = {
   className: PropTypes.string,
   /**
-   * To be shown until 'image' is loaded
+   * To be shown until the src prop is loaded
    */
-  placeholder: PropTypes.node,
+  placeholder: PropTypes.shape(htmlImgProps).isRequired,
   /**
-   * Image to be loaded in case 'image' does not load
+   * Image to be loaded in case the src prop does not load
    */
-  fallback: PropTypes.node,
+  fallback: PropTypes.shape(htmlImgProps),
   /**
-   * <img> property
-   */
-  src: PropTypes.string.isRequired,
-  /**
-   * <img> property
-   */
-  alt: PropTypes.string.isRequired,
-  /**
-   * <img> property
-   */
-  onLoad: PropTypes.func,
-  /**
-   * <img> property
+   * Image property but intercepted by the component in order to do its magic
    */
   onError: PropTypes.func,
   /**
-   * <img> property
+   * Image property but intercepted by the component in order to do its magic
    */
-  crossorigin: PropTypes.string,
+  onLoad: PropTypes.func,
   /**
-   * <img> property
+   * <img> prop
    */
-  height: PropTypes.string,
-  /**
-   * <img> property
-   */
-  ismap: PropTypes.bool,
-  /**
-   * <img> property
-   */
-  longdesc: PropTypes.string,
-  /**
-   * <img> property
-   */
-  referrerpolicy: PropTypes.string,
-  /**
-   * <img> property
-   */
-  sizes: PropTypes.string,
-  /**
-   * <img> property
-   */
-  srcset: PropTypes.string,
-  /**
-   * <img> property
-   */
-  width: PropTypes.string,
-  /**
-   * <img> property
-   */
-  usemap: PropTypes.string
+  ...htmlImgProps
 }
 
 export default ImagePlaceholder

--- a/components/image/placeholder/src/index.scss
+++ b/components/image/placeholder/src/index.scss
@@ -15,4 +15,8 @@ $c-image-placeholder-fill: $c-gray;
   svg {
     fill: $c-image-placeholder-fill;
   }
+
+  img {
+    width: 100%;
+  }
 }

--- a/components/image/placeholder/src/index.scss
+++ b/components/image/placeholder/src/index.scss
@@ -16,7 +16,7 @@ $c-image-placeholder-fill: $c-gray;
     fill: $c-image-placeholder-fill;
   }
 
-  img {
+  &-image {
     width: 100%;
   }
 }

--- a/components/image/placeholder/src/libs/index.js
+++ b/components/image/placeholder/src/libs/index.js
@@ -1,0 +1,12 @@
+/**
+ * @param {Object} obj Object to iterate through
+ * @param {Array.<string>} keysToBeFiltered those keys that should stay
+ */
+export const filterObjectKeys = function (obj, keysToBeFiltered) {
+  return Object.keys(obj)
+    .filter((key) => keysToBeFiltered.indexOf(key) !== -1)
+    .reduce((acc, key) => {
+      acc[key] = obj[key]
+      return acc
+    }, {})
+}

--- a/demo/image/placeholder/playground
+++ b/demo/image/placeholder/playground
@@ -1,7 +1,5 @@
 const placeholder= (
-  <svg viewBox='0 0 1 1'>
-    <rect width='100%' height='100%' />
-  </svg>
+  <img src="http://media.infojobs.net/appgrade/svgs/image-placeholder.svg" alt=""/>
 )
 
 return (

--- a/demo/image/placeholder/playground
+++ b/demo/image/placeholder/playground
@@ -1,23 +1,22 @@
-const placeholder= (
-  <img src="http://media.infojobs.net/appgrade/svgs/image-placeholder.svg" alt=""/>
-)
+const placeholder= {
+  src: 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB2aWV3Qm94PSIwIDAgNTAwIDUwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjUwMCIgaGVpZ2h0PSI1MDAiIGZpbGw9IiM3NzciLz4KPC9zdmc+',
+  alt: 'placeholder'
+}
+
+const fallback= {
+  src: 'https://satyr.io/500',
+  alt: 'fallback'
+}
 
 return (
   <div>
-    <h2>SVG Placeholder</h2>
+    <h2>Placeholder</h2>
     <div style={{width: '20%'}}>
       <ImagePlaceholder
         src='https://satyr.io/1000?delay=3g'
         alt='Some alt'
         placeholder={placeholder}
-      />
-    </div>
-    <h2>Image Placeholder</h2>
-    <div style={{width: '20%'}}>
-      <ImagePlaceholder
-        src='https://satyr.io/1000?delay=3g'
-        alt='Some alt'
-        placeholder={<img src='https://satyr.io/100' width='100%'/>}
+        onLoad={() => console.log('custom onLoad')}
       />
     </div>
     <h2>Fallback example</h2>
@@ -25,8 +24,8 @@ return (
       <ImagePlaceholder
         src='http://404'
         alt='Some alt'
-        placeholder={<img src='https://satyr.io/10' />}
-        fallback={<img src='https://satyr.io/500' className='some-important-class' alt='Fallback alt' />}
+        placeholder={placeholder}
+        fallback={fallback}
       />
     </div>
     <h2>Error without Fallback example</h2>
@@ -35,6 +34,7 @@ return (
         src='http://404'
         alt='Some alt'
         placeholder={placeholder}
+        onError={() => console.log('custom onError')}
       />
     </div>
     <h2>Failing Fallback example</h2>
@@ -43,7 +43,10 @@ return (
         src='http://404'
         alt='Some alt'
         placeholder={placeholder}
-        fallback={<img src='https://404' alt='Fallback alt' />}
+        fallback={{
+          src: 'http://404',
+          alt: ''
+        }}
       />
     </div>
   </div>

--- a/demo/thumbnail/basic/playground
+++ b/demo/thumbnail/basic/playground
@@ -1,7 +1,5 @@
 const placeholder= (
-  <svg viewBox="0 0 1 1">
-      <rect width="100%" height="100%" />
-  </svg>
+  <img src="http://media.infojobs.net/appgrade/svgs/image-placeholder.svg" alt=""/>
 )
 
 return (

--- a/demo/thumbnail/basic/playground
+++ b/demo/thumbnail/basic/playground
@@ -1,5 +1,7 @@
 const placeholder= (
-  <img src="http://media.infojobs.net/appgrade/svgs/image-placeholder.svg" alt=""/>
+  <svg viewBox="0 0 1 1">
+    <rect width="100%" height="100%" />
+  </svg>
 )
 
 return (


### PR DESCRIPTION
As svg resize is broken in IE11 this component does not allow <svg> node as placeholder/fallback anymore. For now on, use placeholder/fallback.src in order to set your svg's (see playground file)