### PR TITLE
Fixes the problem with server side rendering

### DIFF
--- a/components/services/markdown/src/index.js
+++ b/components/services/markdown/src/index.js
@@ -7,14 +7,20 @@ class ServiceMarkdown extends Component {
   state = {html: ''}
 
   async componentDidMount() {
-    const markedLibrary = await import('marked')
-    const marked = markedLibrary.default || markedLibrary
-    const req = new window.XMLHttpRequest()
-    req.open('GET', this.props.src, false)
-    req.send(null)
-    if (req.status === STATUS_OK) {
-      this.setState({html: marked(req.responseText)})
-    }
+    require.ensure(
+      [],
+      require => {
+        const markedLibrary = require('marked')
+        const marked = markedLibrary.default || markedLibrary
+        const req = new window.XMLHttpRequest()
+        req.open('GET', this.props.src, false)
+        req.send(null)
+        if (req.status === STATUS_OK) {
+          this.setState({html: marked(req.responseText)})
+        }
+      },
+      'marked'
+    )
   }
 
   render() {


### PR DESCRIPTION
We're not transpiling correctly with babel dynamic imports and thus the server side rendering is broken, as it doesn't understand the import keyword. It's working in node 10 but not in node 6 (being used in FC).

Moving to the ugly require.ensure until we get a fix for this.

```
[nodemon] 1.17.5
[nodemon] to restart at any time, enter `rs`
[nodemon] watching: *.*
[nodemon] starting `node server/index.js`
(node:51902) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): SyntaxError: Unexpected token import
```