### PR TITLE
fix(META): mAke tests work with react 15

### DIFF
--- a/components/abtesting/optimizelyXExperiment/test/index.test.js
+++ b/components/abtesting/optimizelyXExperiment/test/index.test.js
@@ -1,10 +1,7 @@
 /* eslint-env jest */
 import React from 'react'
-import Enzyme, { render, mount } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { render, mount } from 'enzyme'
 import AbTestOptimizelyXExperiment from '../src/index'
-
-Enzyme.configure({ adapter: new Adapter() })
 
 jest.mock('../src/optimizely-x')
 import {createExperimentUseCase} from '../src/optimizely-x'
@@ -18,7 +15,7 @@ describe('<AbTestOptimizelyXExperiment />', () => {
   </AbTestOptimizelyXExperiment>)
 
   it('should render nothing when OptimizelyX is not available', () => {
-    expect(render(component).html()).toEqual('Original')
+    expect(render(component).text()).toEqual('Original')
   })
 
   describe('When OptimizelyX API is present', () => {

--- a/components/abtesting/toggle/test/index.test.js
+++ b/components/abtesting/toggle/test/index.test.js
@@ -1,10 +1,7 @@
 /* eslint-env jest */
 import React from 'react'
-import Enzyme, { render } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { render } from 'enzyme'
 import AbTestToggle from '../src/index'
-
-Enzyme.configure({ adapter: new Adapter() })
 
 describe('<AbTestToggle />', () => {
   const variations = [
@@ -16,16 +13,16 @@ describe('<AbTestToggle />', () => {
 
   it('should render corresponding variation when variation IS defined', () => {
     const component = <AbTestToggle variation='B'>{variations}</AbTestToggle>
-    expect(render(component).html()).toEqual('Blue Button (B)')
+    expect(render(component).text()).toEqual('Blue Button (B)')
   })
 
   it('should render default variation when variation IS NOT defined', () => {
     const component = <AbTestToggle>{variations}</AbTestToggle>
-    expect(render(component).html()).toEqual('Black Button')
+    expect(render(component).text()).toEqual('Black Button')
   })
 
   it('should render nothing when variation IS defined but doesn\'t exist', () => {
     const component = <AbTestToggle variation='D'>{variations}</AbTestToggle>
-    expect(render(component).html()).toEqual(null)
+    expect(render(component).text()).toEqual('')
   })
 })

--- a/package.json
+++ b/package.json
@@ -28,12 +28,10 @@
     "@s-ui/precommit": "2",
     "@s-ui/studio": "4",
     "babel-jest": "20.0.3",
-    "enzyme": "3.1.0",
-    "enzyme-adapter-react-16": "1.0.1",
+    "enzyme": "2.9.1",
     "husky": "0.13.4",
     "jest": "20.0.4",
     "react-addons-test-utils": "15.6.0",
-    "react-test-renderer": "16.0.0",
     "validate-commit-msg": "2.12.2"
   },
   "dependencies": {


### PR DESCRIPTION
The tests where changed to react 16 and then sui-studio was downgraded to 4 without downgrading tests.

