### PR TITLE
fix(atom/button): use pointer events none for inner span on button

### DIFF
--- a/components/atom/button/src/index.scss
+++ b/components/atom/button/src/index.scss
@@ -90,6 +90,7 @@ $p-atom-button-large: $p-l !default;
     align-items: center;
     display: inline-flex;
     height: 100%;
+    pointer-events: none;
   }
 
   // Icons


### PR DESCRIPTION
Please review @SUI-Components/developers 

Add pointer-events none for span inside a button. While the onClick of the element is working as expected because React is adding a synthetic event to it, native events like an addEventListener for the button doesn't work as expected as it thinks that the span has been clicked instead the button. With this fix, we ensure the event is captured by the button instead the spans inside.