### PR TITLE
feat(dropdown/user): remove useless declaration

### DIFF
--- a/components/dropdown/user/src/index.scss
+++ b/components/dropdown/user/src/index.scss
@@ -138,10 +138,6 @@
         }
       }
 
-      &Text {
-        flex: 1;
-      }
-
       &Notification {
         @include sui-badge-notification;
       }


### PR DESCRIPTION
Removing useless declaration, which is bugging IE navigation dropdowns:

### Before:

![image](https://user-images.githubusercontent.com/886033/34977843-7a4108de-fa9c-11e7-9f44-99abf646c4f0.png)

### After:

![image](https://user-images.githubusercontent.com/886033/34977857-8a39ce56-fa9c-11e7-8e94-393dc57dfede.png)


