### PR TITLE
chore(META): avoid travis log to overload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - npm i -g npx
   - npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
 install:
-  - npm run phoenix
+  - npm run phoenix -- --no-progress
 before_deploy:
   - npm i -g now@9
   - npm run build


### PR DESCRIPTION
Avoid travis log to exceed max buffer of 4MB. 
This is caused because of "updating" output of `sui-mono phoenix`.

This PR must be merged after this one: https://github.com/SUI-Components/sui/pull/372/files