### PR TITLE
feat(list/image): simplify image gutter customisation, improve gradient…

### DIFF
--- a/components/list/image/src/_settings.scss
+++ b/components/list/image/src/_settings.scss
@@ -1,9 +1,20 @@
+
+// List Image item
+$bgc-list-image-item: $c-gray-lightest !default;
+
+// List image item size and gutter for small/medium screens (mobile, tablet)
+$gutter-list-image: $m-l !default;
+$sz-list-image-item: 50% !default;
+$mb-list-image-item: $gutter-list-image !default;
+$fxb-list-image-item: calc(#{$sz-list-image-item} - #{$mb-list-image-item / 2}) !default;
+
+// List image item size and gutter for large screens (desktop)
+$gutter-list-image-desktop: $m-l !default;
+$mb-list-image-item-desktop: $gutter-list-image-desktop !default;
+$ml-list-image-item-desktop: $gutter-list-image-desktop !default;
 $fxb-list-image-item-desktop: 196px !default;
-$fxb-list-image-item-mobile: 50% !default;
-$m-v-list-image-item-full-gutter: $m-l !default;
-$m-h-list-image-item-full-gutter: $m-l !default;
-$bg-list-image-last-item: $c-gray-dark !default;
-$op-list-image-last-item: .65 !default;
-$m-h-list-image-item-half-gutter: ceil($m-h-list-image-item-full-gutter / 2) !default;
-$m-v-list-image-item-half-gutter: ceil($m-v-list-image-item-full-gutter / 2) !default;
-$m-h-list-image-item-breakpoint-l-gutter: $m-h-list-image-item-half-gutter !default;
+
+// More items box gradient and label
+$c-list-image-more-items-box-label: $c-white !default;
+$bgc-list-image-more-items-box-gradient: $c-black !default;
+$op-list-image-more-items-box-gradient: .65 !default;

--- a/components/list/image/src/index.scss
+++ b/components/list/image/src/index.scss
@@ -1,58 +1,62 @@
 @import '~@schibstedspain/sui-theme/lib/index';
 @import '~@schibstedspain/sui-image-lazy-load/lib/index';
-@import 'settings';
+@import './settings';
 
 .sui-ListImage {
   @include sui-list('custom');
-  @include media-breakpoint-only(xl) {
-    margin: -($m-v-list-image-item-half-gutter);
+  @include media-breakpoint-up(l) {
+    justify-content: flex-start;
+    margin-left: -($ml-list-image-item-desktop);
   }
-  @include media-breakpoint-only(l) {
-    margin: (-($m-v-list-image-item-half-gutter)) (-($m-h-list-image-item-breakpoint-l-gutter));
-  }
-  @include media-breakpoint-down(m) {
-    justify-content: space-between;
-  }
+
   flex-wrap: wrap;
+  justify-content: space-between;
 
   &-item {
-    @include media-breakpoint-only(xl) {
-      margin: $m-v-list-image-item-half-gutter;
+    @include media-breakpoint-up(l) {
+      flex-basis: $fxb-list-image-item-desktop;
+      margin-bottom: $mb-list-image-item-desktop;
+      margin-left: $ml-list-image-item-desktop;
     }
-    @include media-breakpoint-only(l) {
-      margin: $m-v-list-image-item-half-gutter $m-h-list-image-item-breakpoint-l-gutter;
-    }
-    @include media-breakpoint-down(m) {
-      flex-basis: calc(#{$fxb-list-image-item-mobile} - #{$m-h-list-image-item-half-gutter});
-      margin-bottom: $m-v-list-image-item-full-gutter;
-    }
+
+    background-color: $bgc-list-image-item;
     cursor: pointer;
-    flex-basis: $fxb-list-image-item-desktop;
+    flex-basis: $fxb-list-image-item;
+    flex-grow: 0;
+    flex-shrink: 0;
+    margin-bottom: $mb-list-image-item;
     overflow: hidden;
   }
 
   &-lastItemContainer {
     position: relative;
+
+    &::after {
+      background-color: $bgc-list-image-more-items-box-gradient;
+      content: '';
+      height: 100%;
+      left: 0;
+      opacity: $op-list-image-more-items-box-gradient;
+      position: absolute;
+      top: 0;
+      width: 100%;
+    }
   }
 
   &-moreItemsBox {
     align-items: center;
-    background: $bg-list-image-last-item;
-    cursor: pointer;
     display: flex;
     height: 100%;
+    justify-content: center;
     left: 0;
-    margin: 0;
-    opacity: $op-list-image-last-item;
     position: absolute;
     top: 0;
     width: 100%;
+    z-index: 1;
 
     &Label {
-      color: $c-white;
-      padding: 0 $p-h;
+      color: $c-list-image-more-items-box-label;
       text-align: center;
-      width: 100%;
     }
   }
 }

--- a/demo/list/image/playground
+++ b/demo/list/image/playground
@@ -1,46 +1,29 @@
-const imagesList = [
-     {
-         src: 'https://d.fotocasa.es/promotion/2016/09/16/19245163/1582800.jpg/504x504/a_fill',
-         onClick: () => {alert('Image 1 clicked!')}
-     },
-     {
-         src: 'https://d.fotocasa.es/promotion/2016/09/16/19245163/1582802.jpg/504x504/a_fill',
-         onClick: () => {alert('Image 2 clicked!')}
-     },
-     {
-         src: 'https://d.fotocasa.es/promotion/2016/09/16/19245163/1582806.jpg/504x504/a_fill',
-         onClick: () => {alert('Image 3 clicked!')}
-     },
-     {
-         src: 'https://d.fotocasa.es/promotion/2016/09/16/19245163/1582809.jpg/504x504/a_fill',
-         onClick: () => {alert('Image 4 clicked!')}
-     },
-     {
-         src: 'https://d.fotocasa.es/promotion/2016/09/16/19245163/1582798.jpg/504x504/a_fill',
-         onClick: () => {alert('Image 5 clicked!')}
-     },
-     {
-         src: 'https://d.fotocasa.es/promotion/2016/09/16/19245163/1582803.jpg/504x504/a_fill',
-         onClick: () => {alert('Image 6 clicked!')}
-     },
-     {
-         src: 'https://d.fotocasa.es/promotion/2016/09/16/19245163/1582797.jpg/504x504/a_fill',
-         onClick: () => {alert('Image 7 clicked!')}
-     },
-     {
-         src: 'https://d.fotocasa.es/promotion/2016/09/16/19245163/1582807.jpg/504x504/a_fill',
-         onClick: () => {alert('Image 8 clicked!')}
-     }
- ]
+const imageBaseUrl = 'http://lorempicsum.com/futurama/320/320/'
+const buildClickHandler = index => () => { alert('Image ' + index + ' clicked!!') }
+
+const imagesList = [...Array(10).keys()].map(index => ({
+  src: imageBaseUrl + (index + 1),
+  onClick: buildClickHandler(index + 1)
+}))
+
+const containerStyles = {
+  style: {
+    width: '100%',
+    backgroundColor: 'white'
+  }
+}
 
 return (
-    <div style={{width: '100%', background: '#fff'}}>
-        <ListImage
-            images={ imagesList }
-            moreItemsBox={{
-                label: 'Ver las 35 imagenes en pantalla completa',
-                onClick: () => { alert('Last item clicked!') }
-            }}
-        maxItems={ 6 } />
-    </div>
+  <div {...containerStyles}>
+    <ListImage
+      images={imagesList}
+      moreItemsBox={{
+        label: 'Custom label to notify there are more items...',
+        onClick: () => {
+          alert('Last item clicked!!')
+        }
+      }}
+      maxItems={8}
+    />
+  </div>
 )


### PR DESCRIPTION
…over last item.

- Calculation of the gutter between images was a bit messy and did not work correctly when changing its container's size. So, in this PR we are simplifying the required vars to set up the gutter and the sizes of each image item.

- The last item that should display a gradient with a text label (only when there are more images available than the prop `maxItems` provided) was not styled according to designs, so we are fixing this issue creating the gradient now in the pseudo element after.
