### PR TITLE
fix(atom/tag): added right and bottom margin, removed left margin

### DIFF
--- a/components/atom/tag/src/index.scss
+++ b/components/atom/tag/src/index.scss
@@ -27,12 +27,9 @@ $p-atom-tag: 0 $p-l !default;
   font-size: $fz-s;
   height: $h-atom-tag;
   line-height: $h-atom-tag;
+  margin: 0 $m-m $m-m 0;
   padding: $p-atom-tag;
   white-space: nowrap;
-
-  & + & {
-    margin-left: $m-m;
-  }
 
   &-label {
     // max width - 2 icon size


### PR DESCRIPTION
In document definition we need 8px of margin right and 8px of margin bottom.