### PR TITLE
feat(section/basic): no margins for "hr" section line separator.

### DIFF
--- a/components/section/basic/src/index.scss
+++ b/components/section/basic/src/index.scss
@@ -23,6 +23,7 @@
   &-separator {
     border: $bd-section-basic-hr-separator;
     height: 0;
+    margin: 0;
     width: 100%;
   }
 


### PR DESCRIPTION
By default, the "hr" element is getting a margin style of `0.5em`.
We should avoid it, since the spacing between elements within the section component are already handled by its own allowed properties.