### PR TITLE
fix(atom/tooltip): use require.ensure for avoiding problems with transpiled code

### DIFF
--- a/components/atom/tooltip/src/index.js
+++ b/components/atom/tooltip/src/index.js
@@ -41,11 +41,14 @@ class AtomTooltip extends Component {
   }
 
   loadAsyncReacstrap(e) {
-    import(/* webpackChunkName: "reactstrap" */ 'reactstrap').then(
-      ({Tooltip}) => {
-        this.setState({Tooltip: Tooltip})
+    require.ensure(
+      [],
+      require => {
+        const Tooltip = require('reactstrap/lib/Tooltip').default
+        this.setState({Tooltip})
         this.handleToggle(e)
-      }
+      },
+      'reactstrap-Tooltip'
     )
   }
 


### PR DESCRIPTION
- [x] Use require.ensure as we're not transpiling dynamic import and is failing in our bundles.
- [x] Only load the needed Tooltip stuff instead  the whole reactstrap library.