### PR TITLE
fix(atom/button): fix fullWidth link type button text is not centered

### DIFF
--- a/components/atom/button/src/index.scss
+++ b/components/atom/button/src/index.scss
@@ -175,6 +175,7 @@ $p-atom-button-large: $p-l !default;
 
   &--fullWidth {
     justify-content: center;
+    text-align: center;
     width: 100%;
   }
 
@@ -185,7 +186,6 @@ $p-atom-button-large: $p-l !default;
     }
   }
 
-  // Modifiers
   &--link {
     text-decoration: none;
   }

--- a/demo/atom/button/playground
+++ b/demo/atom/button/playground
@@ -122,6 +122,7 @@ return (<div>
   <p><Button link title='button link' href='http://www.google.com' type='accent' className='customClass' disabled>Button link disabled</Button></p>
   <p><Button link size='small' title='button link' href='http://www.google.com' type='primary' className='customClass'>Button link small</Button></p>
   <p><Button link leftIcon={Icon} size='small' title='button link'>Button link</Button></p>
+  <p><Button link fullWidth leftIcon={Icon} size='small' title='button link'>Button link fullWidth</Button></p>
 </div>)
 
 function getStarIcon () { return  (<svg className='sui-Icon' viewBox="0 0 24 24">


### PR DESCRIPTION
- [x] Force to text-align center the button in order to fix the problem that the text is not aligned when the type of the button is a link.

Before fix:
![image](https://user-images.githubusercontent.com/1561955/40065935-3c550d20-5863-11e8-81ff-647b309e6b57.png)

After fix:
![image](https://user-images.githubusercontent.com/1561955/40065956-4671a2f0-5863-11e8-9315-a27791fb3b97.png)
