### PR TITLE
feat(list/image): allow customising more items box text styles.

### DIFF
--- a/components/list/image/src/_settings.scss
+++ b/components/list/image/src/_settings.scss
@@ -16,5 +16,8 @@ $fxb-list-image-item-desktop: 196px !default;
 
 // More items box gradient and label
 $c-list-image-more-items-box-label: $c-white !default;
+$fz-list-image-more-items-box-label: $fz-s !default;
+$fw-list-image-more-items-box-label: $fw-regular !default;
+$lh-list-image-more-items-box-label: $lh-s !default;
 $bgc-list-image-more-items-box-gradient: $c-black !default;
 $op-list-image-more-items-box-gradient: .65 !default;

--- a/components/list/image/src/index.scss
+++ b/components/list/image/src/index.scss
@@ -29,6 +29,7 @@
   }
 
   &-lastItemContainer {
+    height: 100%;
     position: relative;
 
     &::after {
@@ -56,6 +57,10 @@
 
     &Label {
       color: $c-list-image-more-items-box-label;
+      font-size: $fz-list-image-more-items-box-label;
+      font-wieght: $fw-list-image-more-items-box-label;
+      line-height: $lh-list-image-more-items-box-label;
+      padding: $p-m;
       text-align: center;
     }
   }

--- a/components/list/image/src/index.scss
+++ b/components/list/image/src/index.scss
@@ -58,7 +58,7 @@
     &Label {
       color: $c-list-image-more-items-box-label;
       font-size: $fz-list-image-more-items-box-label;
-      font-wieght: $fw-list-image-more-items-box-label;
+      font-weight: $fw-list-image-more-items-box-label;
       line-height: $lh-list-image-more-items-box-label;
       padding: $p-m;
       text-align: center;


### PR DESCRIPTION
Additionally, let last item container grows its height to 100% to avoid that the :after content is not displayed when an image url is broken.