### PR TITLE
fix(molecule/notification): write correct name for the sui-component

### DIFF
--- a/components/molecule/notification/README.md
+++ b/components/molecule/notification/README.md
@@ -5,14 +5,14 @@
 ## Installation
 
 ```sh
-$ npm install @s-ui/sui-molecule-notification --save
+$ npm install @s-ui/react-molecule-notification --save
 ```
 
 ## Usage
 
 ### Basic usage
 ```js
-import MoleculeNotification from '@s-ui/sui-molecule-notification'
+import MoleculeNotification from '@s-ui/react-molecule-notification'
 
 // sui-atom-button
 const BUTTONS = [
@@ -29,11 +29,11 @@ const BUTTONS = [
 ]
 
 return (
-  <MoleculeNotification 
+  <MoleculeNotification
     text='Lorem fistrum'
     type='success',
     autoclose='short'
-    buttons={BUTTONS} 
+    buttons={BUTTONS}
   />
 )
 ```

--- a/components/molecule/notification/package.json
+++ b/components/molecule/notification/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@s-ui/sui-molecule-notification",
+  "name": "@s-ui/react-molecule-notification",
   "version": "1.2.0",
   "description": "",
   "main": "lib/index.js",


### PR DESCRIPTION
Use correct name for the package of this component.

Before:
`@s-ui/sui-molecule-notification`

After:
`npm install @s-ui/react-molecule-notification`

