### PR TITLE
feat(cover/basic): remove object-fit fix, use always background-image…

### DIFF
--- a/components/cover/basic/src/index.js
+++ b/components/cover/basic/src/index.js
@@ -13,19 +13,18 @@ const CoverBasic = (props) => {
     {'is-clickable': isClickable(props)})
 
   const imageContainerClassNames = cx(
-    {'sui-CoverBasic-gradient': props.gradient},
-    {'sui-CoverBasic-objectFitFix': !isObjectFitSupported()})
+    'sui-CoverBasic-image',
+    {'sui-CoverBasic-gradient': props.gradient})
 
-  // Sadly, object-fit compatibility support cannot be done with just adding one class.
-  // The following line is the second part of the solution which is an inline style.
-  const ieObjectFitInlineStyleFix =
-    isObjectFitSupported() ? '' : { style: {backgroundImage: 'url(' + props.src + ')'} }
+  const coverBackgroundImageInlineStyle = {
+    style: {
+      backgroundImage: 'url(' + props.src + ')'
+    }
+  }
 
   return (
     <div className={coverBasicClassNames} onClick={buildClickHandler(props)}>
-      <div className={imageContainerClassNames} {...ieObjectFitInlineStyleFix}>
-        <img className='sui-CoverBasic-image' src={props.src} />
-      </div>
+      <div className={imageContainerClassNames} {...coverBackgroundImageInlineStyle} />
       {props.children &&
         <div className='sui-CoverBasic-children'>
           {props.children}
@@ -68,10 +67,6 @@ const buildButtons = (props) => {
       </div>
     )
   })
-}
-
-const isObjectFitSupported = () => {
-  return !(typeof document.documentElement.style.objectFit === 'undefined')
 }
 
 CoverBasic.displayName = 'CoverBasic'

--- a/components/cover/basic/src/index.scss
+++ b/components/cover/basic/src/index.scss
@@ -50,20 +50,11 @@ $bdrs-cover-basic-button: $bdrs-base !default;
     width: 100%;
   }
 
-  &-objectFitFix {
+  &-image {
     background-position: center center;
     background-repeat: no-repeat;
     background-size: cover;
-
-    img {
-      opacity: 0;
-    }
-  }
-
-  &-image {
-    display: block;
     height: 100%;
-    object-fit: cover;
     width: 100%;
   }
 


### PR DESCRIPTION
… with bg-size cover.

As the validation if 'object-fit' style is supported in current page is not compatible with SSR (because it is checking the `document`), we have decided to remove the use of image and only support a div with its `background-image` with the style `background-size: cover`.

This solution works well in the different supported browsers, and with Client and Server Side Rendering.