### PR TITLE
feat(atom/button): fix icons alignment

### DIFF
--- a/components/atom/button/src/index.js
+++ b/components/atom/button/src/index.js
@@ -63,12 +63,14 @@ const AtomButton = (props) => {
 
   return (
     <Button {...newProps} className={classNames} title={title} disabled={disabled}>
-      {leftIcon && <span className={`${CLASS}-leftIcon`}>{leftIcon}</span>}
-      {leftIcon || rightIcon
-        ? <span className={`${CLASS}-text`}>{children}</span>
-        : children
-      }
-      {rightIcon && <span className={`${CLASS}-rightIcon`}>{rightIcon}</span>}
+      <div className={`${CLASS}-inner`}>
+        {leftIcon && <span className={`${CLASS}-leftIcon`}>{leftIcon}</span>}
+        {leftIcon || rightIcon
+          ? <span className={`${CLASS}-text`}>{children}</span>
+          : children
+        }
+        {rightIcon && <span className={`${CLASS}-rightIcon`}>{rightIcon}</span>}
+      </div>
     </Button>
   )
 }

--- a/components/atom/button/src/index.scss
+++ b/components/atom/button/src/index.scss
@@ -47,8 +47,11 @@ $p-atom-button-large: $p-l !default;
 @mixin button-icon ($size, $margin) {
   & .sui-AtomButton-leftIcon,
   & .sui-AtomButton-rightIcon {
-    height: $size;
-    width: $size;
+    &,
+    & [class*="Icon"] {
+      height: $size;
+      width: $size;
+    }
   }
 
   & .sui-AtomButton-leftIcon {
@@ -66,13 +69,14 @@ $p-atom-button-large: $p-l !default;
   border: 1px solid;
   border-radius: $bdrs-m;
   box-sizing: border-box;
+  display: inline-block;
   font: {
     family: $ff-sans-serif;
     size: $fz-atom-button;
     weight: $fw-semi-bold;
   }
   height: $sz-atom-button;
-  line-height: $sz-atom-button;
+  line-height: normal;
   min-width: $sz-atom-button;
   outline: 0;
   padding: 0 $p-atom-button;
@@ -82,15 +86,16 @@ $p-atom-button-large: $p-l !default;
     margin-left: $m-m;
   }
 
+  &-inner {
+    align-items: center;
+    display: inline-flex;
+    height: 100%;
+  }
+
   // Icons
   &-leftIcon,
   &-rightIcon {
-    display: inline-block;
-    vertical-align: middle;
-  }
-
-  &-text {
-    vertical-align: middle;
+    display: inline-flex;
   }
 
   // Types and colors
@@ -156,7 +161,6 @@ $p-atom-button-large: $p-l !default;
     @include button-icon($icon-sz-atom-button-small, $icon-m-atom-button-small);
     font-size: $fz-atom-button-small;
     height: $sz-atom-button-small;
-    line-height: $sz-atom-button-small;
     min-width: $sz-atom-button-small;
     padding: 0 $p-atom-button-small;
   }
@@ -165,12 +169,12 @@ $p-atom-button-large: $p-l !default;
     @include button-icon($icon-sz-atom-button-large, $icon-m-atom-button-large);
     font-size: $fz-atom-button-large;
     height: $sz-atom-button-large;
-    line-height: $sz-atom-button-large;
     min-width: $sz-atom-button-large;
     padding: 0 $p-atom-button-large;
   }
 
   &--fullWidth {
+    justify-content: center;
     width: 100%;
   }
 
@@ -183,7 +187,6 @@ $p-atom-button-large: $p-l !default;
 
   // Modifiers
   &--link {
-    display: inline-block;
     text-decoration: none;
   }
 }

--- a/demo/atom/button/playground
+++ b/demo/atom/button/playground
@@ -124,7 +124,7 @@ return (<div>
   <p><Button link leftIcon={Icon} size='small' title='button link'>Button link</Button></p>
 </div>)
 
-function getStarIcon () { return  (<svg viewBox="0 0 24 24">
+function getStarIcon () { return  (<svg className='sui-Icon' viewBox="0 0 24 24">
   <g>
     <path id="a" d="M21.14 11a1.51 1.51 0 0 0-.86-2.65L15.64 8a.51.51 0 0 1-.43-.31l-1.82-4.27a1.51 1.51 0 0 0-2.78 0L8.8 7.7a.51.51 0 0 1-.43.3l-4.64.4a1.51 1.51 0 0 0-.86 2.6l3.52 3.1a.51.51 0 0 1 .16.5l-1 4.48a1.54 1.54 0 0 0 2.25 1.67l3.94-2.37a.51.51 0 0 1 .53 0l4 2.41a1.49 1.49 0 0 0 1.67-.07 1.49 1.49 0 0 0 .58-1.57l-1.06-4.54a.51.51 0 0 1 .16-.5L21.14 11z"/>
   </g>


### PR DESCRIPTION
align icons properly using flexfox instead of line-height:

```scss
.sui-AtomButton-inner {
    align-items: center;
    display: inline-flex;
    height: 100%;
}
```
Note that we've applied the flexbox in to the layer `inner`. 
That is because some browsers does not support flex in `button` elements.
https://stackoverflow.com/questions/35464067/flexbox-not-working-on-button-or-fieldset-elements

btw, we've forced the icon size, in order to avoid flexbox resizing it
```scss
[class*="Icon"] {
    height: $size;
    width: $size;
}
```
