### PR TITLE
Fix/make the atom switch great again

### DIFF
--- a/components/atom/switch/README.md
+++ b/components/atom/switch/README.md
@@ -3,10 +3,10 @@
 > Description
 
 The switch is the radio button when there’re only 2 exclusive options. “On/off” is a common and clear example for explaining this component.
-In order to collect the result of this switch there is a callback `onToggle`, this callback receives a flag on true if
-select is active.
 
-There are several types and sizes for this component.
+In order to collect the result of this switch there is a callback `onToggle`, this callback receives a flag on `true` if select is active. If you're using a `select` type of this component, `false` means the first option and `true` the second one.
+
+There are several two sizes for this component: `default` and `large`.
 
 ## Installation
 
@@ -22,6 +22,7 @@ import AtomSwitch from '@s-ui/react-atom-switch'
 
 return (
   <AtomSwitch
+    initialValue={false}
     size='default'
     type='toggle'
     disabled={false}
@@ -29,7 +30,7 @@ return (
     labelLeft='Off'
     labelRight='On'
     labelOptionalText='Optional label'
-    onToggle={customCallback}
+    onToggle={flag => console.log(`Switch value is ${flag}`)}
   />
 )
 ```

--- a/components/atom/switch/src/SwitchType/single.js
+++ b/components/atom/switch/src/SwitchType/single.js
@@ -5,17 +5,18 @@ import {prefixClass, workClassNames} from './helpers'
 import PropTypes from 'prop-types'
 
 export const SingleSwitchTypeRender = ({
-  name,
+  disabled,
+  isFocus,
+  isToggle,
   label,
   labelOptionalText,
+  name,
+  onBlur,
+  onFocus,
+  onKeyDown,
   size,
-  type,
-  disabled,
-  isToggle,
-  isFocus,
-  focusSwitchCallback,
-  blurSwitchCallback,
-  toggleSwitchCallback
+  onToggle,
+  type
 }) => {
   return (
     <div
@@ -27,13 +28,14 @@ export const SingleSwitchTypeRender = ({
         isFocus,
         disabled
       )}
-      onClick={toggleSwitchCallback}
+      onClick={() => onToggle()}
     >
       <div
         className={prefixClass('container')}
         tabIndex="0"
-        onFocus={focusSwitchCallback}
-        onBlur={blurSwitchCallback}
+        onKeyDown={onKeyDown}
+        onFocus={onFocus}
+        onBlur={onBlur}
       >
         <AtomLabel name={name} text={label} optionalText={labelOptionalText} />
         <div className={prefixClass('inputContainer')}>
@@ -86,13 +88,13 @@ SingleSwitchTypeRender.propTypes = {
   /**
    * Callback on focus element
    */
-  focusSwitchCallback: PropTypes.func,
+  onFocus: PropTypes.func,
   /**
    * Callback on toggle element
    */
-  blurSwitchCallback: PropTypes.func,
+  onBlur: PropTypes.func,
   /**
    * Callback on toggle element
    */
-  toggleSwitchCallback: PropTypes.func
+  onToggle: PropTypes.func
 }

--- a/components/atom/switch/src/SwitchType/single.js
+++ b/components/atom/switch/src/SwitchType/single.js
@@ -96,5 +96,9 @@ SingleSwitchTypeRender.propTypes = {
   /**
    * Callback on toggle element
    */
-  onToggle: PropTypes.func
+  onToggle: PropTypes.func,
+  /**
+   * Callback on keydown on the switch
+   */
+  onKeyDown: PropTypes.func
 }

--- a/components/atom/switch/src/SwitchType/single.js
+++ b/components/atom/switch/src/SwitchType/single.js
@@ -14,8 +14,8 @@ export const SingleSwitchTypeRender = ({
   onBlur,
   onFocus,
   onKeyDown,
-  size,
   onToggle,
+  size,
   type
 }) => {
   return (

--- a/components/atom/switch/src/SwitchType/toggle.js
+++ b/components/atom/switch/src/SwitchType/toggle.js
@@ -5,21 +5,20 @@ import {prefixClass, workClassNames} from './helpers'
 import PropTypes from 'prop-types'
 
 export const ToggleSwitchTypeRender = ({
-  name,
-  label,
-  labelOptionalText,
-  labelLeft,
-  labelRight,
-  size,
-  type,
   disabled,
-  isToggle,
   isFocus,
-  focusSwitchCallback,
-  blurSwitchCallback,
-  toggleSwitchCallback,
-  activateToggleCallback,
-  deactivateToggleCallback
+  isToggle,
+  label,
+  labelLeft,
+  labelOptionalText,
+  labelRight,
+  name,
+  onBlur,
+  onFocus,
+  onKeyDown,
+  onToggle,
+  size,
+  type
 }) => {
   return (
     <div
@@ -36,18 +35,19 @@ export const ToggleSwitchTypeRender = ({
       <div
         className={cx(prefixClass('container'))}
         tabIndex="0"
-        onFocus={focusSwitchCallback}
-        onBlur={blurSwitchCallback}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        onKeyDown={onKeyDown}
       >
         <span
           className={cx(prefixClass('text'), prefixClass('left'))}
-          onClick={deactivateToggleCallback}
+          onClick={() => onToggle(false)}
         >
           {labelLeft}
         </span>
         <div
           className={cx(prefixClass('inputContainer'))}
-          onClick={toggleSwitchCallback}
+          onClick={() => onToggle()}
         >
           <div
             className={cx(prefixClass('circle'), {
@@ -57,7 +57,7 @@ export const ToggleSwitchTypeRender = ({
         </div>
         <span
           className={cx(prefixClass('text'), prefixClass('right'))}
-          onClick={activateToggleCallback}
+          onClick={() => onToggle(true)}
         >
           {labelRight}
         </span>

--- a/components/atom/switch/src/SwitchType/toggle.js
+++ b/components/atom/switch/src/SwitchType/toggle.js
@@ -112,21 +112,17 @@ ToggleSwitchTypeRender.propTypes = {
   /**
    * Callback on focus element
    */
-  focusSwitchCallback: PropTypes.func,
+  onFocus: PropTypes.func,
   /**
    * Callback on blur element
    */
-  blurSwitchCallback: PropTypes.func,
+  onBlur: PropTypes.func,
   /**
    * Callback on toggle element
    */
-  toggleSwitchCallback: PropTypes.func,
+  onToggle: PropTypes.func,
   /**
-   * Calback on activate toggle
+   * Callback on keydown on the switch
    */
-  activateToggleCallback: PropTypes.func,
-  /**
-   * Callback on deacrtivate toggle
-   */
-  deactivateToggleCallback: PropTypes.func
+  onKeyDown: PropTypes.func
 }

--- a/components/atom/switch/src/index.js
+++ b/components/atom/switch/src/index.js
@@ -114,11 +114,11 @@ AtomSwitch.propTypes = {
 }
 
 AtomSwitch.defaultProps = {
-  initialValue: false,
-  size: SIZES.DEFAULT,
   disabled: false,
+  initialValue: false,
   labelLeft: 'Off',
   labelRight: 'On',
+  size: SIZES.DEFAULT,
   type: TYPES.TOGGLE
 }
 

--- a/components/atom/switch/src/index.js
+++ b/components/atom/switch/src/index.js
@@ -16,101 +16,54 @@ export const TYPES = {
   SINGLE: 'single'
 }
 
+const SUPPORTED_KEYS = [' ', 'Enter', 'Spacebar']
+
 class AtomSwitch extends Component {
   state = {
-    toggle: false,
+    isToggle: this.props.initialValue,
     isFocus: false
   }
 
-  constructor(props) {
-    super(props)
+  _onKeyDown = event => {
+    if (this.props.disabled === true) return
 
-    this.executeIfEnabledFocusSwitch = this.executeIfEnabled(this.focusSwitch)
-    this.executeIfEnabledFocusOutSwitch = this.executeIfEnabled(
-      this.focusOutSwitch
-    )
-    this.executeIfEnabledToggleSwitch = this.executeIfEnabled(this.toggleSwitch)
-    this.executeIfEnabledActivateSwitch = this.executeIfEnabled(
-      this.activateToggle
-    )
-    this.executeIfEnabledDeactivateSwitch = this.executeIfEnabled(
-      this.deactivateToggle
-    )
-  }
-
-  componentDidMount() {
-    window.addEventListener('keydown', this.keyBindings, true)
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('keydown', this.keyBindings, true)
-  }
-
-  keyBindings = event => {
-    const {isFocus} = this.state
-    if (!isFocus || event.defaultPrevented) {
-      return
-    }
-    if (
-      event.key === 'Enter' ||
-      event.key === ' ' ||
-      event.key === 'Spacebar'
-    ) {
-      this.toggleSwitch()
+    if (SUPPORTED_KEYS.includes(event.key)) {
+      this._onToggle()
       event.preventDefault()
     }
   }
 
-  toggleSwitch = () => {
-    const {toggle} = this.state
+  _onToggle = forceValue => {
+    const {isToggle: stateToggle} = this.state
     const {onToggle} = this.props
-    this.setState({toggle: !toggle}, () => onToggle(!toggle))
+    const isToggle = forceValue !== undefined ? forceValue : !stateToggle
+    this.setState({isToggle}, () => onToggle(isToggle))
   }
 
-  activateToggle = () => {
-    this.setState({toggle: true})
+  _onBlur = () => {
+    this.setState({isFocus: false})
   }
-
-  deactivateToggle = () => {
-    this.setState({toggle: false})
-  }
-
-  executeIfEnabled = func => () => {
-    const {disabled} = this.props
-    !disabled && func()
-  }
-
-  focusSwitch = () => {
+  _onFocus = () => {
     this.setState({isFocus: true})
   }
 
-  focusOutSwitch = () => {
-    this.setState({isFocus: false})
-  }
-
   render() {
-    const {toggle, isFocus} = this.state
+    const {isToggle, isFocus} = this.state
+
+    const commonProps = {
+      ...this.props,
+      isFocus,
+      isToggle,
+      onBlur: this._onBlur,
+      onFocus: this._onFocus,
+      onKeyDown: this._onKeyDown,
+      onToggle: this._onToggle
+    }
 
     return this.props.type === TYPES.SINGLE ? (
-      <SingleSwitchTypeRender
-        {...this.props}
-        isToggle={toggle}
-        isFocus={isFocus}
-        focusSwitchCallback={this.executeIfEnabledFocusSwitch}
-        blurSwitchCallback={this.executeIfEnabledFocusOutSwitch}
-        toggleSwitchCallback={this.executeIfEnabledToggleSwitch}
-      />
+      <SingleSwitchTypeRender {...commonProps} />
     ) : (
-      <ToggleSwitchTypeRender
-        {...this.props}
-        isToggle={toggle}
-        isFocus={isFocus}
-        focusSwitchCallback={this.executeIfEnabledFocusSwitch}
-        blurSwitchCallback={this.executeIfEnabledFocusOutSwitch}
-        toggleSwitchCallback={this.executeIfEnabledToggleSwitch}
-        activateToggleCallback={this.executeIfEnabledActivateSwitch}
-        deactivateToggleCallback={this.executeIfEnabledDeactivateSwitch}
-      />
+      <ToggleSwitchTypeRender {...commonProps} />
     )
   }
 }
@@ -118,6 +71,10 @@ class AtomSwitch extends Component {
 AtomSwitch.displayName = 'AtomSwitch'
 
 AtomSwitch.propTypes = {
+  /**
+   * Wheter switch is checked on init
+   */
+  initialValue: PropTypes.bool,
   /**
    * Size of switch: 'default', 'large'
    */
@@ -157,6 +114,7 @@ AtomSwitch.propTypes = {
 }
 
 AtomSwitch.defaultProps = {
+  initialValue: false,
   size: SIZES.DEFAULT,
   disabled: false,
   labelLeft: 'Off',

--- a/components/atom/switch/src/index.scss
+++ b/components/atom/switch/src/index.scss
@@ -1,12 +1,12 @@
 @import '~@schibstedspain/sui-theme/lib/index';
 
 $h-atom-switch--m: $sz-icon-l !default;
-$w-atom-switch--m: 40px !default;
+$w-atom-switch--m: 35px !default;
 $m-atom-switch-circle--m: 12px !default;
 $h-atom-switch-container--m: 22px !default;
 
 $h-atom-switch--l: $sz-icon-xl !default;
-$w-atom-switch--l: 56px !default;
+$w-atom-switch--l: 51px !default;
 $m-atom-switch-circle--l: 18px !default;
 $h-atom-switch-container--l: 32px !default;
 
@@ -30,6 +30,7 @@ $c-atom-switch--default: color-variation($c-gray, 3) !default;
   }
 
   &--container {
+    border: 1px solid transparent;
     display: flex;
     height: $h-atom-switch--m;
     justify-content: center;
@@ -78,6 +79,7 @@ $c-atom-switch--default: color-variation($c-gray, 3) !default;
 
   &.sui-AtomSwitch--disabled {
     color: $c-gray;
+    pointer-events: none;
   }
 
   &.sui-AtomSwitch--active {

--- a/demo/atom/switch/playground
+++ b/demo/atom/switch/playground
@@ -1,6 +1,7 @@
 
 const flexInlineContainer = {display: 'flex', justifyContent: 'space-between', padding: '2vh 2vw'}
 const itemInlineFlex = {padding: '10px'}
+const log = flag => console.log(flag)
 
 return (
 <div>
@@ -9,15 +10,15 @@ return (
   <div style={flexInlineContainer}>
     <div style={itemInlineFlex}>
       <h4>Medium</h4>
-      <AtomSwitch  name='inputSwitchTest' label='Label title' onToggle={(flag) => {} }/>
+      <AtomSwitch  name='inputSwitchTest' label='Label title' onToggle={log}/>
     </div>
     <div style={itemInlineFlex}>
       <h4>Large</h4>
-      <AtomSwitch size='large'  name='inputSwitchTest' label='Label title' labelOptionalText='optional text' onToggle={(flag) => {} } />
+      <AtomSwitch size='large'  name='inputSwitchTest' label='Label title' labelOptionalText='optional text' onToggle={log} />
     </div>
     <div style={itemInlineFlex}>
       <h4>Disabled</h4>
-      <AtomSwitch disabled={true} name='inputSwitchTest'  label='Label title' onToggle={(flag) => {} } />
+      <AtomSwitch disabled={true} name='inputSwitchTest'  label='Label title' onToggle={log} />
     </div>
   </div>
 
@@ -25,15 +26,15 @@ return (
   <div style={flexInlineContainer}>
     <div style={itemInlineFlex}>
       <h4>Toggle</h4>
-      <AtomSwitch  name='inputSwitchTest' label='Label title' onToggle={(flag) => {} }/>
+      <AtomSwitch  name='inputSwitchTest' label='Label title' onToggle={log}/>
     </div>
     <div style={itemInlineFlex}>
       <h4>Select</h4>
-      <AtomSwitch type='select' labelLeft='Option A' labelRight='Option B' name='inputSwitchTest' label='Label title' onToggle={(flag) => {} }/>
+      <AtomSwitch type='select' labelLeft='Option A' labelRight='Option B' name='inputSwitchTest' label='Label title' onToggle={log}/>
     </div>
     <div style={itemInlineFlex}>
       <h4>Single</h4>
-      <AtomSwitch type='single' labelLeft='Lorem ipsum option'  name='inputSwitchTest' label='Label title' onToggle={(flag) => {} }/>
+      <AtomSwitch type='single' labelLeft='Lorem ipsum option'  name='inputSwitchTest' label='Label title' onToggle={log}/>
     </div>
   </div>
 </div>)


### PR DESCRIPTION
- [x] Add the possibility of initialize the component with a value.
- [x] Stop using global event listener and use React synthetic event instead.
- [x] Avoid any interaction when the component is disabled.
- [x] Fix circle animation to stop before the end of the width.
- [x] Simplify the callbacks.
- [x] Fix weird jump when toggling.
- [x] Improve playground.
- [x] Refactor to use same props for the two different component types.