### PR TITLE
feat(collapsible/basic): remove max-height limitation in collapsible content.

### DIFF
--- a/components/collapsible/basic/src/_settings.scss
+++ b/components/collapsible/basic/src/_settings.scss
@@ -11,3 +11,6 @@ $c-collapsible-basic: $c-gray-dark !default;
 $bdc-collapsible-basic: $c-gray-lightest !default;
 $bd-collapsible-basic: 1px solid $bdc-collapsible-basic !default;
 $trs-collapsible-basic-trigger-icon: transform $trs-base !default;
+$trs-collapsible-basic-content: .3s ease-out;
+$mah-collapsible-basic-content-expanded: 100%;
+$ov-collapsible-basic-content-expanded: scroll;

--- a/components/collapsible/basic/src/index.scss
+++ b/components/collapsible/basic/src/index.scss
@@ -63,9 +63,5 @@
         transform: rotateZ(180deg);
       }
     }
-
-    #{$root-parent}-collapsibleContent {
-      max-height: 100%;
-    }
   }
 }

--- a/components/collapsible/basic/src/index.scss
+++ b/components/collapsible/basic/src/index.scss
@@ -3,7 +3,6 @@
 @import '~@schibstedspain/sui-theme/lib/index';
 @import './settings';
 
-
 .sui-CollapsibleBasic {
   background-color: $bgc-collapsible-basic;
   border: $bd-collapsible-basic;
@@ -43,7 +42,7 @@
   &-collapsibleContent {
     margin-bottom: $mb-collapsible-basic-content;
     overflow: hidden;
-    transition: max-height $trs-base;
+    transition: max-height $trs-collapsible-basic-content;
   }
 
   /* Keep root parent ref to avoid string repetition on nesting */
@@ -62,6 +61,11 @@
       &-icon {
         transform: rotateZ(180deg);
       }
+    }
+
+    #{$root-parent}-collapsibleContent {
+      max-height: $mah-collapsible-basic-content-expanded;
+      overflow: $ov-collapsible-basic-content-expanded;
     }
   }
 }


### PR DESCRIPTION
When we have a very large content in the collapsible component, this content is currently limited to the current height of screen (max-height: 100%). Any overflowing elements are hidden.

I'm removing this limitation, since I don't see its possible usefulness.
