### PR TITLE
feat(collapsible/basic): add new collapsible vars

### DIFF
--- a/components/collapsible/basic/src/_settings.scss
+++ b/components/collapsible/basic/src/_settings.scss
@@ -1,0 +1,11 @@
+$p-collapsible-basic-trigger: 0 !default;
+$bd-collapsible-basic-trigger: none !default;
+$bdr-collapsible-basic-trigger: 0 !default;
+$mb-collapsible-basic-trigger: 0 !default;
+$mb-collapsible-basic-content: 0 !default;
+$bgc-collapsible-basic: $c-gray-lightest !default;
+$bgc-collapsible-basic-expanded: $c-gray-lightest !default;
+$lh-collapsible-basic: $lh-base !default;
+$c-collapsible-basic: $c-gray-dark !default;
+$bdc-collapsible-basic: $c-gray-lightest !default;
+$bd-collapsible-basic: 1px solid $bdc-collapsible-basic !default;

--- a/components/collapsible/basic/src/index.scss
+++ b/components/collapsible/basic/src/index.scss
@@ -2,6 +2,18 @@
 @import '~@schibstedspain/sui-theme/lib/settings-compat-v7/index';
 @import '~@schibstedspain/sui-theme/lib/index';
 
+$p-collapsible-basic-trigger: 0 !default;
+$bd-collapsible-basic-trigger: none !default;
+$bdr-collapsible-basic-trigger: 0 !default;
+$mb-collapsible-basic-trigger: 0 !default;
+$mb-collapsible-basic-content: 0 !default;
+$bgc-collapsible-basic: $c-gray-lightest !default;
+$bgc-collapsible-basic-expanded: $c-gray-lightest !default;
+$lh-collapsible-basic: $lh-base !default;
+$c-collapsible-basic: $c-gray-dark !default;
+$bdc-collapsible-basic: $c-gray-lightest !default;
+$bd-collapsible-basic: 1px solid $bdc-collapsible-basic !default;
+
 .sui-CollapsibleBasic {
   background-color: $bgc-collapsible-basic;
   border: $bd-collapsible-basic;
@@ -9,8 +21,12 @@
 
   &-trigger {
     align-items: center;
+    border: $bd-collapsible-basic-trigger;
+    border-radius: $bdr-collapsible-basic-trigger;
     display: flex;
     line-height: $lh-collapsible-basic;
+    padding: $p-collapsible-basic-trigger;
+    margin-bottom: $mb-collapsible-basic-trigger;
 
     &-icon {
       flex: 1;
@@ -30,6 +46,7 @@
   }
 
   &-collapsibleContent {
+    margin-bottom: $mb-collapsible-basic-content;
     overflow: hidden;
     transition: max-height $trs-base;
   }

--- a/components/collapsible/basic/src/index.scss
+++ b/components/collapsible/basic/src/index.scss
@@ -1,18 +1,8 @@
 // sass-lint:disable class-name-format
 @import '~@schibstedspain/sui-theme/lib/settings-compat-v7/index';
 @import '~@schibstedspain/sui-theme/lib/index';
+@import './settings';
 
-$p-collapsible-basic-trigger: 0 !default;
-$bd-collapsible-basic-trigger: none !default;
-$bdr-collapsible-basic-trigger: 0 !default;
-$mb-collapsible-basic-trigger: 0 !default;
-$mb-collapsible-basic-content: 0 !default;
-$bgc-collapsible-basic: $c-gray-lightest !default;
-$bgc-collapsible-basic-expanded: $c-gray-lightest !default;
-$lh-collapsible-basic: $lh-base !default;
-$c-collapsible-basic: $c-gray-dark !default;
-$bdc-collapsible-basic: $c-gray-lightest !default;
-$bd-collapsible-basic: 1px solid $bdc-collapsible-basic !default;
 
 .sui-CollapsibleBasic {
   background-color: $bgc-collapsible-basic;


### PR DESCRIPTION
i've added 5 new variables, in order to make it reusable in coches:

```scss
$p-collapsible-basic-trigger: 0 !default;
$bd-collapsible-basic-trigger: none !default;
$bdr-collapsible-basic-trigger: 0 !default;
$mb-collapsible-basic-trigger: 0 !default;
$mb-collapsible-basic-content: 0 !default;
```

at same time, instead of defining this new variables in sui-theme, i deleted those variables there to define them here.

PR removing sui-theme vars:
https://github.com/SUI-Components/sui-theme/pull/130

