### PR TITLE
Feature/remove root parent selector in collapsibles

### DIFF
--- a/components/card/collapsible/src/index.scss
+++ b/components/card/collapsible/src/index.scss
@@ -14,7 +14,6 @@
   &-header {
     @include sui-list;
     align-items: center;
-    $root-parent: &;
 
     &Image {
       @include sui-list;
@@ -53,7 +52,7 @@
     &.is-expanded {
       flex-direction: row;
 
-      #{$root-parent} {
+      .sui-CardCollapsible-header {
         &Image {
           margin: $m-s 0;
         }

--- a/components/collapsible/basic/src/index.scss
+++ b/components/collapsible/basic/src/index.scss
@@ -3,7 +3,6 @@
 @import '~@schibstedspain/sui-theme/lib/index';
 @import './settings';
 
-
 .sui-CollapsibleBasic {
   background-color: $bgc-collapsible-basic;
   border: $bd-collapsible-basic;
@@ -47,11 +46,8 @@
     transition: max-height $trs-base;
   }
 
-  /* Keep root parent ref to avoid string repetition on nesting */
-  $root-parent: &;
-
   &.is-collapsed {
-    #{$root-parent}-collapsibleContent {
+    .sui-CollapsibleBasic-collapsibleContent {
       max-height: 0;
     }
   }
@@ -59,13 +55,13 @@
   &.is-expanded {
     background-color: $bgc-collapsible-basic-expanded;
 
-    #{$root-parent}-trigger {
+    .sui-CollapsibleBasic-trigger {
       &-icon {
         transform: rotateZ(180deg);
       }
     }
 
-    #{$root-parent}-collapsibleContent {
+    .sui-CollapsibleBasic-collapsibleContent {
       max-height: 100%;
     }
   }


### PR DESCRIPTION
This `root-parent: &` in scss files cause some problems when loading styles inside a wrapper selector like:
```
.nc-detail {
  @import '../pages/NewConstructionDetail/index';
}
```
(This way of importing scss files is used inside fotocasa to include "Obra Nueva" new detail page without affecting FC styles).
