### PR TITLE
fix(atom/switch): removed not needed binding

### DIFF
--- a/components/atom/switch/src/index.js
+++ b/components/atom/switch/src/index.js
@@ -25,7 +25,6 @@ class AtomSwitch extends Component {
   constructor (props) {
     super(props)
 
-    this.keyBindings.bind(this)
     this.executeIfEnabledFocusSwitch = this.executeIfEnabled(this.focusSwitch)
     this.executeIfEnabledFocusOutSwitch = this.executeIfEnabled(this.focusOutSwitch)
     this.executeIfEnabledToggleSwitch = this.executeIfEnabled(this.toggleSwitch)


### PR DESCRIPTION
Not needed as the function is being bind with arrow fn