### PR TITLE
Change dep from react-lazy-load to @schibstedspain/react-lazy-load

### DIFF
--- a/components/image/lazyLoad/package.json
+++ b/components/image/lazyLoad/package.json
@@ -12,8 +12,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@schibstedspain/sui-spinner-basic": "1",
     "@s-ui/component-dependencies": "1",
-    "react-lazy-load": "3.0.12"
+    "@schibstedspain/react-lazy-load": "3.0.12",
+    "@schibstedspain/sui-spinner-basic": "1"
   }
 }


### PR DESCRIPTION
because the original component seem like abandoned , I have created a new fork of this project inside of @schibstedspain org, to be able release a new version

https://github.com/loktar00/react-lazy-load/issues/113

https://github.com/SUI-Components/react-lazy-load/commit/d436443ae134996fab53e860981fc7a745fb4131