### PR TITLE
feat(atom/input): component prepared for MoleculeInputTags

### DIFF
--- a/components/atom/input/src/Input/Component/_mixins.scss
+++ b/components/atom/input/src/Input/Component/_mixins.scss
@@ -1,0 +1,16 @@
+@mixin sui-atom-input-input {
+  background: $c-white;
+  border: 1px solid $c-gray-light;
+  box-sizing: border-box;
+  font-size: $fz-base;
+  height: $h-atom-input--m;
+  padding-left: $p-l;
+  padding-right: $p-l;
+  width: 100%;
+}
+
+@mixin sui-atom-input-input-focus {
+  border: solid 1px $c-primary;
+  box-shadow: 0 0 3px 0 $c-primary;
+  outline: 0 none;
+}

--- a/components/atom/input/src/Input/Component/_placeholders.scss
+++ b/components/atom/input/src/Input/Component/_placeholders.scss
@@ -1,6 +1,8 @@
-@mixin sui-atom-input-input {
+@import 'settings';
+
+%sui-atom-input-input {
   background: $c-white;
-  border: 1px solid $c-gray-light;
+  border: $bdw-atom-input solid $c-gray-light;
   box-sizing: border-box;
   font-size: $fz-base;
   height: $h-atom-input--m;
@@ -9,7 +11,7 @@
   width: 100%;
 }
 
-@mixin sui-atom-input-input-focus {
+%sui-atom-input-input-focus {
   border: solid 1px $c-primary;
   box-shadow: 0 0 3px 0 $c-primary;
   outline: 0 none;

--- a/components/atom/input/src/Input/Component/_placeholders.scss
+++ b/components/atom/input/src/Input/Component/_placeholders.scss
@@ -2,7 +2,7 @@
 
 %sui-atom-input-input {
   background: $c-white;
-  border: $bdw-atom-input solid $c-gray-light;
+  border: $bdw-s solid $c-gray-light;
   box-sizing: border-box;
   font-size: $fz-base;
   height: $h-atom-input--m;
@@ -12,7 +12,7 @@
 }
 
 %sui-atom-input-input-focus {
-  border: solid 1px $c-primary;
+  border: $bdw-s solid $c-primary;
   box-shadow: $bxsh-focus;
   outline: 0 none;
 }

--- a/components/atom/input/src/Input/Component/_placeholders.scss
+++ b/components/atom/input/src/Input/Component/_placeholders.scss
@@ -13,6 +13,6 @@
 
 %sui-atom-input-input-focus {
   border: solid 1px $c-primary;
-  box-shadow: 0 0 3px 0 $c-primary;
+  box-shadow: $bxsh-focus;
   outline: 0 none;
 }

--- a/components/atom/input/src/Input/Component/_settings.scss
+++ b/components/atom/input/src/Input/Component/_settings.scss
@@ -1,0 +1,8 @@
+$h-atom-input--m: 40px !default;
+$h-atom-input--s: 32px !default;
+
+$c-atom-input--success: $c-success !default;
+$c-atom-input--error: $c-error !default;
+
+$sizes-atom-input: m $h-atom-input--m, s $h-atom-input--s !default;
+$states-atom-input: success $c-atom-input--success, error $c-atom-input--error !default;

--- a/components/atom/input/src/Input/Component/_settings.scss
+++ b/components/atom/input/src/Input/Component/_settings.scss
@@ -4,7 +4,5 @@ $h-atom-input--s: 32px !default;
 $c-atom-input--success: $c-success !default;
 $c-atom-input--error: $c-error !default;
 
-$bdw-atom-input: 1px !default;
-
 $sizes-atom-input: m $h-atom-input--m, s $h-atom-input--s !default;
 $states-atom-input: success $c-atom-input--success, error $c-atom-input--error !default;

--- a/components/atom/input/src/Input/Component/_settings.scss
+++ b/components/atom/input/src/Input/Component/_settings.scss
@@ -4,5 +4,7 @@ $h-atom-input--s: 32px !default;
 $c-atom-input--success: $c-success !default;
 $c-atom-input--error: $c-error !default;
 
+$bdw-atom-input: 1px !default;
+
 $sizes-atom-input: m $h-atom-input--m, s $h-atom-input--s !default;
 $states-atom-input: success $c-atom-input--success, error $c-atom-input--error !default;

--- a/components/atom/input/src/Input/Component/index.js
+++ b/components/atom/input/src/Input/Component/index.js
@@ -23,7 +23,7 @@ class Input extends Component {
     onChange && onChange({value, ev})
   }
 
-  hendleKeyDown = ev => {
+  handleKeyDown = ev => {
     const {onEnter, onEnterKey} = this.props
     const {key} = ev
     if (key === onEnterKey && onEnter) onEnter(ev)
@@ -78,7 +78,7 @@ class Input extends Component {
         onChange={this.changeHandler}
         onFocus={onFocus}
         onBlur={onBlur}
-        onKeyDown={this.hendleKeyDown}
+        onKeyDown={this.handleKeyDown}
         placeholder={placeholder}
         ref={reference}
         type={type}

--- a/components/atom/input/src/Input/Component/index.js
+++ b/components/atom/input/src/Input/Component/index.js
@@ -23,10 +23,10 @@ class Input extends Component {
     onChange && onChange({value, ev})
   }
 
-  onEnterHandler = ev => {
-    const {onEnter} = this.props
+  hendleKeyDown = ev => {
+    const {onEnter, onEnterKey} = this.props
     const {key} = ev
-    if (key === 'Enter') onEnter && onEnter(ev)
+    if (key === onEnterKey && onEnter) onEnter(ev)
   }
 
   getErrorStateClass(errorState) {
@@ -78,7 +78,7 @@ class Input extends Component {
         onChange={this.changeHandler}
         onFocus={onFocus}
         onBlur={onBlur}
-        onKeyDown={this.onEnterHandler}
+        onKeyDown={this.hendleKeyDown}
         placeholder={placeholder}
         ref={reference}
         type={type}
@@ -106,6 +106,8 @@ Input.propTypes = {
   onFocus: PropTypes.func,
   /* onEnter callback */
   onEnter: PropTypes.func,
+  /* key to provoke the onEnter callback. Valid any value defined here → https://www.w3.org/TR/uievents-key/#named-key-attribute-values */
+  onEnterKey: PropTypes.string,
   /* A hint to the user of what can be entered in the control. The placeholder text must not contain carriage returns or line-feeds. */
   placeholder: PropTypes.string,
   /* 's' or 'm', default: 'm' */
@@ -125,7 +127,8 @@ Input.propTypes = {
 }
 
 Input.defaultProps = {
-  size: SIZES.MEDIUM
+  size: SIZES.MEDIUM,
+  onEnterKey: 'Enter'
 }
 
 export default Input

--- a/components/atom/input/src/Input/Component/index.js
+++ b/components/atom/input/src/Input/Component/index.js
@@ -15,8 +15,18 @@ const ERROR_STATES = {
 }
 
 class Input extends Component {
-  changeHandler(ev, onChange) {
-    onChange && onChange({value: ev.target.value, ev})
+  changeHandler = ev => {
+    const {onChange} = this.props
+    const {
+      target: {value}
+    } = ev
+    onChange && onChange({value, ev})
+  }
+
+  onEnterHandler = ev => {
+    const {onEnter} = this.props
+    const {key} = ev
+    if (key === 'Enter') onEnter && onEnter(ev)
   }
 
   getErrorStateClass(errorState) {
@@ -43,7 +53,7 @@ class Input extends Component {
       id,
       name,
       onBlur,
-      onChange,
+      onFocus,
       placeholder,
       reference,
       size,
@@ -65,8 +75,10 @@ class Input extends Component {
         disabled={disabled}
         id={id}
         name={name}
-        onChange={ev => this.changeHandler(ev, onChange)}
+        onChange={this.changeHandler}
+        onFocus={onFocus}
         onBlur={onBlur}
+        onKeyDown={this.onEnterHandler}
         placeholder={placeholder}
         ref={reference}
         type={type}
@@ -90,6 +102,10 @@ Input.propTypes = {
   onBlur: PropTypes.func,
   /* onChange callback */
   onChange: PropTypes.func,
+  /* onFocus callback */
+  onFocus: PropTypes.func,
+  /* onEnter callback */
+  onEnter: PropTypes.func,
   /* A hint to the user of what can be entered in the control. The placeholder text must not contain carriage returns or line-feeds. */
   placeholder: PropTypes.string,
   /* 's' or 'm', default: 'm' */

--- a/components/atom/input/src/Input/Component/index.scss
+++ b/components/atom/input/src/Input/Component/index.scss
@@ -1,8 +1,8 @@
+@import 'placeholders';
 @import 'settings';
-@import 'mixins';
 
 .sui-AtomInput-input {
-  @include sui-atom-input-input;
+  @extend %sui-atom-input-input;
 
   &--size {
     width: inherit;
@@ -33,7 +33,7 @@
   }
 
   &:focus {
-    @include sui-atom-input-input-focus;
+    @extend %sui-atom-input-input-focus;
   }
 
   @each $type, $attr in $sizes-atom-input {

--- a/components/atom/input/src/Input/Component/index.scss
+++ b/components/atom/input/src/Input/Component/index.scss
@@ -1,22 +1,8 @@
-$h-atom-input--m: 40px !default;
-$h-atom-input--s: 32px !default;
-
-$c-atom-input--success: $c-success !default;
-$c-atom-input--error: $c-error !default;
-
-$sizes-atom-input: m $h-atom-input--m, s $h-atom-input--s !default;
-$states-atom-input: success $c-atom-input--success, error $c-atom-input--error !default;
+@import 'settings';
+@import 'mixins';
 
 .sui-AtomInput-input {
-  border-color: $c-gray-light;
-  border-style: solid;
-  border-width: 1px;
-  box-sizing: border-box;
-  font-size: $fz-base;
-  height: $h-atom-input--m;
-  padding-left: $p-l;
-  padding-right: $p-l;
-  width: 100%;
+  @include sui-atom-input-input;
 
   &--size {
     width: inherit;
@@ -47,7 +33,7 @@ $states-atom-input: success $c-atom-input--success, error $c-atom-input--error !
   }
 
   &:focus {
-    box-shadow: inset 0 0 3px 0 $c-primary;
+    @include sui-atom-input-input-focus;
   }
 
   @each $type, $attr in $sizes-atom-input {

--- a/demo/atom/input/playground
+++ b/demo/atom/input/playground
@@ -299,7 +299,11 @@ return (
       <h4>onEnter</h4>
       <AtomInput
         name="second"
-        onEnter={ ({target: {value}}) => alert(value)}
+        onEnter={ ev => {
+          const {target: {value}} = ev
+          ev.preventDefault()
+          alert(value)
+        }}
       />
     </div>
 
@@ -307,7 +311,11 @@ return (
       <h4>onEnter on Tab</h4>
       <AtomInput
         name="second"
-        onEnter={ ({target: {value}}) => alert(value)}
+        onEnter={ ev => {
+          const {target: {value}} = ev
+          ev.preventDefault()
+          alert(value)
+        }}
         onEnterKey="Tab"
       />
     </div>

--- a/demo/atom/input/playground
+++ b/demo/atom/input/playground
@@ -295,6 +295,24 @@ return (
       />
     </div>
 
+    <div style={field}>
+      <h4>onEnter</h4>
+      <AtomInput
+        name="second"
+        onEnter={ ({target: {value}}) => alert(value)}
+      />
+    </div>
+
+    <div style={field}>
+      <h4>onEnter on Tab</h4>
+      <AtomInput
+        name="second"
+        onEnter={ ({target: {value}}) => alert(value)}
+        onEnterKey="Tab"
+      />
+    </div>
+
+
     <h2>Checkbox & Radio</h2>
 
     <SimpleCheckboxRadioForm />


### PR DESCRIPTION
- Added `onFocus` & `onEnter`props
- Added mixins ready to be (re)used in other components

These additions are needed for the `MoleculeInputTags` component

Online version of these changes can be checked at → https://sui-components-atom-input-ready-tags.now.sh/workbench/atom/input/demo

It depends on the following PR's (merge this PR **only after** these ones have been merged):
- https://github.com/SUI-Components/sui-theme/pull/165
- https://github.com/SUI-Components/sui-theme/pull/164