### PR TITLE
fix(modal/gallery): remove negative header margin for mobile landscap…

### DIFF
--- a/components/modal/gallery/src/index.scss
+++ b/components/modal/gallery/src/index.scss
@@ -56,12 +56,14 @@ $mt-modal-gallery-header-height-mobile: -($h-modal-basic-icon + ($m-l * 2)) !def
         justify-content: center;
       }
 
-      &-header {
-        margin-top: $mt-modal-gallery-header-height-mobile;
-      }
-
       &-content {
         flex-grow: 0;
+      }
+    }
+
+    @include media-breakpoint-down (xs) {
+      &-header {
+        margin-top: $mt-modal-gallery-header-height-mobile;
       }
     }
 


### PR DESCRIPTION
…e view.

So, the modal header (that includes the close button) was not being displayed in mobile using lansdcape view.