### PR TITLE
feat(atom/button): export types

### DIFF
--- a/components/atom/button/src/index.js
+++ b/components/atom/button/src/index.js
@@ -177,3 +177,4 @@ AtomButton.defaultProps = {
 
 export default AtomButton
 export {GROUP_POSITIONS as atomButtonGroupPositions}
+export {TYPES as atomButtonTypes}


### PR DESCRIPTION
In order to configure button `type` properly in the `MoleculeButtonGroup` propTypes we need to export them so they can be used as they should in other components.