### PR TITLE
Feature/upgrade version of react slidy in image slider

### DIFF
--- a/components/image/slider/package.json
+++ b/components/image/slider/package.json
@@ -13,6 +13,6 @@
   "license": "ISC",
   "dependencies": {
     "@s-ui/component-dependencies": "1",
-    "react-slidy": "3"
+    "react-slidy": "1.2"
   }
 }

--- a/components/image/slider/package.json
+++ b/components/image/slider/package.json
@@ -13,6 +13,6 @@
   "license": "ISC",
   "dependencies": {
     "@s-ui/component-dependencies": "1",
-    "react-slidy": "1.2"
+    "react-slidy": "3"
   }
 }

--- a/components/image/slider/src/index.js
+++ b/components/image/slider/src/index.js
@@ -8,7 +8,7 @@ const ImageSlider = (props) => {
   return (
     <div onClick={props.handleClick} className='sui-ImageSlider'>
       { hasMoreThanOneImage(props.images)
-        ? (<ReactSlidy>{ slides }</ReactSlidy>)
+        ? (<ReactSlidy {...props.sliderOptions}>{ slides }</ReactSlidy>)
         : slides
       }
     </div>
@@ -50,14 +50,25 @@ ImageSlider.propTypes = {
   /**
    * Callback executed when clicking over the slider.
    */
-  handleClick: PropTypes.func
+  handleClick: PropTypes.func,
+  /**
+   * Custom configuration options to pass to react-slidy component.
+   */
+  sliderOptions: PropTypes.shape({
+    lazyLoadSlider: PropTypes.bool,
+    initialSlide: PropTypes.number
+  })
 }
 
 ImageSlider.defaultProps = {
   /**
    * This function will receive the onClick arguments
    */
-  handleClick: () => {}
+  handleClick: () => {},
+  /**
+   * If not set, react-slidy will be created with its default properties.
+   */
+  sliderOptions: {}
 }
 
 ImageSlider.displayName = 'ImageSlider'


### PR DESCRIPTION
- Upgrade version of react-slidy package to v3. This is necessary because a new porperty `initialSlide` has been included, in order to customise the first image to show when creating the slider.

- Expose the props `initialSlide` and `lazyLoadConfig` of react-slidy component, to allow their customisation.

**In order not to break the current usage of this component,  a new major version of sui-image-slider will be generated (2.0.0)**