### PR TITLE
fix(atom/button): remove warning and avoid sending a boolean to the attribute

### DIFF
--- a/components/atom/button/src/index.js
+++ b/components/atom/button/src/index.js
@@ -59,7 +59,7 @@ const AtomButton = (props) => {
 
   const Button = ({ children, href, target, disabled, ...attrs }) => link
     ? (
-      <Link {...attrs} href={href} target={target} rel={target === '_blank' && 'noopener'}>
+      <Link {...attrs} href={href} target={target} rel={target === '_blank' ? 'noopener' : undefined}>
         {children}
       </Link>
     ) : <button {...attrs} disabled={disabled}>{children}</button>


### PR DESCRIPTION
Remove this warning as we're sending a boolean to the attribute:
![image](https://user-images.githubusercontent.com/1561955/39992086-ee21f2d6-5771-11e8-8599-7dada1fadc17.png)
