### PR TITLE
feat(script/criteo): use number as a customerId proptype

### DIFF
--- a/components/script/criteo/src/index.js
+++ b/components/script/criteo/src/index.js
@@ -49,7 +49,7 @@ ScriptCriteo.displayName = 'ScriptCriteo'
 ScriptCriteo.propTypes = {
   accountIds: PropTypes.array.isRequired,
   siteType: PropTypes.oneOf(['d', 'm', 't']).isRequired,
-  customerId: PropTypes.string,
+  customerId: PropTypes.number,
   email: PropTypes.string,
   hashedEmail: PropTypes.string,
   pageEvent: PropTypes.object


### PR DESCRIPTION
Use number as a customerId propType in order to fix a validation warning.