### PR TITLE
Feature/collapsible basic is clickable

### DIFF
--- a/components/collapsible/basic/README.md
+++ b/components/collapsible/basic/README.md
@@ -1,4 +1,28 @@
 ### CollapsibleBasic
 
-Expandable/collapsable block.
-  
+> Expandable/collapsable block.
+
+<!-- ![](./assets/preview.png) -->
+
+## Installation
+
+```sh
+$ npm install @schibstedspain/sui-collapsible-basic --save
+```
+
+## Usage
+
+### Basic usage
+```js
+import CollapsibleBasic from '@schibstedspain/sui-collapsible-basic'
+
+return (<CollapsibleBasic 
+          hideTriggerIcon={hideTriggerIcon} 
+          collapsed={collpased} 
+          label={'Custom label could be a string or component'}>
+        Here will be the content of this collapsible basic
+        </CollapsibleBasic>)
+```
+
+
+> **Find full description and more examples in the [demo page](#).**

--- a/components/collapsible/basic/src/index.js
+++ b/components/collapsible/basic/src/index.js
@@ -36,7 +36,8 @@ class CollapsibleBasic extends Component {
       label,
       animationSpeed,
       hideTriggerIcon,
-      children
+      children,
+      isClickable
     } = this.props
     const {isCollapsed} = this.state
     const cssClassNames = cx('sui-CollapsibleBasic', {
@@ -52,7 +53,7 @@ class CollapsibleBasic extends Component {
       <div className={cssClassNames}>
         <div
           className="sui-CollapsibleBasic-trigger"
-          onClick={this._handleClick}
+          onClick={isClickable && this._handleClick}
         >
           <div className="sui-CollapsibleBasic-trigger-label">{label}</div>
           {!hideTriggerIcon && (
@@ -100,6 +101,10 @@ CollapsibleBasic.propTypes = {
   /**
    * Customise the speed of the transition animation: normal 0.3s, fast: 0.15s
    */
+  isClickable: PropTypes.bool,
+  /**
+   * Allow click in the label to open or close it
+   */
   animationSpeed: PropTypes.oneOf(Object.keys(ANIMATION_SPEED_CLASSNAMES))
 }
 
@@ -108,6 +113,7 @@ CollapsibleBasic.defaultProps = {
   collapsed: true,
   hideTriggerIcon: false,
   animationSpeed: 'normal',
+  isClickable: true,
   handleClick: () => {}
 }
 

--- a/components/collapsible/basic/src/index.js
+++ b/components/collapsible/basic/src/index.js
@@ -99,11 +99,11 @@ CollapsibleBasic.propTypes = {
    */
   hideTriggerIcon: PropTypes.bool,
   /**
-   * Customise the speed of the transition animation: normal 0.3s, fast: 0.15s
+   * Allow click in the label to open or close it
    */
   isClickable: PropTypes.bool,
   /**
-   * Allow click in the label to open or close it
+   * Customise the speed of the transition animation: normal 0.3s, fast: 0.15s
    */
   animationSpeed: PropTypes.oneOf(Object.keys(ANIMATION_SPEED_CLASSNAMES))
 }


### PR DESCRIPTION
This feature allows us to manage when should be clickable the collapsible basic. For example, when has been opened for the first time we can set isCickable prop to false and the user won't be able to close the component.