### PR TITLE
feat(card/collapsible): expose click handler func of collapsible.

### DIFF
--- a/components/card/collapsible/src/_settings.scss
+++ b/components/card/collapsible/src/_settings.scss
@@ -1,0 +1,7 @@
+$bgc-card-collapsible: $c-white !default;
+$h-card-collapsible-header-image: 100px;
+$c-card-collapsible-info-item: $c-gray-dark !default;
+$fz-card-collapsible-info-item-collapsed: $fz-l + 2 !default;
+$fz-card-collapsible-info-item-expanded: $fz-m !default;
+$lh-card-collapsible-info-item: 1.2 !default;
+$bxsh-card-collapsible: 0 2px 15px rgba($c-black, .3) !default;

--- a/components/card/collapsible/src/index.js
+++ b/components/card/collapsible/src/index.js
@@ -87,7 +87,7 @@ class CardCollapsible extends Component {
     const {collapsed} = this.state
 
     return (
-      <div className={cx('sui-CardCollapsible', className, {'has-shadow': !this.state.collapsed})}>
+      <div className={cx('sui-CardCollapsible', className, {'is-expanded': !this.state.collapsed})}>
         {headerInfo && this._renderCardHeader(headerImage, collapsed ? headerInfo.displayWhenCollapsed : headerInfo.displayWhenExpanded)}
         <CollapsibleBasic
           collapsed={collapsed}

--- a/components/card/collapsible/src/index.js
+++ b/components/card/collapsible/src/index.js
@@ -83,13 +83,19 @@ class CardCollapsible extends Component {
   }
 
   render () {
-    const {className, children, headerImage, headerInfo, collapseButton, expandButton} = this.props
+    const {className, children, headerImage, headerInfo, collapseButton, expandButton, onChangeHandler} = this.props
     const {collapsed} = this.state
 
     return (
-      <div className={cx('sui-CardCollapsible', className)}>
+      <div className={cx('sui-CardCollapsible', className, {'has-shadow': !this.state.collapsed})}>
         {headerInfo && this._renderCardHeader(headerImage, collapsed ? headerInfo.displayWhenCollapsed : headerInfo.displayWhenExpanded)}
-        <CollapsibleBasic collapsed={collapsed} label={this._renderActionButton(collapsed ? expandButton : collapseButton)} icon={false}>{children}</CollapsibleBasic>
+        <CollapsibleBasic
+          collapsed={collapsed}
+          label={this._renderActionButton(collapsed ? expandButton : collapseButton)}
+          icon={false}
+          handleClick={onChangeHandler}>
+          {children}
+        </CollapsibleBasic>
       </div>
     )
   }
@@ -149,7 +155,11 @@ CardCollapsible.propTypes = {
    */
   collapseButton: PropTypes.shape({
     label: PropTypes.string.isRequired
-  })
+  }),
+  /**
+   * Function to call when the expanded/collapsed status of collapsible component has changed.
+   */
+  onChangeHandler: PropTypes.func
 }
 
 CardCollapsible.displayName = 'CardCollapsible'

--- a/components/card/collapsible/src/index.scss
+++ b/components/card/collapsible/src/index.scss
@@ -2,16 +2,14 @@
 @import '~@schibstedspain/sui-theme/lib/index';
 @import '~@schibstedspain/sui-button-basic/lib/index';
 @import '~@schibstedspain/sui-collapsible-basic/lib/index';
-
-$bgc-card-collapsible: $c-white !default;
-$h-card-collapsible-header-image: 100px;
-$c-card-collapsible-info-item: $c-gray-dark !default;
-$fz-card-collapsible-info-item-collapsed: $fz-l + 2 !default;
-$fz-card-collapsible-info-item-expanded: $fz-m !default;
-$lh-card-collapsible-info-item: 1.2 !default;
+@import 'settings';
 
 .sui-CardCollapsible {
   background-color: $bgc-card-collapsible;
+
+  &.has-shadow {
+    box-shadow: $bxsh-card-collapsible;
+  }
 
   &-header {
     @include sui-list;

--- a/components/card/collapsible/src/index.scss
+++ b/components/card/collapsible/src/index.scss
@@ -7,7 +7,7 @@
 .sui-CardCollapsible {
   background-color: $bgc-card-collapsible;
 
-  &.has-shadow {
+  &.is-expanded {
     box-shadow: $bxsh-card-collapsible;
   }
 


### PR DESCRIPTION
- Add prop `onChangeHandler` to allow customisation of `handleClick` prop of collapsible.
- Add box-shadow style to card only when it is expanded.
- Move scss vars to _settings.scss partial file.