### PR TITLE
fix(script/loader): add default timeout render to return null

### DIFF
--- a/components/script/loader/src/index.js
+++ b/components/script/loader/src/index.js
@@ -64,6 +64,7 @@ ScriptLoader.propTypes = {
 ScriptLoader.defaultProps = {
   isAsync: true,
   onTimeout: () => {},
+  timeoutRender: () => null,
   detectionDelay: 5000
 }
 


### PR DESCRIPTION
In case of timeout nothing was executed and React was failing