### PR TITLE
feat(molecule/notification): add children prop, so we can print HTML

### DIFF
--- a/components/molecule/notification/src/index.js
+++ b/components/molecule/notification/src/index.js
@@ -99,13 +99,6 @@ class MoleculeNotification extends Component {
       .slice(0, BUTTONS_MAX)
       .map((button, i) => <Button key={i} {...button} />)
   }
-  printContent = () => {
-    const {text, children} = this.props
-    if (children) {
-      return children
-    }
-    return `<span>${text}</span>`
-  }
 
   render() {
     const {show, delay} = this.state

--- a/components/molecule/notification/src/index.js
+++ b/components/molecule/notification/src/index.js
@@ -107,10 +107,6 @@ class MoleculeNotification extends Component {
     return `<span>${text}</span>`
   }
 
-  createMarkup(markup) {
-    return {__html: markup}
-  }
-
   render() {
     const {show, delay} = this.state
     const {

--- a/components/molecule/notification/src/index.js
+++ b/components/molecule/notification/src/index.js
@@ -119,6 +119,10 @@ class MoleculeNotification extends Component {
         [`${CLASS}-effect--hide`]: effect && delay
       }
     )
+    const innerWrapperClassName = cx({
+      [`${CLASS}-children`]: children,
+      [`${CLASS}-text`]: text
+    })
 
     if (!show && !delay) {
       return null
@@ -130,7 +134,7 @@ class MoleculeNotification extends Component {
           <div className={`${CLASS}-iconLeft`}>
             <span className={`${CLASS}-icon`}>{icon || ICONS[type]}</span>
           </div>
-          <div className={`${CLASS}-text`}>{text || children}</div>
+          <div className={innerWrapperClassName}>{children || text}</div>
           {showCloseButton && (
             <div className={`${CLASS}-iconClose`} onClick={this.toggleShow}>
               <span className={`${CLASS}-icon`}>
@@ -159,9 +163,9 @@ MoleculeNotification.propTypes = {
    */
   buttons: PropTypes.array,
   /**
-   * Content to be printed. Alternatively you can use "text" prop
+   * Notification content
    */
-  children: PropTypes.node,
+  children: PropTypes.node.isRequired,
   /**
    * Transition enabled
    */
@@ -183,7 +187,7 @@ MoleculeNotification.propTypes = {
    */
   showCloseButton: PropTypes.bool,
   /**
-   * Content text. Alternatively you can use "children" prop
+   * Content text. Deprecated, use children instead.
    */
   text: PropTypes.string,
   /**

--- a/components/molecule/notification/src/index.js
+++ b/components/molecule/notification/src/index.js
@@ -99,6 +99,17 @@ class MoleculeNotification extends Component {
       .slice(0, BUTTONS_MAX)
       .map((button, i) => <Button key={i} {...button} />)
   }
+  printContent = () => {
+    const {text, children} = this.props
+    if (children) {
+      return children
+    }
+    return `<span>${text}</span>`
+  }
+
+  createMarkup(markup) {
+    return {__html: markup}
+  }
 
   render() {
     const {show, delay} = this.state
@@ -109,7 +120,8 @@ class MoleculeNotification extends Component {
       position,
       showCloseButton,
       effect,
-      text
+      text,
+      children
     } = this.props
     const wrapperClassName = cx(
       `${CLASS} ${CLASS}--${type} ${CLASS}--${position}`,
@@ -129,9 +141,7 @@ class MoleculeNotification extends Component {
           <div className={`${CLASS}-iconLeft`}>
             <span className={`${CLASS}-icon`}>{icon || ICONS[type]}</span>
           </div>
-          <div className={`${CLASS}-text`}>
-            <span>{text}</span>
-          </div>
+          <div className={`${CLASS}-text`}>{text || children}</div>
           {showCloseButton && (
             <div className={`${CLASS}-iconClose`} onClick={this.toggleShow}>
               <span className={`${CLASS}-icon`}>
@@ -160,6 +170,10 @@ MoleculeNotification.propTypes = {
    */
   buttons: PropTypes.array,
   /**
+   * Content to be printed. Alternatively you can use "text" prop
+   */
+  children: PropTypes.node,
+  /**
    * Transition enabled
    */
   effect: PropTypes.bool,
@@ -180,7 +194,7 @@ MoleculeNotification.propTypes = {
    */
   showCloseButton: PropTypes.bool,
   /**
-   * Content text
+   * Content text. Alternatively you can use "children" prop
    */
   text: PropTypes.string,
   /**

--- a/components/molecule/notification/src/index.scss
+++ b/components/molecule/notification/src/index.scss
@@ -12,6 +12,7 @@
     padding: $p-l;
   }
 
+  &-children,
   &-text {
     flex: 1 1 auto;
     font-size: $fz-m;

--- a/demo/molecule/notification/playground
+++ b/demo/molecule/notification/playground
@@ -11,7 +11,7 @@ const BUTTONS = [
   }
 ]
 
-const TEXT = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis vitae orci consectetur, suscipit ligula vel.'
+const TEXT = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis vitae orci consectetur ligula vel.'
 
 function logClose () {
 	console.log('Closed!')
@@ -40,14 +40,14 @@ class PositionNotification extends React.Component {
 
     return(
       <div>
-        <button 
-          className={'sui-AtomButton sui-AtomButton--secondary'} 
+        <button
+          className={'sui-AtomButton sui-AtomButton--secondary'}
           onClick={this.toggleShow}
           style={{ width: '100px' }}
         >
           { show ? 'Hide' : 'Show' }
         </button>
-        <MoleculeNotification 
+        <MoleculeNotification
           text={TEXT}
           buttons={BUTTONS}
           position={this.props.position}
@@ -72,14 +72,14 @@ return (
     />
     <Title>Success</Title>
     <MoleculeNotification
-      autoClose='manual' 
+      autoClose='manual'
       text={TEXT}
       type='success'
       buttons={BUTTONS}
       onClose={logClose}
     />
     <Title>Warning</Title>
-    <MoleculeNotification 
+    <MoleculeNotification
       autoClose='manual'
       text={TEXT}
       type='warning'
@@ -87,7 +87,7 @@ return (
       onClose={logClose}
     />
     <Title>Error</Title>
-    <MoleculeNotification 
+    <MoleculeNotification
       autoClose='manual'
       text={TEXT}
       type='error'
@@ -102,6 +102,15 @@ return (
       buttons={BUTTONS}
       onClose={logClose}
     />
+    <br/>
+    <h2>With children content</h2>
+    <MoleculeNotification
+      autoClose='manual'
+      type='info'
+      onClose={logClose}
+    >
+      <span>Lorem ipsum dolor sit amet, <a href="#">consectetur adipiscing</a> elit. Duis vitae orci consectetur ligula vel.</span>
+    </MoleculeNotification>
     <br/>
     <h2>AutoClose</h2>
     <Title>Short</Title>
@@ -128,15 +137,15 @@ return (
     <h2>Positions</h2>
     <table width="auto" cellPadding="8" cellSpacing="0" style={{padding: 15}}>
       <tbody>
-        <tr> 
+        <tr>
           <td><Title>Top</Title></td>
           <td><PositionNotification position='top' /></td>
         </tr>
-        <tr> 
+        <tr>
           <td><Title>Bottom</Title></td>
           <td><PositionNotification position='bottom' /></td>
         </tr>
-        <tr> 
+        <tr>
           <td style={{ verticalAlign: 'top', paddingTop: '20px' }}><Title>Relative</Title></td>
           <td><PositionNotification position='relative' /></td>
         </tr>


### PR DESCRIPTION
### Objective
Insert links in the notification content.

### Why
We need to reduce space used by this notification, so we decided to insert a link in the notification content, and do not use its default CTA buttons.

### How
Printing children if text prop does not exists, so this will not cause a major change.

### Example with CTA buttons
<img width="1392" alt="captura de pantalla 2018-11-08 a las 15 06 42" src="https://user-images.githubusercontent.com/886033/48207501-0e911980-e371-11e8-92ed-7f7d6a941b47.png">

### Example without CTA buttons and using children
![image](https://user-images.githubusercontent.com/886033/48249145-58721200-e3fa-11e8-9d04-63d5ebefc1aa.png)
