### PR TITLE
fix(atom/image): fix position placeholder skeleton

### DIFF
--- a/components/atom/image/src/index.scss
+++ b/components/atom/image/src/index.scss
@@ -18,6 +18,7 @@ $bgs-atom-image-skeleton: 30% !default;
     background-position: center;
     background-repeat: no-repeat;
     margin: 0;
+    height: 100%;
 
     &--placeholder {
       background-size: $bgs-atom-image-placeholder;


### PR DESCRIPTION
Skeleton is not being properly placed because of a missing property to set the height of the container
https://sui-components.now.sh/workbench/atom/image/demo
