### PR TITLE
fix(map/basic): fix error in leafletLocalInstall.js script.

### DIFF
--- a/components/map/basic/leafletLocalInstall.js
+++ b/components/map/basic/leafletLocalInstall.js
@@ -1,9 +1,7 @@
 var fs = require('fs')
-var path = require('path')
 
-var basePath = __dirname.split('node_modules')[0]
-var originPath = path.join(basePath, '/node_modules/leaflet/dist/leaflet.css')
-var destinationPath = path.join(basePath, '/node_modules/leaflet/dist/leaflet.scss')
+var originPath = require.resolve('leaflet/dist/leaflet.css')
+var destinationPath = require.resolve('leaflet/dist/leaflet.scss')
 
 fs.readFile(originPath, 'utf8', function read (err, data) {
   if (err) {

--- a/components/map/basic/leafletLocalInstall.js
+++ b/components/map/basic/leafletLocalInstall.js
@@ -1,8 +1,9 @@
 var fs = require('fs')
 var path = require('path')
 
-var originPath = path.join(__dirname, '/node_modules/leaflet/dist/leaflet.css')
-var destinationPath = path.join(__dirname, '/node_modules/leaflet/dist/leaflet.scss')
+var basePath = __dirname.split('node_modules')[0]
+var originPath = path.join(basePath, '/node_modules/leaflet/dist/leaflet.css')
+var destinationPath = path.join(basePath, '/node_modules/leaflet/dist/leaflet.scss')
 
 fs.readFile(originPath, 'utf8', function read (err, data) {
   if (err) {

--- a/components/map/basic/leafletLocalInstall.js
+++ b/components/map/basic/leafletLocalInstall.js
@@ -1,7 +1,9 @@
 var fs = require('fs')
+var path = require('path')
 
-var originPath = require.resolve('leaflet/dist/leaflet.css')
-var destinationPath = require.resolve('leaflet/dist/leaflet.scss')
+var leafletPath = require.resolve('leaflet')
+var originPath = path.resolve(leafletPath, '../leaflet.css')
+var destinationPath = path.resolve(leafletPath, '../leaflet.scss')
 
 fs.readFile(originPath, 'utf8', function read (err, data) {
   if (err) {


### PR DESCRIPTION
There is an error installing the sui-map-basic component as dependency of another component.

Basically, when executing the postInstall script `leafletLocalInstall.js`, the node_modules path where leaflet package is looked up is not always right.
This path is calculated with `path.join(__dirname, '/node_modules/leaflet/dist/leaflet.css')`, but this is what happens:

- When installing it in sui-components repo, it works correctly as leaflet is installed directly in the node_modules directory in the root path of sui-map-basic.

- But when installing as dependency of another component, the `leafletLocalInstall.js` has as __dirname `main-component/node_modules/@schibstedspain/sui-map-basic`, and the leaflet package is in the node_modules folder 3 levels upper.

So, this fix simply uses **require.resolve** to calculate the leaflet module path.