### PR TITLE
fix(atom/button): avoid adding type attribute to button tag, since in…

### DIFF
--- a/components/atom/button/src/index.js
+++ b/components/atom/button/src/index.js
@@ -8,7 +8,7 @@ const SIZES = ['small', 'large']
 const MODIFIERS = ['disabled', 'fullWidth', 'focused', 'negative', 'link']
 const OWN_PROPS = [
   ...TYPES, ...SIZES, ...MODIFIERS,
-  'leftIcon', 'rightIcon', 'className', 'children', 'linkFactory'
+  'leftIcon', 'rightIcon', 'className', 'children', 'linkFactory', 'type'
 ]
 const CLASSES = [...TYPES, ...SIZES, ...MODIFIERS, 'empty']
   .reduce((res, key) => Object.assign(res, {[key]: `${CLASS}--${key}`}), {})


### PR DESCRIPTION
@SUI-Components/developers please review.

By default, HTML5 button tag behaviour is as a "submit", and because of not cleaning the "type" attribute from the props (it can be primary, secondary, ...), it was rendering:

```
<button type="primary">...</button>
```

And this value is not a valid option (in terms of W3C spec, it can be only "button", "submit" or "reset"), si it had a wrong behaviour in browsers (IE basically) where if not a valid option is set, then its behaviour is a simple button (but the rest of browsers consider as a submit).

Maybe we should consider of moving from "type" propType to something different that not collides with native html attributes (buttonType for example).