### PR TITLE
fix(META): loading newest now version for deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 install:
   - npm run phoenix
 before_deploy:
-  - npm i -g now@7
+  - npm i -g now@9
   - npm run build
 deploy:
   skip_cleanup: true


### PR DESCRIPTION
Deployment wasn't working because of `npm i -g now@7`, seems like v7 isn't loading correctly but v9 works and deploys.

```
$ npm i -g now@7
/home/travis/.nvm/versions/node/v6.12.3/bin/now -> /home/travis/.nvm/versions/node/v6.12.3/lib/node_modules/now/download/dist/now
> now@7.4.0 postinstall /home/travis/.nvm/versions/node/v6.12.3/lib/node_modules/now
> node download/install.js
> For the source code, check out: https://github.com/zeit/now-cli
{ Error: incorrect header check
    at Zlib._handle.onerror (zlib.js:371:17) errno: -3, code: 'Z_DATA_ERROR' }
assert.js:84
  throw new assert.AssertionError({
  ^
AssertionError: undefined == true
    at showProgress (/home/travis/.nvm/versions/node/v6.12.3/lib/node_modules/now/download/dist/download.js:8194:24)
    at PassThrough.<anonymous> (/home/travis/.nvm/versions/node/v6.12.3/lib/node_modules/now/download/dist/download.js:2108:49)
    at emitOne (events.js:96:13)
    at PassThrough.emit (events.js:188:7)
    at readableAddChunk (_stream_readable.js:176:18)
    at PassThrough.Readable.push (_stream_readable.js:134:10)
    at PassThrough.Transform.push (_stream_transform.js:128:32)
    at afterTransform (_stream_transform.js:77:12)
    at TransformState.afterTransform (_stream_transform.js:54:12)
    at PassThrough._transform (_stream_passthrough.js:21:3)
npm ERR! Linux 4.14.12-041412-generic
npm ERR! argv "/home/travis/.nvm/versions/node/v6.12.3/bin/node" "/home/travis/.nvm/versions/node/v6.12.3/bin/npm" "i" "-g" "now@7"
npm ERR! node v6.12.3
npm ERR! npm  v3.10.10
npm ERR! code ELIFECYCLE
npm ERR! now@7.4.0 postinstall: `node download/install.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the now@7.4.0 postinstall script 'node download/install.js'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the now package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node download/install.js
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs now
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls now
npm ERR! There is likely additional logging output above.
npm ERR! Please include the following file with any support request:
npm ERR!     /home/travis/build/SUI-Components/sui-components/npm-debug.log
The command "npm i -g now@7" failed and exited with 1 during .
Your build has been stopped.
```