### PR TITLE
feat(collapsible/basic): do not show content scroll bar in IE/Edge if…

### DIFF
--- a/components/collapsible/basic/src/index.scss
+++ b/components/collapsible/basic/src/index.scss
@@ -73,7 +73,7 @@
 
     .sui-CollapsibleBasic-collapsibleContent {
       max-height: 100vh;
-      overflow-y: scroll;
+      overflow-y: auto;
     }
   }
 }


### PR DESCRIPTION
… not needed.

The `overflow-y` in the collapsible's content was set to allow scroll if its content is bigger than 100vh (full screen's height), but in IE and EDGE browser the scroll bar is shown disabled even if the content do not really need scroll.
Switching to `overflow: auto` fixed the problem and scroll bar is only displayed when needed.