### PR TITLE
feat(tag/selectableList): resolve warning to parameters

### DIFF
--- a/components/tag/selectableList/src/index.js
+++ b/components/tag/selectableList/src/index.js
@@ -64,7 +64,7 @@ export default class TagSelectableList extends Component {
           onClick={this.toggleAll}
           isSelected={isAllSelected}
           label={allLabel}
-          icon={isAllSelected && this.props.checkIcon}
+          icon={isAllSelected ? this.props.checkIcon : null}
         />}
         {this._renderTags()}
       </div>


### PR DESCRIPTION
I need to pass as a parameter a function or null to solve this warning: 

`Warning: Failed prop type: Invalid prop `icon` of type `boolean` supplied to `TagSelectable`, expected `function`.
    in TagSelectable (created by TagSelectableList)`

The previous code, return false sometimes and show the warning in console.