### PR TITLE
Feature/handle accept when clicking outside banner cmp

### DIFF
--- a/components/cmp/banner/src/CmpBanner/index.js
+++ b/components/cmp/banner/src/CmpBanner/index.js
@@ -4,7 +4,8 @@ import PropTypes from 'prop-types'
 import {CmpBanner} from './component'
 import CmpModal from '@s-ui/react-cmp-modal'
 
-import {I18N} from '../settings'
+import {CLASS, I18N} from '../settings'
+const CLASS_CONTAINER = `${CLASS}-container`
 
 export class CmpBannerContainer extends Component {
   state = {
@@ -51,6 +52,20 @@ export class CmpBannerContainer extends Component {
   }
 
   async componentDidMount() {
+    document.addEventListener('click', ({target}) => {
+      let isClickOnCmp = false
+      while (target) {
+        isClickOnCmp =
+          ` ${target.className} `.indexOf(` ${CLASS_CONTAINER} `) > -1
+        console.log(isClickOnCmp)
+        if (isClickOnCmp) break
+        console.log(target)
+        target = target.parentNode
+      }
+      console.log(isClickOnCmp)
+      if (isClickOnCmp === false) this._handleAccept()
+    })
+
     const {getConsentStatus} = this.props
     const consentStatus = await getConsentStatus.execute()
     const {userAcceptedCookies} = consentStatus
@@ -61,7 +76,7 @@ export class CmpBannerContainer extends Component {
   render() {
     const {companyName, lang, logo, privacyUrl} = this.props
     return (
-      <React.Fragment>
+      <div className={CLASS_CONTAINER}>
         {this.state.showNotification && (
           <CmpBanner
             buttons={this._generateButtons()}
@@ -78,7 +93,7 @@ export class CmpBannerContainer extends Component {
             privacyUrl={privacyUrl}
           />
         )}
-      </React.Fragment>
+      </div>
     )
   }
 }

--- a/components/cmp/banner/src/CmpBanner/index.js
+++ b/components/cmp/banner/src/CmpBanner/index.js
@@ -4,8 +4,7 @@ import PropTypes from 'prop-types'
 import {CmpBanner} from './component'
 import CmpModal from '@s-ui/react-cmp-modal'
 
-import {CLASS, I18N} from '../settings'
-const CLASS_CONTAINER = `${CLASS}-container`
+import {I18N} from '../settings'
 
 const CONSENT_STATUS_NOT_ACCEPTED = 'NOT_ACCEPTED'
 
@@ -14,6 +13,8 @@ export class CmpBannerContainer extends Component {
     showModal: false,
     showNotification: false
   }
+
+  containerDOMEl = React.createRef()
 
   _handleAccept = async () => {
     const {getPurposesAndVendors, sendConsents} = this.props
@@ -35,16 +36,8 @@ export class CmpBannerContainer extends Component {
    * he's just navigating the website
    */
   _handleClickOnDocument = ({target}) => {
-    let isUserClickingOnCmp = false
-    while (target) {
-      isUserClickingOnCmp =
-        ` ${target.className} `.indexOf(` ${CLASS_CONTAINER} `) > -1
-
-      if (isUserClickingOnCmp) break
-      target = target.parentElement
-    }
-    // if it's not a click on the cmp, then we assume user is accepting our cmp
-    if (isUserClickingOnCmp === false) this._handleAccept()
+    this.containerDOMEl.current.contains(target) === false &&
+      this._handleAccept()
   }
 
   _handleExitModal = () => {
@@ -89,7 +82,7 @@ export class CmpBannerContainer extends Component {
   render() {
     const {companyName, lang, logo, privacyUrl} = this.props
     return (
-      <div className={CLASS_CONTAINER}>
+      <div ref={this.containerDOMEl}>
         {this.state.showNotification && (
           <CmpBanner
             buttons={this._generateButtons()}

--- a/components/cmp/banner/src/CmpBanner/index.js
+++ b/components/cmp/banner/src/CmpBanner/index.js
@@ -29,6 +29,24 @@ export class CmpBannerContainer extends Component {
     this.setState({showModal: true, showNotification: false})
   }
 
+  /**
+   * This handler is used everytime the user clicks on something in the web
+   * in order to assume he's accepting our CMP if he's not trying to configure it and
+   * he's just navigating the website
+   */
+  _handleClickOnDocument = ({target}) => {
+    let isUserClickingOnCmp = false
+    while (target) {
+      isUserClickingOnCmp =
+        ` ${target.className} `.indexOf(` ${CLASS_CONTAINER} `) > -1
+
+      if (isUserClickingOnCmp) break
+      target = target.parentElement
+    }
+    // if it's not a click on the cmp, then we assume user is accepting our cmp
+    if (isUserClickingOnCmp === false) this._handleAccept()
+  }
+
   _handleExitModal = () => {
     this.setState({showModal: false})
   }
@@ -54,25 +72,18 @@ export class CmpBannerContainer extends Component {
   }
 
   async componentDidMount() {
-    document.addEventListener('click', ({target}) => {
-      let isClickOnCmp = false
-      while (target) {
-        isClickOnCmp =
-          ` ${target.className} `.indexOf(` ${CLASS_CONTAINER} `) > -1
-        console.log(isClickOnCmp)
-        if (isClickOnCmp) break
-        console.log(target)
-        target = target.parentNode
-      }
-      console.log(isClickOnCmp)
-      if (isClickOnCmp === false) this._handleAccept()
-    })
+    // We're assuming, the user accepts our CMP if he keep navigating in our page
+    document.addEventListener('click', this._handleClickOnDocument, true)
 
     const {getConsentStatus} = this.props
     const consentStatus = await getConsentStatus.execute()
     this.setState({
       showNotification: consentStatus === CONSENT_STATUS_NOT_ACCEPTED
     })
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('click', this._handleClickOnDocument, true)
   }
 
   render() {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "phoenix": "npx @s-ui/mono phoenix",
     "precommit": "sui-precommit run",
     "release": "sui-studio release",
-    "start": "sui-studio start",
+    "start": "sui-studio dev",
     "test": "jest"
   },
   "repository": {},

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "phoenix": "npx @s-ui/mono phoenix",
     "precommit": "sui-precommit run",
     "release": "sui-studio release",
-    "start": "sui-studio dev",
+    "start": "sui-studio start",
     "test": "jest"
   },
   "repository": {},


### PR DESCRIPTION
If the user is clicking the website around then we assume he's accepting our CMP. We have to control if he's actually clicking ON the CMP in order to avoid problems when he's trying to just configure the CMP or accepting it directly.