### PR TITLE
feat(atom/spinner): add !default to bg variable

### DIFF
--- a/components/atom/spinner/src/index.scss
+++ b/components/atom/spinner/src/index.scss
@@ -1,7 +1,7 @@
 @import '~@schibstedspain/sui-theme/lib/index';
 @import './SUILoader/index';
 
-$bgc-atom-spinner: rgba($c-white, .6);
+$bgc-atom-spinner: rgba($c-white, .6) !default;
 $z-atom-spinner: 1 !default;
 
 %spinner-layer {


### PR DESCRIPTION
Add default property to $bgc-atom-spinner variable. I need overwrite this variable.