### PR TITLE
fix(abtesting/optimizelyXExperiment): fix: wait for sdk of optimizely…

### DIFF
--- a/components/abtesting/optimizelyXExperiment/src/optimizely-x.js
+++ b/components/abtesting/optimizelyXExperiment/src/optimizely-x.js
@@ -19,7 +19,8 @@ const waitUntil = (truthyFn, callback, delay = 100, interval = 100) => {
   }, interval)
 }
 
-const getOptmizely = () => window && window.optimizely
+const getOptmizely = () =>
+  window && window.optimizely && window.optimizely.get && window.optimizely
 
 let optimizelyPromise
 


### PR DESCRIPTION
… to be loaded.

When optimizely v1 and v2 are loaded in a page,
window.optimizely can be an array for a moment.
We have to wait for the actual sdk