### PR TITLE
feat(button/share): use separated imports to avoid downloading all ic…

### DIFF
--- a/components/button/share/src/index.js
+++ b/components/button/share/src/index.js
@@ -1,7 +1,10 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import cx from 'classnames'
-import {Socialtwitter, Socialfacebook, Commentsquare, Envelopeclosed} from '@schibstedspain/sui-svgiconset'
+import Socialtwitter from '@schibstedspain/sui-svgiconset/lib/Socialtwitter'
+import Socialfacebook from '@schibstedspain/sui-svgiconset/lib/Socialfacebook'
+import Commentsquare from '@schibstedspain/sui-svgiconset/lib/Commentsquare'
+import Envelopeclosed from '@schibstedspain/sui-svgiconset/lib/Envelopeclosed'
 
 const getOnClickHandle = src => () => window.open(src)
 


### PR DESCRIPTION
…ons from package.

Just in order to avoid including all icons from package `sui-svgiconset` when generating the bundles of the pages that use this component.

Using these 4 imports separately, makes that the bundle includes only these 4 icons and not the full package, as it is happening currently in New Construction's detail page.