### PR TITLE
fix(services/markdown): make it compatible with dev and built version

### DIFF
--- a/components/services/markdown/src/index.js
+++ b/components/services/markdown/src/index.js
@@ -7,7 +7,8 @@ class ServiceMarkdown extends Component {
   state = {html: ''}
 
   async componentDidMount() {
-    const marked = await import('marked')
+    const markedLibrary = await import('marked')
+    const marked = markedLibrary.default || markedLibrary
     const req = new window.XMLHttpRequest()
     req.open('GET', this.props.src, false)
     req.send(null)


### PR DESCRIPTION
Make it work in dev and where the built version of the component is used.

It seems that while Webpack is fine using this import, babel is transforming it to a code where it needs access the property default. Maybe is because how is the third party library made (UMD) but this fixes the problem.