### PR TITLE
feat(molecule/breadcrumb): added text decoration sass var in hover link

### DIFF
--- a/components/molecule/breadcrumb/src/index.scss
+++ b/components/molecule/breadcrumb/src/index.scss
@@ -1,7 +1,7 @@
 /* sass-lint:disable no-important, class-name-format*/
 @import '~@schibstedspain/sui-theme/lib/settings-compat-v7/index';
 @import '~@schibstedspain/sui-theme/lib/index';
-@import './settings.scss';
+@import './settings';
 
 
 .sui-BreadcrumbBasic {

--- a/components/molecule/breadcrumb/src/index.scss
+++ b/components/molecule/breadcrumb/src/index.scss
@@ -1,6 +1,8 @@
 /* sass-lint:disable no-important, class-name-format*/
+@import '~@schibstedspain/sui-theme/lib/settings-compat-v7/index';
 @import '~@schibstedspain/sui-theme/lib/index';
-@import './settings';
+@import './settings.scss';
+
 
 .sui-BreadcrumbBasic {
   @include media-breakpoint-up(l) {

--- a/components/molecule/breadcrumb/src/index.scss
+++ b/components/molecule/breadcrumb/src/index.scss
@@ -60,6 +60,7 @@
 
     &:hover {
       color: $c-breadcrumb-link-hover;
+      text-decoration: $td-breadcrumb-link-hover;
     }
   }
 }

--- a/components/molecule/breadcrumb/src/index.scss
+++ b/components/molecule/breadcrumb/src/index.scss
@@ -1,6 +1,8 @@
 /* sass-lint:disable no-important, class-name-format*/
 @import '~@schibstedspain/sui-theme/lib/settings-compat-v7/index';
 @import '~@schibstedspain/sui-theme/lib/index';
+@import './settings.scss';
+
 
 .sui-BreadcrumbBasic {
   @include media-breakpoint-up(l) {

--- a/components/molecule/breadcrumb/src/index.scss
+++ b/components/molecule/breadcrumb/src/index.scss
@@ -1,8 +1,6 @@
 /* sass-lint:disable no-important, class-name-format*/
-@import '~@schibstedspain/sui-theme/lib/settings-compat-v7/index';
 @import '~@schibstedspain/sui-theme/lib/index';
-@import './settings.scss';
-
+@import './settings';
 
 .sui-BreadcrumbBasic {
   @include media-breakpoint-up(l) {

--- a/components/molecule/breadcrumb/src/settings.scss
+++ b/components/molecule/breadcrumb/src/settings.scss
@@ -1,0 +1,11 @@
+$bgc-breadcrumb: transparent !default;
+$bxsh-breadcrumb: none !default;
+$p-breadcrumb-desktop: $p-v $p-h !default;
+$p-breadcrumb-mobile: $p-v $p-h !default;
+$c-breadcrumb-icon: $c-gray !default;
+$c-breadcrumb-link-hover: $c-accent !default;
+$c-breadcrumb-link: $c-primary !default;
+$c-breadcrumb: $c-text-base !default;
+$m-breadcrumb-items: $m-h-small !default;
+$size-breadcrumb-icon: 18px !default;
+$td-breadcrumb-link-hover: none !default;


### PR DESCRIPTION
In order to have available text decoration in breadcrumb component I have created a theme variable that will be set by default to none but each site could change it in his vertical theme.