### PR TITLE
feat(list/image): add style to avoid overflowing container size in IE.

### DIFF
--- a/components/list/image/src/index.scss
+++ b/components/list/image/src/index.scss
@@ -29,6 +29,7 @@
     }
     cursor: pointer;
     flex-basis: $fxb-list-image-item-desktop;
+    overflow: hidden;
   }
 
   &-lastItemContainer {


### PR DESCRIPTION
In IE, we need to add this `overflow: hidden` style to avoid that the image grows bigger than its parent container.
In other browser (Chrome, Safari, Firefox, Opera, Edge), this problem won't happen, and it is not affected as well after adding this new style.