### PR TITLE
feat(atom/input): fixed FormInput loose focus onChange

### DIFF
--- a/components/atom/input/src/Input/index.js
+++ b/components/atom/input/src/Input/index.js
@@ -2,9 +2,10 @@ import React from 'react'
 import AddonHoc from './Features/Addon'
 import Component, {inputSizes} from './Component'
 
+const WithAddonComponent = AddonHoc(Component)
+
 export default props => {
   const {leftAddon, rightAddon} = props // eslint-disable-line react/prop-types
-  const WithAddonComponent = AddonHoc(Component)
   return leftAddon || rightAddon ? (
     <WithAddonComponent {...props} />
   ) : (


### PR DESCRIPTION
This issue had to do w/ https://reactjs.org/docs/higher-order-components.html#dont-use-hocs-inside-the-render-method