### PR TITLE
feat(modal/gallery): avoid return null on render when modal is closed.

### DIFF
--- a/components/modal/gallery/src/index.js
+++ b/components/modal/gallery/src/index.js
@@ -42,6 +42,12 @@ class ModalGallery extends Component {
     )
   }
 
+  _renderEmptyContent () {
+    return (
+      <div className='sui-ModalGallery-emptyContent' />
+    )
+  }
+
   _onSlideChange = (currentSlide) => {
     this.setState(currentSlide)
   }
@@ -60,7 +66,7 @@ class ModalGallery extends Component {
           iconClose={iconClose}
           onClose={onClose}
           header={this._renderHeader({images: {currentSlide: currentSlide + 1, totalSlides: multimedia.images.length}})}
-          content={open && this._renderImageSlider({...multimedia, sliderOptions: {lazyLoadSlider, initialSlide, doAfterSlide: this._onSlideChange}})}
+          content={open ? this._renderImageSlider({...multimedia, sliderOptions: {lazyLoadSlider, initialSlide, doAfterSlide: this._onSlideChange}}) : this._renderEmptyContent()}
         />
       </div>
     )

--- a/components/modal/gallery/src/index.js
+++ b/components/modal/gallery/src/index.js
@@ -12,8 +12,8 @@ class ModalGallery extends Component {
     currentSlide: this.props.initialSlide
   }
 
-  componentWillReceiveProps ({shouldRenderModal, initialSlide = 0}) {
-    if (shouldRenderModal) {
+  componentWillReceiveProps ({open, initialSlide = 0}) {
+    if (open) {
       this.setState({currentSlide: initialSlide})
     }
   }
@@ -48,19 +48,19 @@ class ModalGallery extends Component {
 
   render () {
     const {currentSlide} = this.state
-    const {initialSlide, lazyLoadSlider, multimedia, iconClose, onClose, shouldRenderModal} = this.props
+    const {open, initialSlide, lazyLoadSlider, multimedia, iconClose, onClose} = this.props
 
-    return shouldRenderModal && (
+    return (
       <div className='sui-ModalGallery'>
         <SuiModal
-          open
+          open={open}
           centerVertically
           closeOnOutsideClick
           fitWindow
           iconClose={iconClose}
           onClose={onClose}
           header={this._renderHeader({images: {currentSlide: currentSlide + 1, totalSlides: multimedia.images.length}})}
-          content={this._renderImageSlider({...multimedia, sliderOptions: {lazyLoadSlider, initialSlide, doAfterSlide: this._onSlideChange}})}
+          content={open && this._renderImageSlider({...multimedia, sliderOptions: {lazyLoadSlider, initialSlide, doAfterSlide: this._onSlideChange}})}
         />
       </div>
     )
@@ -70,6 +70,10 @@ class ModalGallery extends Component {
 ModalGallery.displayName = 'ModalGallery'
 
 ModalGallery.propTypes = {
+  /**
+   * Flag to show or hide gallery modal.
+   */
+  open: PropTypes.bool,
   /**
    * Initial slide to show when creating the gallery image slider.
    */
@@ -102,19 +106,15 @@ ModalGallery.propTypes = {
   /**
    * Callback to execute when the modal is closed.
    */
-  onClose: PropTypes.func,
-  /**
-   * Flag to avoid rendering modal gallery component (e.g. when it is closed).
-   */
-  shouldRenderModal: PropTypes.bool
+  onClose: PropTypes.func
 }
 
 ModalGallery.defaultProps = {
   multimedia: {
     images: []
   },
-  shouldRenderModal: false,
-  lazyLoadSlider: false,
+  open: false,
+  lazyLoadSlider: true,
   initialSlide: 0,
   onClose: NO_OP,
   counterTextFormatter: DEFAULT_COUNTER_TEXT_FORMATTER

--- a/demo/modal/gallery/playground
+++ b/demo/modal/gallery/playground
@@ -53,9 +53,9 @@ class FullscreenModalGallery extends React.Component {
       <div>
         <button onClick={() => this._open()}>Open Modal Gallery!</button>
         <ModalGallery
-          shouldRenderModal={this.state.isOpen}
+          open={this.state.isOpen}
           multimedia={{images}}
-          initialSlide={6}
+          initialSlide={11}
           onClose={() => this._close()}
         />
       </div>


### PR DESCRIPTION
In previous version of this component, when the gallery modal was closed, its render method returns null instead of letting that `sui-modal-basic` component's default behaviour just hide it with `display:none` and updates its inner state.

But the problem of doing this is that the `sui-modal-basic` appends/removes a CSS class to the `body` of the page when its status changes (`_toggleWindowScroll`).
Returning null instead of updating it to `open=false` makes that the class is not toggled correctly, causing some scroll problems in mobile devices.

This PR fixes the problem, and renames the prop `shouldRenderModal` to `open`. Also, enables the lazyLoad behoviour of the image slider displayed inside the modal.
