### PR TITLE
feat(sticky/content): calculate window scroll top compatible with dif…

### DIFF
--- a/components/sticky/content/src/index.js
+++ b/components/sticky/content/src/index.js
@@ -78,11 +78,13 @@ export default class StickyContent extends Component {
   }
 
   _shouldStickContent = () => {
-    const windowTop = this._scrollableElement.scrollTop
+    const windowTop = this._scrollableElement
+      ? this._scrollableElement.scrollTop
+      : window.scrollY || document.documentElement.scrollTop
+
     if (!this._elementTop) {
       this._setElementTop()
     }
-
     return windowTop >= this._elementTop
   }
 
@@ -100,8 +102,7 @@ export default class StickyContent extends Component {
     const { sticky, scrollableElementSelector } = this.props
 
     if (sticky) {
-      this._scrollableElement = scrollableElementSelector ? document.querySelector(scrollableElementSelector) : document.documentElement
-
+      this._scrollableElement = scrollableElementSelector && document.querySelector(scrollableElementSelector)
       window.addEventListener('scroll', this._handleScroll, SCROLL_EVENT_LISTENER_OPTIONS)
     }
   }


### PR DESCRIPTION
…ferent browsers.

We were using before `document.documentElement.scrollTop`, which is not compatible with browser like Safari or IE.
The other options:
- `window.scrollY` is full compatible except in IE.
- `document.body.scrollTop` is not compatible with Firefox, Opera and EDGE.

So, in the end I have created a mix of document.documentElement.scrollTop and window.scrollY to make it work in all browsers.
