### PR TITLE
feat(sticky/content): fix error when calculating initial sticky conte…

### DIFF
--- a/components/sticky/content/src/index.js
+++ b/components/sticky/content/src/index.js
@@ -74,13 +74,17 @@ export default class StickyContent extends Component {
 
   _setElementTop = () => {
     const { top: elementTop } = this._DOMElement.getBoundingClientRect()
-    this._elementTop = elementTop
+    this._elementTop = elementTop + this._getCurrentWindowScrollTop()
+  }
+
+  _getCurrentWindowScrollTop () {
+    return window.scrollY || document.documentElement.scrollTop
   }
 
   _shouldStickContent = () => {
     const windowTop = this._scrollableElement
       ? this._scrollableElement.scrollTop
-      : window.scrollY || document.documentElement.scrollTop
+      : this._getCurrentWindowScrollTop()
 
     if (!this._elementTop) {
       this._setElementTop()


### PR DESCRIPTION
…nt element top offset.

When you refresh/navigate to a page containing this component and there is already some scroll set in the page (i.e. when we come form the search results listing page), the initial top position of the element warpped with the sticky content is misscalculated. It was set before to `getBoundingClientRect().top` (corresponding to the height of the element), but we were nor considering the initial scrolled distance of the page.