### PR TITLE
feat(form/checkbox): use flexbox style to align checkbox label when t…

### DIFF
--- a/components/form/checkbox/src/index.scss
+++ b/components/form/checkbox/src/index.scss
@@ -1,16 +1,18 @@
-// sass-lint:disable no-important
-@import '~@schibstedspain/sui-theme/lib/settings-compat-v7/index';
 @import '~@schibstedspain/sui-theme/lib/index';
 
 $c-form-checkbox-icon: $c-primary !default;
 $c-form-checkbox-text-label: $c-gray-dark !default;
-$fz-form-checkbox-text-label: $fz-m !default;
+$fz-form-checkbox-text-label: $fz-s !default;
 $fw-form-checkbox-text-label: $fw-regular !default;
 $c-form-checkbox-error-message: $c-error !default;
-$fz-form-checkbox-error-message: $fz-m !default;
+$fz-form-checkbox-error-message: $fz-s !default;
 $fw-form-checkbox-error-message: $fw-regular !default;
 
 .sui-FormCheckbox {
+  &-container {
+    display: flex;
+  }
+
   &-input {
     display: none;
   }
@@ -18,7 +20,8 @@ $fw-form-checkbox-error-message: $fw-regular !default;
   &-icon {
     @include sui-icon--small;
     cursor: pointer;
-    fill: $c-form-checkbox-icon !important;
+    fill: $c-form-checkbox-icon !important; // sass-lint:disable-line no-important
+    flex: 0 0 auto;
   }
 
   &-label {

--- a/demo/form/checkbox/playground
+++ b/demo/form/checkbox/playground
@@ -37,6 +37,6 @@ return (
     <br />
     <FormCheckbox name='cb-unchecked' label='This checkbox is unchecked' onChange={doNothing} />
     <br />
-    <FormCheckbox name='cb-error' label='This checkbox display an error message below.' errorMessage='This is an error message.' onChange={doNothing} />
+    <FormCheckbox name='cb-error' label='This checkbox display an error message below. And the content of the text label should be displayed in multiple lines, all of them aligned to the left of the text label box.' errorMessage='This is an error message.' onChange={doNothing} />
   </div>
 )


### PR DESCRIPTION
…ext is multiline.

- When the text label of the checkbox is long enough to require displaying it multiline, the alignment is wrong and the text is shown below the check box:

![checkbox_screenshot](https://user-images.githubusercontent.com/3775593/38805208-4fa5c4d2-4175-11e8-87a6-ed0ba4ce82ee.png)
(Now, we are applying flexbox styles to ensure the alignment is always kept.)

- Additionally, the `settings-compat-v7` import has been removed and default sass vars have been adjusted.