### PR TITLE
Feature/sui section info conditional title

### DIFF
--- a/components/section/info/README.md
+++ b/components/section/info/README.md
@@ -1,6 +1,6 @@
 # SectionInfo
 
-> A responsive `section` container to display custom information based on Title and Content structure.
+A responsive `section` container to display custom information based on Title and Content structure.
 
 <!-- ![](./assets/preview.png) -->
 
@@ -11,7 +11,8 @@ $ npm install @schibstedspain/sui-section-info --save
 ```
 
 ## Usage
-Provide an `string` to a `title` prop and wrap a child component as a `content`. If no `title` prop is provided the corresponding DOM element won't be rendered. In addition you can provide an empty string if the Title space is needed.
+Provide an `string` to a `title` prop and wrap a child component as a `content`. If no `title` prop is provided or contains an empty string `''` the corresponding Title DOM element won't be rendered.
+
 Check out **Basic Usage** section to get further info.
 
 Set custom values to container sizing and flex properties using the following Sass variables:

--- a/components/section/info/README.md
+++ b/components/section/info/README.md
@@ -11,7 +11,7 @@ $ npm install @schibstedspain/sui-section-info --save
 ```
 
 ## Usage
-Provide an `string` to a `title` prop and wrap a child component as a `content`. If no `title` prop is provided the corresponding DOM element won'7 be rendered. In addition you can provide an empty string if the Title space is needed.
+Provide an `string` to a `title` prop and wrap a child component as a `content`. If no `title` prop is provided the corresponding DOM element won't be rendered. In addition you can provide an empty string if the Title space is needed.
 Check out **Basic Usage** section to get further info.
 
 Set custom values to container sizing and flex properties using the following Sass variables:

--- a/components/section/info/README.md
+++ b/components/section/info/README.md
@@ -11,7 +11,7 @@ $ npm install @schibstedspain/sui-section-info --save
 ```
 
 ## Usage
-Provide an `string` to a `title` prop and wrap a child component as a `content`.
+Provide an `string` to a `title` prop and wrap a child component as a `content`. If no `title` prop is provided the corresponding DOM element won'7 be rendered. In addition you can provide an empty string if the Title space is needed.
 Check out **Basic Usage** section to get further info.
 
 Set custom values to container sizing and flex properties using the following Sass variables:

--- a/components/section/info/src/index.js
+++ b/components/section/info/src/index.js
@@ -9,7 +9,7 @@ class SectionInfo extends Component {
 
     return (
       <section className={baseClass}>
-        <h3 className={`${baseClass}-title`}>{title}</h3>
+        { title !== undefined && <h3 className={`${baseClass}-title`}>{title}</h3> }
         <div className={`${baseClass}-content`}>{children}</div>
       </section>
     )

--- a/components/section/info/src/index.js
+++ b/components/section/info/src/index.js
@@ -4,12 +4,16 @@ import PropTypes from 'prop-types'
 const baseClass = 'sui-SectionInfo'
 
 class SectionInfo extends Component {
+  displayTitle (title) {
+    return (title !== undefined && title !== '')
+  }
+
   render () {
     const { title, children } = this.props
 
     return (
       <section className={baseClass}>
-        { title !== undefined && <h3 className={`${baseClass}-title`}>{title}</h3> }
+        { this.displayTitle(title) && <h3 className={`${baseClass}-title`}>{title}</h3> }
         <div className={`${baseClass}-content`}>{children}</div>
       </section>
     )

--- a/components/section/info/src/index.js
+++ b/components/section/info/src/index.js
@@ -4,16 +4,12 @@ import PropTypes from 'prop-types'
 const baseClass = 'sui-SectionInfo'
 
 class SectionInfo extends Component {
-  displayTitle (title) {
-    return (title !== undefined && title !== '')
-  }
-
   render () {
     const { title, children } = this.props
 
     return (
       <section className={baseClass}>
-        { this.displayTitle(title) && <h3 className={`${baseClass}-title`}>{title}</h3> }
+        { title && <h3 className={`${baseClass}-title`}>{title}</h3> }
         <div className={`${baseClass}-content`}>{children}</div>
       </section>
     )

--- a/demo/section/info/playground
+++ b/demo/section/info/playground
@@ -1,8 +1,10 @@
 const descriptionElement = <p>Spicy jalapeno bacon ipsum dolor amet pig short ribs pork chop, pork belly sausage rump meatball brisket shoulder. Drumstick jowl filet mignon, turducken rump cupim pork loin frankfurter tri-tip meatball porchetta cow kevin. Leberkas drumstick jowl ground round short ribs pork. Meatloaf shank meatball pork belly, corned beef frankfurter spare ribs tenderloin flank short ribs porchetta pork chop ground round burgdoggen. Tri-tip salami meatloaf, beef ribs buffalo cupim sirloin chicken tenderloin doner andouille picanha bresaola ham. Strip steak bresaola pork chop, short loin shank shankle ham hock ribeye turducken spare ribs chicken bacon landjaeger.</p>
 const description = 'Description'
 
-const extrasElement = <ul><li>air conditioning</li><li>lifter</li><li>terace</li><li>pool</li><li>parking</li><li>solar powered</li><li>kitchen</li><li>toilett</li><li>garden</li><li>appliances</li></ul>
 const extras = 'Extras'
+const extrasElement = <ul><li>air conditioning</li><li>lifter</li><li>terace</li><li>pool</li><li>parking</li><li>solar powered</li><li>kitchen</li><li>toilett</li><li>garden</li><li>appliances</li></ul>
+const extrasElementNoTitle = <p><strong>No title at all</strong> - Spicy jalapeno bacon ipsum dolor amet pig short ribs pork chop, pork belly sausage rump meatball brisket shoulder. Drumstick jowl filet mignon, turducken rump cupim pork loin frankfurter tri-tip meatball porchetta cow kevin. Leberkas drumstick jowl ground round short ribs pork. Meatloaf shank meatball pork belly, corned beef frankfurter spare ribs tenderloin flank short ribs porchetta pork chop ground round burgdoggen. Tri-tip salami meatloaf, beef ribs buffalo cupim sirloin chicken tenderloin doner andouille picanha bresaola ham. Strip steak bresaola pork chop, short loin shank shankle ham hock ribeye turducken spare ribs chicken bacon landjaeger.</p>
+const extrasElementEmptyTitle = <p><strong>A container with empty Title Value</strong> - Spicy jalapeno bacon ipsum dolor amet pig short ribs pork chop, pork belly sausage rump meatball brisket shoulder. Drumstick jowl filet mignon, turducken rump cupim pork loin frankfurter tri-tip meatball porchetta cow kevin. Leberkas drumstick jowl ground round short ribs pork. Meatloaf shank meatball pork belly, corned beef frankfurter spare ribs tenderloin flank short ribs porchetta pork chop ground round burgdoggen. Tri-tip salami meatloaf, beef ribs buffalo cupim sirloin chicken tenderloin doner andouille picanha bresaola ham. Strip steak bresaola pork chop, short loin shank shankle ham hock ribeye turducken spare ribs chicken bacon landjaeger.</p>
 
 return (
   <div>
@@ -12,6 +14,14 @@ return (
 
     <SectionInfo title={extras}>
       {extrasElement}
+    </SectionInfo>
+
+    <SectionInfo title=''>
+      {extrasElementEmptyTitle}
+    </SectionInfo>
+
+    <SectionInfo>
+      {extrasElementNoTitle}
     </SectionInfo>
   </div>
 )


### PR DESCRIPTION
### PR Summary
Adds a conditional `title` prop so you have better flexibility:
- If no title is provided the corresponding DOM element will be hidden.
- If **empty** title is provided the corresponding DOM element **will be hidden too**.

A playground Demo is provided.
Please review @SUI-Components/developers 