### PR TITLE
feat(cover/basic): button list must be displayed over gradient bg image.

### DIFF
--- a/components/cover/basic/src/index.scss
+++ b/components/cover/basic/src/index.scss
@@ -18,6 +18,7 @@ $bgr-cover-basic-bgImage: initial !default;
 $bgc-cover-basic-button: rgba(255, 255, 255, .75) !default;
 $bdrs-cover-basic-button: $bdrs-base !default;
 $z-cover-basic-children: 1 !default;
+$z-cover-basic-button-list: 1 !default;
 
 .sui-CoverBasic {
   @include media-breakpoint-down(s) {
@@ -68,6 +69,7 @@ $z-cover-basic-children: 1 !default;
     margin-top: $mt-cover-basic-buttons;
     position: absolute;
     top: 0;
+    z-index: $z-cover-basic-button-list;
   }
 
   &-button {


### PR DESCRIPTION
When displaying the cover with a gradient, the `sui-CoverBasic-buttonList` container displayed on top-left of the cover is shown below of the gradient.
We are just adding a z-index to display it on top of it (same case as the `sui-CoverBasic-children` container).