### PR TITLE
feat(error/appBoundary): make error appBoundary more resilient and prepared

### DIFF
--- a/components/error/appBoundary/src/index.js
+++ b/components/error/appBoundary/src/index.js
@@ -3,10 +3,24 @@ import PropTypes from 'prop-types'
 
 class ErrorAppBoundary extends Component {
   AlertBasicComponent = null
-  state = { hasError: false }
+  state = { errorCount: 0, hasError: false }
   componentDidCatch (errorMessage, errorStack) {
-    this.props.onError({ errorMessage, errorStack })
-    // import async the alert basic component
+    const { numberOfToleratedErrors, onError, redirectUrlOnUntolerated } = this.props
+    const { errorCount } = this.state
+
+    onError({ errorMessage, errorStack })
+    this.setState({ errorCount: errorCount + 1 })
+
+    return errorCount >= numberOfToleratedErrors
+      ? redirectUrlOnUntolerated && (window.location.href = redirectUrlOnUntolerated)
+      : this._loadNotification()
+  }
+
+  shouldComponentUpdate (nextProps, nextState) {
+    return nextState.errorCount <= nextProps.numberOfToleratedErrors
+  }
+
+  _loadNotification () {
     new Promise(resolve => {
       require.ensure([], (require) => {
         resolve(require('@schibstedspain/sui-alert-basic').default)
@@ -46,19 +60,46 @@ class ErrorAppBoundary extends Component {
 
 ErrorAppBoundary.displayName = 'ErrorAppBoundary'
 ErrorAppBoundary.propTypes = {
+  /**
+   * Label for the button shown on the notification
+   */
   buttonLabel: PropTypes.string,
+  /**
+   * Wrapped childrens to control errors
+   */
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
   ]),
+  /**
+   * Customize the icon you want to show on the notification
+   */
   icon: PropTypes.element,
+  /**
+   * Message to show to the user in order to inform him about the error
+   */
   message: PropTypes.string,
-  onError: PropTypes.func
+  /**
+   * In order to avoid infinite loops for errors on render, do a shortcircuit if the component
+   * can't handle all the errors that are coming
+   */
+  numberOfToleratedErrors: PropTypes.number,
+  /**
+   * Execute some code for each error. Useful for sending traces to some service in order to log
+   * and track errors in the frontend
+   */
+  onError: PropTypes.func,
+  /**
+   * If the numberOfToleratedErrores is surpassed, then we could redirect the user to a different
+   * URL in order to inform him that the web is definitely broken and unusable
+   */
+  redirectUrlOnUntolerated: PropTypes.string
 }
 
 ErrorAppBoundary.defaultProps = {
   buttonLabel: 'OK',
   message: 'Error',
+  numberOfToleratedErrors: 4,
   onError: ({ errorMessage, errorStack }) => console.error({ errorMessage, errorStack })
 }
 

--- a/components/error/appBoundary/src/index.js
+++ b/components/error/appBoundary/src/index.js
@@ -5,19 +5,19 @@ class ErrorAppBoundary extends Component {
   AlertBasicComponent = null
   state = { errorCount: 0, hasError: false }
   componentDidCatch (errorMessage, errorStack) {
-    const { numberOfToleratedErrors, onError, redirectUrlOnUntolerated } = this.props
+    const { errorThreshold, onError, redirectUrlOnBreakingThreshold } = this.props
     const { errorCount } = this.state
 
     onError({ errorMessage, errorStack })
     this.setState({ errorCount: errorCount + 1 })
 
-    return errorCount >= numberOfToleratedErrors
-      ? redirectUrlOnUntolerated && (window.location.href = redirectUrlOnUntolerated)
+    return errorCount >= errorThreshold
+      ? redirectUrlOnBreakingThreshold && (window.location.href = redirectUrlOnBreakingThreshold)
       : this._loadNotification()
   }
 
   shouldComponentUpdate (nextProps, nextState) {
-    return nextState.errorCount <= nextProps.numberOfToleratedErrors
+    return nextState.errorCount <= nextProps.errorThreshold
   }
 
   _loadNotification () {
@@ -83,7 +83,7 @@ ErrorAppBoundary.propTypes = {
    * In order to avoid infinite loops for errors on render, do a shortcircuit if the component
    * can't handle all the errors that are coming
    */
-  numberOfToleratedErrors: PropTypes.number,
+  errorThreshold: PropTypes.number,
   /**
    * Execute some code for each error. Useful for sending traces to some service in order to log
    * and track errors in the frontend
@@ -93,13 +93,13 @@ ErrorAppBoundary.propTypes = {
    * If the numberOfToleratedErrores is surpassed, then we could redirect the user to a different
    * URL in order to inform him that the web is definitely broken and unusable
    */
-  redirectUrlOnUntolerated: PropTypes.string
+  redirectUrlOnBreakingThreshold: PropTypes.string
 }
 
 ErrorAppBoundary.defaultProps = {
   buttonLabel: 'OK',
   message: 'Error',
-  numberOfToleratedErrors: 4,
+  errorThreshold: 4,
   onError: ({ errorMessage, errorStack }) => console.error({ errorMessage, errorStack })
 }
 


### PR DESCRIPTION
Please review @SUI-Components/developers 

- [x] Add tolerance error ratio in order to avoid infinite loops for errors on `render()`s methods.
- [x] Add the possibility to redirect to a different page if you have an error.
- [x] Add comments for propTypes.