### PR TITLE
Feature/section basic new features

### DIFF
--- a/components/section/basic/README.md
+++ b/components/section/basic/README.md
@@ -1,10 +1,37 @@
-### SectionBasic
+# SectionBasic
 
-Creates a basic section container wrapped in a `<section>` HTML tag.
-?
-Contains:
+> Just a basic section container wrapped in a `<section>` HTML tag, with customisable margin-bottom between its inner elements and the possibility to add an <hr> separator.
 
-- Title as `<h3>` element (the title alignment is customizable).
-- Subtitle as `<h5>` element (the subtitle alignment is customizable).
-- The content of the section may be only text (when textContent property is used) wrapped in a `<p>` HTML tag.
-- It also support any other HTML element (or multiple HTML nodes) as a SectionBasic children content.
+## Installation
+
+```sh
+$ npm install @schibstedspain/sui-section-basic --save
+```
+
+## Usage
+
+### Basic usage
+```js
+import SectionBasic, {sectionBasicBottomSpacing} from '@schibstedspain/sui-atom-panel'
+
+return (
+  <div>
+    <SectionBasic
+      title='Title of the section'
+      separator
+      sectionBottomSpacing={sectionBasicBottomSpacing.GIANT}
+      headerBottomSpacing={sectionBasicBottomSpacing.XLARGE}
+      contentBottomSpacing={sectionBasicBottomSpacing.MEDIUM}>
+      <p>This section has a title</p>
+      <p>There is a line separator displayed at the bottom of this section as an hr element.</p>
+      <p>The margin-bottom of header, content and full section component have been customised.</p>
+    </SectionBasic>
+    <SectionBasic
+      textContent='This section has no title, only text content and default vertical spacing.'
+    />
+  </div>
+)
+
+```
+
+> **Find full description and more examples in the [demo page](https://sui-components.now.sh/workbench/section/basic/demo).**

--- a/components/section/basic/src/_settings.scss
+++ b/components/section/basic/src/_settings.scss
@@ -1,0 +1,26 @@
+// Title
+$c-section-basic-title: $c-gray-dark !default;
+$fz-section-basic-title: $fz-s !default;
+$fw-section-basic-title: $fw-regular !default;
+$lh-section-basic-title: $lh-s !default;
+$ta-section-basic-title: left !default;
+
+// Text content
+$c-section-basic-text-content: $c-gray-dark !default;
+$fz-section-basic-text-content: $fz-m !default;
+$fw-section-basic-text-content: $fw-regular !default;
+$lh-section-basic-text-content: 1.5 !default;
+$ta-section-basic-text-content: left !default;
+
+// Line separator (hr)
+$bd-section-basic-hr-separator: 1px solid $c-gray-lightest;
+
+// Section/header/content available margin-bottoms
+$bottom-spacings-section-basic: (
+  none: 0,
+  small: $m-m,    //  8px
+  medium: $m-l,   // 16px
+  large: $m-xl,   // 24px
+  xlarge: $m-xxl, // 32px
+  giant: $m-giant // 48px
+) !default;

--- a/components/section/basic/src/constants.js
+++ b/components/section/basic/src/constants.js
@@ -1,0 +1,12 @@
+const SPACING = {
+  NONE: 'none',
+  SMALL: 'small',
+  MEDIUM: 'medium',
+  LARGE: 'large',
+  XLARGE: 'xlarge',
+  GIANT: 'giant'
+}
+
+export {
+  SPACING
+}

--- a/components/section/basic/src/index.js
+++ b/components/section/basic/src/index.js
@@ -1,50 +1,43 @@
-import PropTypes from 'prop-types'
 import React from 'react'
+import PropTypes from 'prop-types'
 import cx from 'classnames'
+import { SPACING } from './constants'
 
-const SECTION_TITLE_ALIGNMENTS = ['left', 'center', 'right']
+const CLASS = 'sui-SectionBasic'
+const AVAILABLE_SPACINGS = Object.values(SPACING)
 
-const SectionBasic = ({className, children, textContent, title, titleAlign, subtitle, subtitleAlign, lineSeparator}) => (
-  <section className={cx('sui-SectionBasic', className)}>
-    <div className='sui-SectionBasic-header'>
-      <h3 className={cx('sui-SectionBasic-title', `sui-SectionBasic-title--${titleAlign}`)}>{title}</h3>
-      {subtitle &&
-      <h5 className={cx('sui-SectionBasic-subtitle', `sui-SectionBasic-subtitle--${subtitleAlign}`)}>{subtitle}</h5>}
-    </div>
-    <div className='sui-SectionBasic-content'>
-      {textContent && <p className='sui-SectionBasic-contentOnlyText'>{textContent}</p>}
-      {children}
-    </div>
-    {lineSeparator && <hr className='sui-SectionBasic-lineSeparator' />}
-  </section>
-)
+const getSpacingClassName = modifier => `${CLASS}-bottomSpacing--${modifier}`
+
+const SectionBasic = ({ children, contentBottomSpacing, headerBottomSpacing, sectionBottomSpacing, separator, textContent, title }) => {
+  return (
+    <section className={cx(CLASS, getSpacingClassName(sectionBottomSpacing))}>
+      { title &&
+        <header className={cx(`${CLASS}-header`, getSpacingClassName(headerBottomSpacing))}>
+          <h3 className={`${CLASS}-title`}>{ title }</h3>
+        </header>
+      }
+      <div className={cx(`${CLASS}-content`, { [getSpacingClassName(contentBottomSpacing)]: separator })}>
+        { textContent
+          ? <p className={`${CLASS}-textContent`}>{ textContent }</p>
+          : children }
+      </div>
+      { separator &&
+        <hr className={`${CLASS}-separator`} />
+      }
+    </section>
+  )
+}
 
 SectionBasic.displayName = 'SectionBasic'
 
 SectionBasic.propTypes = {
-  /**
-   * HTML Node to include as component's children. Can be a single HTML element, a plain text, or an array of them.
-   */
   children: PropTypes.node,
   /**
-   * CSS className to apply to Section Basic container.
+   * Flag to include an "hr" line separator element at the bottom of the section (default to false).
    */
-  className: PropTypes.string,
+  separator: PropTypes.bool,
   /**
-   * If true, include an "hr" separator element at the bottom of the section.
-   */
-  lineSeparator: PropTypes.bool,
-  /**
-   * Text to be displayed as subtitle at the top of the Section (below section's main title).
-   */
-  subtitle: PropTypes.string,
-  /**
-   * Text alignment of Section's subtitle.
-   */
-  subtitleAlign: PropTypes.oneOf(SECTION_TITLE_ALIGNMENTS),
-  /**
-   * If the content of the Section will be pure text, it can be specified through this option and will be added directly
-   * in the component wrapped by a HTML paragraph element.
+   * Specifies that content of the section will be only the provided text, ignoring children and wrapping textContent in a paragraph.
    */
   textContent: PropTypes.string,
   /**
@@ -52,15 +45,27 @@ SectionBasic.propTypes = {
    */
   title: PropTypes.string,
   /**
-   * Text alignment of Section's title.
+   * Allows customisation of the bottom margin to add to the section's element.
    */
-  titleAlign: PropTypes.oneOf(SECTION_TITLE_ALIGNMENTS)
+  sectionBottomSpacing: PropTypes.oneOf(AVAILABLE_SPACINGS),
+  /**
+   * Allows customisation of the bottom margin to add to the section's header element.
+   */
+  headerBottomSpacing: PropTypes.oneOf(AVAILABLE_SPACINGS),
+  /**
+   * Allows customisation of the bottom margin to add to the section's content element (between content and line separator).
+   */
+  contentBottomSpacing: PropTypes.oneOf(AVAILABLE_SPACINGS)
 }
 
 SectionBasic.defaultProps = {
-  lineSeparator: true,
-  subtitleAlign: 'right',
-  titleAlign: 'left'
+  contentBottomSpacing: SPACING.LARGE,
+  headerBottomSpacing: SPACING.LARGE,
+  sectionBottomSpacing: SPACING.NONE,
+  separator: false
 }
 
 export default SectionBasic
+export {
+  SPACING as sectionBasicBottomSpacing
+}

--- a/components/section/basic/src/index.js
+++ b/components/section/basic/src/index.js
@@ -45,15 +45,15 @@ SectionBasic.propTypes = {
    */
   title: PropTypes.string,
   /**
-   * Allows customisation of the bottom margin to add to the section's element.
+   * Allows customisation of the bottom margin to add to the main section HTML element (margin bottom of component).
    */
   sectionBottomSpacing: PropTypes.oneOf(AVAILABLE_SPACINGS),
   /**
-   * Allows customisation of the bottom margin to add to the section's header element.
+   * Allows customisation of the bottom margin to add to the section's header element (space between header and content).
    */
   headerBottomSpacing: PropTypes.oneOf(AVAILABLE_SPACINGS),
   /**
-   * Allows customisation of the bottom margin to add to the section's content element (between content and line separator).
+   * Allows customisation of the bottom margin to add to the section's content element (space between content and separator line).
    */
   contentBottomSpacing: PropTypes.oneOf(AVAILABLE_SPACINGS)
 }

--- a/components/section/basic/src/index.scss
+++ b/components/section/basic/src/index.scss
@@ -1,58 +1,36 @@
-@import '~@schibstedspain/sui-theme/lib/settings-compat-v7/index';
 @import '~@schibstedspain/sui-theme/lib/index';
-
-@mixin section-title-text-alignments {
-  width: 100%;
-
-  &--left {
-    text-align: left;
-  }
-
-  &--center {
-    text-align: center;
-  }
-
-  &--right {
-    text-align: right;
-  }
-}
+@import './settings';
 
 .sui-SectionBasic {
-  margin-bottom: $mb-section-basic;
-
-  &-header {
-    margin-bottom: $mb-section-basic-header;
-  }
-
   &-title {
-    @include section-title-text-alignments;
-
-    color: $c-section-basic-main-title;
+    color: $c-section-basic-title;
     font-size: $fz-section-basic-title;
-    font-weight: $fw-regular;
-    margin: 0 0 $m-v;
+    font-weight: $fw-section-basic-title;
+    line-height: $lh-section-basic-title;
+    margin: 0;
+    text-align: $ta-section-basic-title;
   }
 
-  &-subtitle {
-    @include section-title-text-alignments;
-
-    color: $c-section-basic-subtitle;
-    font-size: $fz-section-basic-subtitle;
-    font-weight: $fw-regular;
-    margin: 0 0 $m-v-small;
+  &-textContent {
+    color: $c-section-basic-text-content;
+    font-size: $fz-section-basic-text-content;
+    font-weight: $fw-section-basic-text-content;
+    line-height: $lh-section-basic-text-content;
+    margin: 0;
+    text-align: $ta-section-basic-text-content;
   }
 
-  &-contentOnlyText {
-    color: $c-section-basic-content-text-paragraph;
-    font-size: $fz-section-basic-content-text-paragraph;
-    font-weight: $fw-regular;
-    line-height: $lh-section-basic-paragraph;
-    margin: $m-v-section-basic-content-text-paragraph 0;
-  }
-
-  &-lineSeparator {
-    border: $bd-section-basic-line-separator;
+  &-separator {
+    border: $bd-section-basic-hr-separator;
     height: 0;
     width: 100%;
+  }
+
+  &-bottomSpacing {
+    @each $name, $value in $bottom-spacings-section-basic {
+      &--#{$name} {
+        margin-bottom: $value;
+      }
+    }
   }
 }

--- a/demo/section/basic/playground
+++ b/demo/section/basic/playground
@@ -1,21 +1,42 @@
+const sampleText = 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum.'
+const sampleText2 = 'Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue velit cursus nunc, quis gravida magna mi a libero. Fusce vulputate eleifend sapien. Vestibulum purus quam, scelerisque ut, mollis sed, nonummy id, metus. Nullam accumsan lorem in dui. Cras ultricies mi eu turpis hendrerit fringilla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; In ac dui quis mi consectetuer lacinia. Nam pretium turpis et arcu. Duis arcu tortor, suscipit eget, imperdiet nec, imperdiet iaculis, ipsum. Sed aliquam ultrices mauris. Integer ante arcu, accumsan a, consectetuer eget, posuere ut, mauris. Praesent adipiscing. Phasellus ullamcorper ipsum rutrum nunc. Nunc nonummy metus. Vestibulum volutpat pretium libero. Cras id dui. Aenean ut eros et nisl sagittis vestibulum. Nullam nulla eros, ultricies sit amet, nonummy id, imperdiet feugiat, pede. Sed lectus. Donec mollis hendrerit risus. Phasellus nec sem in justo pellentesque facilisis. Etiam imperdiet imperdiet orci. Nunc nec neque. Phasellus leo dolor, tempus non, auctor et, hendrerit quis, nisi. Curabitur ligula sapien, tincidunt non, euismod vitae, posuere imperdiet, leo. Maecenas malesuada. Praesent congue erat at massa. Sed cursus turpis vitae tortor. Donec posuere vulputate arcu. Phasellus accumsan cursus velit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae;'
+const sampleText3 = 'Sed aliquam, nisi quis porttitor congue, elit erat euismod orci, ac placerat dolor lectus quis orci. Phasellus consectetuer vestibulum elit. Aenean tellus metus, bibendum sed, posuere ac, mattis non, nunc. Vestibulum fringilla pede sit amet augue. In turpis. Pellentesque posuere. Praesent turpis. Aenean posuere, tortor sed cursus feugiat, nunc augue blandit nunc, eu sollicitudin urna dolor sagittis lacus. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Nullam sagittis. Suspendisse pulvinar, augue ac venenatis condimentum, sem libero volutpat nibh, nec pellentesque velit pede quis nunc. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce id purus. Ut varius tincidunt libero. Phasellus dolor. Maecenas vestibulum mollis diam. Pellentesque ut neque. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. In dui magna, posuere eget, vestibulum et, tempor auctor, justo. In ac felis quis tortor malesuada pretium. Pellentesque auctor neque nec urna. Proin sapien ipsum, porta a, auctor quis, euismod ut, mi. Aenean viverra rhoncus pede. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Ut non enim eleifend felis pretium feugiat. Vivamus quis mi. Phasellus a est. Phasellus magna. In hac habitasse platea dictumst. Curabitur at lacus ac velit ornare lobortis. Curabitur a felis in nunc fringilla tristique. Morbi mattis ullamcorper velit. Phasellus gravida semper nisi. Nullam vel sem. Pellentesque libero tortor, tincidunt et, tincidunt eget, semper nec, quam. Sed hendrerit. Morbi ac felis. Nunc egestas, augue at pellentesque laoreet, felis eros vehicula leo, at malesuada velit leo quis pede. Donec interdum, metus et hendrerit aliquet, dolor diam sagittis ligula, eget egestas libero turpis vel mi. Nunc nulla. Fusce risus nisl, viverra et, tempor et, pretium in, sapien. Donec venenatis vulputate lorem. Morbi nec metus. Phasellus blandit leo ut odio. Maecenas ullamcorper, dui et placerat feugiat, eros pede varius nisi, condimentum viverra felis nunc et lorem. Sed magna purus, fermentum eu, tincidunt eu, varius ut, felis. In auctor lobortis lacus. Quisque libero metus, condimentum nec, tempor a, commodo mollis, magna. Vestibulum ullamcorper mauris at ligula. Fusce fermentum. Nullam cursus lacinia erat. Praesent blandit laoreet nibh. Fusce convallis metus id felis luctus adipiscing. Pellentesque egestas, neque sit amet convallis pulvinar, justo nulla eleifend augue, ac auctor orci leo non est. Quisque id mi. Ut tincidunt tincidunt erat. Etiam feugiat lorem non metus. Vestibulum dapibus nunc ac augue. Curabitur vestibulum aliquam leo. Praesent egestas neque eu enim. In hac habitasse platea dictumst. Fusce a quam. Etiam ut purus mattis mauris sodales aliquam. Curabitur nisi. Quisque malesuada placerat nisl. Nam ipsum risus, rutrum vitae, vestibulum eu, molestie vel, lacus. Sed augue ipsum, egestas nec, vestibulum et, malesuada adipiscing, dui. Vestibulum facilisis, purus nec pulvinar iaculis, ligula mi congue nunc, vitae euismod ligula urna in dolor. Mauris sollicitudin fermentum libero.'
+
+const sampleImage = { src: 'https://picsum.photos/160/160/?random' }
+const sampleImage2 = { src: 'https://picsum.photos/600/200/?random', style: { maxWidth: '100%', alignSelf: 'center' } }
+const sampleImage3 = { src: 'https://picsum.photos/1400/90/?random' }
+
+const sectionWithContentImage = { title: 'Image', sectionBottomSpacing: sectionBasicBottomSpacing.GIANT }
+const sectionWithContentOnlyText = { title: 'Sample text', textContent: sampleText, sectionBottomSpacing: sectionBasicBottomSpacing.GIANT }
+const sectionWithNoTitle = { textContent: sampleText2, contentBottomSpacing: 'medium', sectionBottomSpacing: sectionBasicBottomSpacing.XLARGE }
+const sectionWithMixedContent = { title: 'Multiple content as children', headerBottomSpacing: sectionBasicBottomSpacing.GIANT, contentBottomSpacing: sectionBasicBottomSpacing.SMALL, sectionBottomSpacing: sectionBasicBottomSpacing.LARGE }
+const sectionWithMap = { title: 'Iframe with map', sectionBottomSpacing: sectionBasicBottomSpacing.MEDIUM }
+
 return (
-    <div>
-        <SectionBasic
-            title='Descripci&oacute;n'
-            subtitle='Descargar Memoria de Calidades'
-            textContent='Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus.' />
-
-        <SectionBasic
-            title='Equipamientos comunidad'
-            textContent='Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus.'>
-            <img src="https://irp-cdn.multiscreensite.com/dd482778/dms3rep/multi/desktop/sundollar-pools-imgslider-6-1350x598.jpg" height="299" width="625" />
+  <div style={{ backgroundColor: '#ffffff' }}>
+    <div style={{ display: 'flex' }}>
+      <div style={{ flex: 1 }}>
+        <SectionBasic {...sectionWithContentImage}>
+          <img {...sampleImage} style={{ paddingRight: 16 }} />
         </SectionBasic>
-
-        <SectionBasic
-            title='Ubicaci&oacute;n'
-            subtitle='Pla&ccedil;a de Xavier Cugat, 2, 08174 Sant Cugat del Vall&egrave;s, Barcelona'
-            subtitleAlign='left'>
-            <iframe style={{width: '100%', minHeight: 500}} src="https://wego.here.com/?map=41.49434,2.08047,15,normal"></iframe>
-        </SectionBasic>
+      </div>
+      <div style={{ flex: 4 }}>
+        <SectionBasic {...sectionWithContentOnlyText} />
+      </div>
     </div>
+
+    <SectionBasic {...sectionWithNoTitle} separator />
+
+    <SectionBasic {...sectionWithMixedContent} separator>
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <img {...sampleImage2} />
+        <strong style={{ fontSize: 18, margin: '48px 0' }}>{ sampleText3 }</strong>
+        <img {...sampleImage3} />
+      </div>
+    </SectionBasic>
+
+    <SectionBasic {...sectionWithMap}>
+      <iframe style={{width: '100%', minHeight: 300, border: 'none' }} src="https://wego.here.com/?map=41.49434,2.08047,15,normal" />
+    </SectionBasic>
+  </div>
 )


### PR DESCRIPTION
The `sui-section-basic` component has been changed to remove some unnecessary properties, and to add new ones in order to allow a better customisation of the vertical spacing between the inner elements of the section:
- The props `title` and  `textContent` have been preserved and they keep the behaviour they had before.
- The prop `lineSeparator` has been renamed to `separator`, with a default value 'false'.
- As we needed to have customisable vertical spacing between Section's header and content, content and separator line, and section with its next sibling element, there are 3 new properties added to achieve this: `sectionBottomSpacing`, `headerBottomSpacing` and `contentBottomSpacing`.
The available vertical spacings have been defined as follows: 
```
const SPACING = {
  NONE: 'none',     // 0px
  SMALL: 'small',   // 8px
  MEDIUM: 'medium', // 16px
  LARGE: 'large',   // 24px
  XLARGE: 'xlarge', // 32px
  GIANT: 'giant'    // 48px
}
```
and exported as `sectionBasicBottomSpacing`.

**A new major version of this component will be generated.**