### PR TITLE
fix(atom/button): disallow overwrite generic hover effect for button link

### DIFF
--- a/components/atom/button/src/index.scss
+++ b/components/atom/button/src/index.scss
@@ -188,5 +188,9 @@ $p-atom-button-large: $p-l !default;
 
   &--link {
     text-decoration: none;
+
+    &:hover {
+      text-decoration: none;
+    }
   }
 }

--- a/components/atom/button/src/index.scss
+++ b/components/atom/button/src/index.scss
@@ -187,8 +187,7 @@ $p-atom-button-large: $p-l !default;
   }
 
   &--link {
-    text-decoration: none;
-
+    &,
     &:hover {
       text-decoration: none;
     }


### PR DESCRIPTION
Overwrite the text-decoration of the hovered button of type link so a generic styling doesn't affect it and change it behaviour as a lot of websites has the `a:hover { text-decoration: underline }`.

Example of wrong behaviour without this style:
![image](https://user-images.githubusercontent.com/1561955/40660878-914ad70c-6352-11e8-96ae-fb97d56d0bf5.png)
