### PR TITLE
Feature/use new react molecule notification

### DIFF
--- a/components/error/appBoundary/package.json
+++ b/components/error/appBoundary/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@s-ui/component-dependencies": "1",
-    "@schibstedspain/sui-alert-basic": "1"
+    "@s-ui/react-molecule-notification": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/error/appBoundary/src/index.js
+++ b/components/error/appBoundary/src/index.js
@@ -2,7 +2,7 @@ import React, {Component, Fragment} from 'react'
 import PropTypes from 'prop-types'
 
 class ErrorAppBoundary extends Component {
-  AlertBasicComponent = null
+  MoleculeNotification = null
   state = {errorCount: 0, hasError: false}
   componentDidCatch(errorMessage, errorStack) {
     const {errorThreshold, onError, redirectUrlOnBreakingThreshold} = this.props
@@ -26,39 +26,40 @@ class ErrorAppBoundary extends Component {
       require.ensure(
         [],
         require => {
-          resolve(require('@schibstedspain/sui-alert-basic').default)
+          resolve(require('@s-ui/react-molecule-notification').default)
         },
-        'AlertBasic'
+        'MoleculeNotification'
       )
     }).then(Component => {
-      this.AlertBasicComponent = Component
+      this.MoleculeNotification = Component
       // Display fallback UI
       this.setState({hasError: true})
     })
   }
 
   render() {
-    const {buttonLabel, children, icon, message} = this.props
+    const {buttonLabel, children, message} = this.props
 
     return (
       <Fragment>
         {children}
         {this.state.hasError && (
           <div className="sui-ErrorAppBoundary-notification">
-            <this.AlertBasicComponent
-              actions={[
+            <this.MoleculeNotification
+              buttons={[
                 {
-                  handle: () => {
+                  type: 'secondary',
+                  negative: true,
+                  children: buttonLabel,
+                  onClick: () => {
                     this.setState({hasError: false})
-                  },
-                  text: buttonLabel
+                  }
                 }
               ]}
-              icon={icon}
-              type="info"
-            >
-              <p>{message}</p>
-            </this.AlertBasicComponent>
+              type="warning"
+              text={message}
+              position="bottom"
+            />
           </div>
         )}
       </Fragment>
@@ -79,10 +80,6 @@ ErrorAppBoundary.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
   ]),
-  /**
-   * Customize the icon you want to show on the notification
-   */
-  icon: PropTypes.element,
   /**
    * Message to show to the user in order to inform him about the error
    */

--- a/components/error/appBoundary/src/index.scss
+++ b/components/error/appBoundary/src/index.scss
@@ -1,22 +1,2 @@
 @import '~@schibstedspain/theme-basic/lib/index';
-
-$p-error-app-boundary: 0 !default;
-$w-error-app-boundary: 100% !default;
-$z-error-app-boundary: 1 !default;
-
-$bdl-error-app-boundary: 4px solid $c-gray-dark !default;
-$bgc-error-app-boundary: $c-gray-lightest !default;
-
-$bgc-alert-basic-info: $bgc-error-app-boundary;
-$bdl-alert-basic-info: $bdl-error-app-boundary;
-
-.sui-ErrorAppBoundary-notification {
-  bottom: 0;
-  left: 0;
-  padding: $p-error-app-boundary;
-  position: fixed;
-  width: $w-error-app-boundary;
-  z-index: $z-error-app-boundary;
-}
-
-@import '~@schibstedspain/sui-alert-basic/lib/index';
+@import '~@s-ui/react-molecule-notification/lib/index';

--- a/demo/error/appBoundary/themes/carfactory.scss
+++ b/demo/error/appBoundary/themes/carfactory.scss
@@ -1,0 +1,2 @@
+@import '../../../../themes/carfactory';
+@import '../../../../components/error/appBoundary/src/index.scss';

--- a/demo/error/appBoundary/themes/coches.scss
+++ b/demo/error/appBoundary/themes/coches.scss
@@ -1,0 +1,2 @@
+@import '../../../../themes/coches';
+@import '../../../../components/error/appBoundary/src/index.scss';

--- a/demo/error/appBoundary/themes/finn.scss
+++ b/demo/error/appBoundary/themes/finn.scss
@@ -1,0 +1,2 @@
+@import '../../../../themes/finn';
+@import '../../../../components/error/appBoundary/src/index.scss';

--- a/demo/error/appBoundary/themes/fotocasa.scss
+++ b/demo/error/appBoundary/themes/fotocasa.scss
@@ -1,0 +1,2 @@
+@import '../../../../themes/fotocasa';
+@import '../../../../components/error/appBoundary/src/index.scss';

--- a/demo/error/appBoundary/themes/infojobs.scss
+++ b/demo/error/appBoundary/themes/infojobs.scss
@@ -1,0 +1,2 @@
+@import '../../../../themes/infojobs';
+@import '../../../../components/error/appBoundary/src/index.scss';

--- a/demo/error/appBoundary/themes/leboncoin.scss
+++ b/demo/error/appBoundary/themes/leboncoin.scss
@@ -1,0 +1,2 @@
+@import '../../../../themes/leboncoin';
+@import '../../../../components/error/appBoundary/src/index.scss';

--- a/demo/error/appBoundary/themes/motos.scss
+++ b/demo/error/appBoundary/themes/motos.scss
@@ -1,0 +1,2 @@
+@import '../../../../themes/motos';
+@import '../../../../components/error/appBoundary/src/index.scss';

--- a/demo/error/appBoundary/themes/sui.scss
+++ b/demo/error/appBoundary/themes/sui.scss
@@ -1,0 +1,2 @@
+@import '../../../../themes/sui';
+@import '../../../../components/error/appBoundary/src/index.scss';


### PR DESCRIPTION
Drop @schibstedspain/sui-alert-basic dependency and use the new and shiny **@s-ui/react-molecule-notification** in order to use the component approved by UX and, also, save a few bytes by avoiding adding stuff that we for sure already have in our web.

![image](https://user-images.githubusercontent.com/1561955/43511934-0705746c-957a-11e8-8575-10235ce8578a.png)
