### PR TITLE
feat(atom/badgeNotification): create badge notification component

### DIFF
--- a/components/atom/badgeNotification/CHANGELOG.md
+++ b/components/atom/badgeNotification/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+

--- a/components/atom/badgeNotification/README.md
+++ b/components/atom/badgeNotification/README.md
@@ -1,0 +1,30 @@
+# AtomBadge
+
+> Atom Element: SUI badge
+
+![](./assets/screenshot.png)
+
+## Installation
+
+```sh
+npm install @schibstedspain/sui-atom-badge --save
+```
+
+## Usage
+
+```js
+import Badge, { atomBadgeTypes, atomBadgeSizes } from '@schibstedspain/sui-atom-badge'
+
+render {
+  return (
+    <Badge
+      size={atomBadgeSizes.SMALL}
+      type={atomBadgeTypes.SUCCESS}
+      label='Hello SUI-Badge!'
+    />
+  )
+}
+
+```
+
+**Find full description and more examples in the [demo page](https://sui-components.now.sh/workbench/atom/badge).**

--- a/components/atom/badgeNotification/README.md
+++ b/components/atom/badgeNotification/README.md
@@ -1,30 +1,24 @@
-# AtomBadge
+# AtomBadgeNotification
 
-> Atom Element: SUI badge
-
-![](./assets/screenshot.png)
+> Atom Element: SUI badgeNotification
 
 ## Installation
 
 ```sh
-npm install @schibstedspain/sui-atom-badge --save
+npm install @schibstedspain/sui-atom-badge-notification --save
 ```
 
 ## Usage
 
 ```js
-import Badge, { atomBadgeTypes, atomBadgeSizes } from '@schibstedspain/sui-atom-badge'
+import BadgeNotification from '@schibstedspain/sui-atom-badge-notification'
 
 render {
   return (
-    <Badge
-      size={atomBadgeSizes.SMALL}
-      type={atomBadgeTypes.SUCCESS}
-      label='Hello SUI-Badge!'
-    />
+    <BadgeNotification />
   )
 }
 
 ```
 
-**Find full description and more examples in the [demo page](https://sui-components.now.sh/workbench/atom/badge).**
+**Find full description and more examples in the [demo page](#).**

--- a/components/atom/badgeNotification/package.json
+++ b/components/atom/badgeNotification/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@schibstedspain/sui-atom-badge-notification",
+  "version": "1.0.0",
+  "description": "",
+  "main": "lib/index.js",
+  "scripts": {
+    "build": "rm -Rf ./lib && mkdir -p ./lib && npm run build:js && npm run build:styles",
+    "build:js": "../../../node_modules/.bin/babel --presets sui ./src --out-dir ./lib",
+    "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
+  },
+  "dependencies": {
+    "@s-ui/component-dependencies": "latest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT"
+}

--- a/components/atom/badgeNotification/src/index.js
+++ b/components/atom/badgeNotification/src/index.js
@@ -1,0 +1,32 @@
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+
+class BadgeNotification extends Component {
+  render () {
+    return (
+      <div className='sui-BadgeNotification'>
+        <span className={`sui-BadgeNotification-type sui-BadgeNotification-type-${this.props.type}-${this.props.size} sui-BadgeNotification-size-${this.props.size}`} />
+      </div>
+    )
+  }
+}
+
+BadgeNotification.displayName = 'BadgeNotification'
+
+BadgeNotification.propTypes = {
+  /**
+   * The string content is the badge size
+   */
+  size: PropTypes.oneOf(['large', 'medium', 'small']),
+  /**
+   * The string content is the bage type
+   */
+  type: PropTypes.oneOf(['bullet'])
+}
+
+BadgeNotification.defaultProps = {
+  type: 'bullet',
+  size: 'medium'
+}
+
+export default BadgeNotification

--- a/components/atom/badgeNotification/src/index.scss
+++ b/components/atom/badgeNotification/src/index.scss
@@ -1,0 +1,56 @@
+@import '~@schibstedspain/theme-basic/lib/index';
+
+$bd-badge-notification: none !default;
+$bdc-badge-notification: $c-error !default;
+$c-badge-notification: $c-white !default;
+$border-size-badge-notification-large: 6px !default;
+$size-badge-notification-large: 16px !default;
+$border-size-badge-notification-medium: 5px !default;
+$size-badge-notification-medium: 12px !default;
+$border-size-badge-notification-small: 3px !default;
+$size-badge-notification-small: 8px !default;
+
+.sui-BadgeNotification {
+  position: relative;
+
+  &-type {
+    border-color: $bdc-badge-notification;
+    border-style: solid;
+    background: $c-badge-notification;
+    border-radius: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+  }
+
+  &-type {
+    &-bullet-small {
+      border-width: $border-size-badge-notification-small;
+    }
+
+    &-bullet-medium {
+      border-width: $border-size-badge-notification-medium;
+    }
+
+    &-bullet-large {
+      border-width: $border-size-badge-notification-large;
+    }
+  }
+
+  &-size {
+    &-small {
+      height: $size-badge-notification-small;
+      width: $size-badge-notification-small;
+    }
+
+    &-medium {
+      height: $size-badge-notification-medium;
+      width: $size-badge-notification-medium;
+    }
+
+    &-large {
+      height: $size-badge-notification-large;
+      width: $size-badge-notification-large;
+    }
+  }
+}

--- a/demo/atom/badgeNotification/playground
+++ b/demo/atom/badgeNotification/playground
@@ -1,0 +1,9 @@
+return (
+  <div>
+    <BadgeNotification size='small' />
+    <br />
+    <BadgeNotification />
+    <br />
+    <BadgeNotification size='large' />
+  </div>
+)


### PR DESCRIPTION
@SUI-Components/developers please review.

Creating a badge notification. There's no documentation yet for this component, and UX is working on it, so the documentation used is the current Zeplin definition.

https://app.zeplin.io/project/57175ac73411f50f35b16bd6/screen/5a0d783aae5fa715ab539a6f

![image](https://user-images.githubusercontent.com/16606947/33025803-387c1628-ce0f-11e7-9c14-abd67579ad30.png)
