### PR TITLE
feat(molecule/notification): add new variation property for positive colors

### DIFF
--- a/components/molecule/notification/src/index.js
+++ b/components/molecule/notification/src/index.js
@@ -28,6 +28,11 @@ const AUTO_CLOSE_TIME = {
 const TRANSITION_DELAY = 1000 // ms
 const BUTTONS_MAX = 3 // buttons
 
+const VARIATIONS = {
+  negative: 'negatvie',
+  positive: 'positive'
+}
+
 class MoleculeNotification extends Component {
   state = {
     show: this.props.show,
@@ -116,7 +121,7 @@ class MoleculeNotification extends Component {
     const wrapperClassName = cx(
       `${CLASS} ${CLASS}--${type} ${CLASS}--${position}`,
       {
-        [`${CLASS}--${variation}`]: variation === 'positive',
+        [`${CLASS}--${variation}`]: variation === VARIATIONS.positive,
         [`${CLASS}-effect--${position}`]: effect,
         [`${CLASS}-effect--hide`]: effect && delay
       }
@@ -203,7 +208,7 @@ MoleculeNotification.propTypes = {
   /**
    * Color variation of the notification: 'positive' with washed out colors, 'negative' with bold colors
    */
-  variation: PropTypes.string
+  variation: PropTypes.oneOf(Object.keys(VARIATIONS))
 }
 
 MoleculeNotification.defaultProps = {

--- a/components/molecule/notification/src/index.js
+++ b/components/molecule/notification/src/index.js
@@ -103,18 +103,20 @@ class MoleculeNotification extends Component {
   render() {
     const {show, delay} = this.state
     const {
-      type,
       buttons,
+      children,
+      effect,
       icon,
       position,
       showCloseButton,
-      effect,
       text,
-      children
+      type,
+      variation
     } = this.props
     const wrapperClassName = cx(
       `${CLASS} ${CLASS}--${type} ${CLASS}--${position}`,
       {
+        [`${CLASS}--${variation}`]: variation === 'positive',
         [`${CLASS}-effect--${position}`]: effect,
         [`${CLASS}-effect--hide`]: effect && delay
       }
@@ -175,6 +177,10 @@ MoleculeNotification.propTypes = {
    */
   icon: PropTypes.node,
   /**
+   * On close callback
+   */
+  onClose: PropTypes.func,
+  /**
    * Positions: 'top', 'bottom', 'relative'
    */
   position: PropTypes.string,
@@ -195,9 +201,9 @@ MoleculeNotification.propTypes = {
    */
   type: PropTypes.string,
   /**
-   * On close callback
+   * Color variation of the notification: 'positive' with washed out colors, 'negative' with bold colors
    */
-  onClose: PropTypes.func
+  variation: PropTypes.string
 }
 
 MoleculeNotification.defaultProps = {
@@ -207,7 +213,8 @@ MoleculeNotification.defaultProps = {
   position: 'relative',
   show: true,
   showCloseButton: true,
-  type: 'info'
+  type: 'info',
+  variation: 'negative'
 }
 
 export default MoleculeNotification

--- a/components/molecule/notification/src/index.js
+++ b/components/molecule/notification/src/index.js
@@ -29,7 +29,7 @@ const TRANSITION_DELAY = 1000 // ms
 const BUTTONS_MAX = 3 // buttons
 
 const VARIATIONS = {
-  negative: 'negatvie',
+  negative: 'negative',
   positive: 'positive'
 }
 
@@ -219,7 +219,7 @@ MoleculeNotification.defaultProps = {
   show: true,
   showCloseButton: true,
   type: 'info',
-  variation: 'negative'
+  variation: VARIATIONS.negative
 }
 
 export default MoleculeNotification

--- a/components/molecule/notification/src/index.scss
+++ b/components/molecule/notification/src/index.scss
@@ -2,7 +2,9 @@
 @import '~@schibstedspain/sui-atom-button/lib/index';
 @import './settings';
 
-.sui-MoleculeNotification {
+$base-class: '.sui-MoleculeNotification';
+
+#{$base-class} {
   color: $c-white;
   max-height: $mh-notification;
 
@@ -49,15 +51,29 @@
   }
 
   // Type
-
   @each $key, $value in $notification-type-colors {
     &--#{$key} {
       background-color: #{$value};
     }
   }
 
-  // Position
+  // Variation
+  &--positive {
+    color: $c-black;
 
+    #{$base-class}-icon svg {
+      fill: $c-gray !important;
+    }
+
+    // Type variations
+    @each $key, $value in $notification-type-colors {
+      &#{$base-class}--#{$key} {
+        background-color: color-variation($value, $c-light-step * 2);
+      }
+    }
+  }
+
+  // Position
   &--relative {
     position: relative;
   }

--- a/demo/molecule/notification/playground
+++ b/demo/molecule/notification/playground
@@ -11,14 +11,19 @@ const BUTTONS = [
   }
 ]
 
-const TEXT = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis vitae orci consectetur ligula vel.'
+const TEXT =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis vitae orci consectetur ligula vel.'
 
-function logClose () {
-	console.log('Closed!')
+function logClose() {
+  console.log('Closed!')
 }
 
-function Title ({children}) {
-  return <p style={{color: '#999', fontSize: 12, textTransform: 'uppercase'}}>{children}</p>
+function Title({children}) {
+  return (
+    <p style={{color: '#999', fontSize: 12, textTransform: 'uppercase'}}>
+      {children}
+    </p>
+  )
 }
 
 class PositionNotification extends React.Component {
@@ -28,24 +33,24 @@ class PositionNotification extends React.Component {
 
   toggleShow = () => {
     const show = !this.state.show
-    this.setState({ show })
+    this.setState({show})
   }
 
   handleClose = () => {
-    this.setState({ show: false })
+    this.setState({show: false})
   }
 
-  render () {
-    const { show } = this.state
+  render() {
+    const {show} = this.state
 
-    return(
+    return (
       <div>
         <button
-          className={'sui-AtomButton sui-AtomButton--secondary'}
+          className="sui-AtomButton sui-AtomButton--secondary"
           onClick={this.toggleShow}
-          style={{ width: '100px' }}
+          style={{width: '100px'}}
         >
-          { show ? 'Hide' : 'Show' }
+          {show ? 'Hide' : 'Show'}
         </button>
         <MoleculeNotification
           text={TEXT}
@@ -59,95 +64,84 @@ class PositionNotification extends React.Component {
   }
 }
 
+const TYPES = ['info', 'success', 'warning', 'error', 'system']
+const VARIATIONS = ['positive', 'negative']
+
 return (
   <div>
     <h1>Notification</h1>
-    <h2>Types</h2>
-    <Title>Info</Title>
-    <MoleculeNotification
-      autoClose={'manual'}
-      text={TEXT}
-      buttons={BUTTONS}
-      onClose={logClose}
-    />
-    <Title>Success</Title>
-    <MoleculeNotification
-      autoClose='manual'
-      text={TEXT}
-      type='success'
-      buttons={BUTTONS}
-      onClose={logClose}
-    />
-    <Title>Warning</Title>
-    <MoleculeNotification
-      autoClose='manual'
-      text={TEXT}
-      type='warning'
-      buttons={BUTTONS}
-      onClose={logClose}
-    />
-    <Title>Error</Title>
-    <MoleculeNotification
-      autoClose='manual'
-      text={TEXT}
-      type='error'
-      buttons={BUTTONS}
-      onClose={logClose}
-    />
-    <Title>System</Title>
-    <MoleculeNotification
-      autoClose='manual'
-      text={TEXT}
-      type='system'
-      buttons={BUTTONS}
-      onClose={logClose}
-    />
-    <br/>
+    <h2>Types and variations</h2>
+    {TYPES.map(type =>
+      VARIATIONS.map(variation => (
+        <React.Fragment>
+          <Title>
+            Type: {type} - Variation: {variation}
+          </Title>
+          <MoleculeNotification
+            autoClose="manual"
+            buttons={BUTTONS}
+            onClose={logClose}
+            type={type}
+            variation={variation}
+          >
+            {TEXT}
+          </MoleculeNotification>
+        </React.Fragment>
+      ))
+    )}
+    <br />
     <h2>With children content</h2>
-    <MoleculeNotification
-      autoClose='manual'
-      type='info'
-      onClose={logClose}
-    >
-      <span>Lorem ipsum dolor sit amet, <a href="#">consectetur adipiscing</a> elit. Duis vitae orci consectetur ligula vel.</span>
+    <MoleculeNotification autoClose="manual" type="info" onClose={logClose}>
+      <span>
+        Lorem ipsum dolor sit amet, <a href="#">consectetur adipiscing</a> elit.
+        Duis vitae orci consectetur ligula vel.
+      </span>
     </MoleculeNotification>
-    <br/>
+    <br />
     <h2>AutoClose</h2>
     <Title>Short</Title>
-    <MoleculeNotification
-      text={TEXT}
-      buttons={BUTTONS}
-      onClose={logClose}
-    />
+    <MoleculeNotification text={TEXT} buttons={BUTTONS} onClose={logClose} />
     <Title>Medium</Title>
     <MoleculeNotification
-      autoClose='medium'
+      autoClose="medium"
       text={TEXT}
       buttons={BUTTONS}
       onClose={logClose}
     />
     <Title>Long</Title>
     <MoleculeNotification
-      autoClose='long'
+      autoClose="long"
       text={TEXT}
       buttons={BUTTONS}
       onClose={logClose}
     />
-    <br/>
+    <br />
     <h2>Positions</h2>
     <table width="auto" cellPadding="8" cellSpacing="0" style={{padding: 15}}>
       <tbody>
         <tr>
-          <td><Title>Top</Title></td>
-          <td><PositionNotification position='top' /></td>
+          <td>
+            <Title>Top</Title>
+          </td>
+          <td>
+            <PositionNotification position="top" />
+          </td>
         </tr>
         <tr>
-          <td><Title>Bottom</Title></td>
-          <td><PositionNotification position='bottom' /></td>
+          <td>
+            <Title>Bottom</Title>
+          </td>
+          <td>
+            <PositionNotification position="bottom" />
+          </td>
         </tr>
         <tr>
-          <td style={{ verticalAlign: 'top', paddingTop: '20px' }}><Title>Relative</Title></td>
-          <td><PositionNotification position='relative' /></td>
+          <td style={{verticalAlign: 'top', paddingTop: '20px'}}>
+            <Title>Relative</Title>
+          </td>
+          <td>
+            <PositionNotification position="relative" />
+          </td>
         </tr>
       </tbody>
     </table>

--- a/demo/molecule/notification/playground
+++ b/demo/molecule/notification/playground
@@ -1,15 +1,17 @@
-const BUTTONS = [
-  {
-    type: 'secondary',
-    children: 'Secondary',
-    negative: true
-  },
-  {
-    type: 'primary',
-    children: 'Primary',
-    negative: true
-  }
-]
+function getButtons(variation = 'negative') {
+  return [
+    {
+      type: variation === 'positive' ? 'primary' : 'secondary',
+      children: 'Secondary',
+      negative: true
+    },
+    {
+      type: variation === 'positive' ? 'primary' : 'secondary',
+      children: 'Primary',
+      negative: true
+    }
+  ]
+}
 
 const TEXT =
   'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis vitae orci consectetur ligula vel.'
@@ -53,12 +55,13 @@ class PositionNotification extends React.Component {
           {show ? 'Hide' : 'Show'}
         </button>
         <MoleculeNotification
-          text={TEXT}
-          buttons={BUTTONS}
+          buttons={getButtons()}
           position={this.props.position}
           show={show}
           onClose={this.handleClose}
-        />
+        >
+          {TEXT}
+        </MoleculeNotification>
       </div>
     )
   }
@@ -73,13 +76,13 @@ return (
     <h2>Types and variations</h2>
     {TYPES.map(type =>
       VARIATIONS.map(variation => (
-        <React.Fragment>
+        <React.Fragment key={type + variation}>
           <Title>
             Type: {type} - Variation: {variation}
           </Title>
           <MoleculeNotification
             autoClose="manual"
-            buttons={BUTTONS}
+            buttons={getButtons(variation)}
             onClose={logClose}
             type={type}
             variation={variation}
@@ -100,21 +103,25 @@ return (
     <br />
     <h2>AutoClose</h2>
     <Title>Short</Title>
-    <MoleculeNotification text={TEXT} buttons={BUTTONS} onClose={logClose} />
+    <MoleculeNotification buttons={getButtons()} onClose={logClose}>
+      {TEXT}
+    </MoleculeNotification>
     <Title>Medium</Title>
     <MoleculeNotification
       autoClose="medium"
-      text={TEXT}
-      buttons={BUTTONS}
+      buttons={getButtons()}
       onClose={logClose}
-    />
+    >
+      {TEXT}
+    </MoleculeNotification>
     <Title>Long</Title>
     <MoleculeNotification
       autoClose="long"
-      text={TEXT}
-      buttons={BUTTONS}
+      buttons={getButtons()}
       onClose={logClose}
-    />
+    >
+      {TEXT}
+    </MoleculeNotification>
     <br />
     <h2>Positions</h2>
     <table width="auto" cellPadding="8" cellSpacing="0" style={{padding: 15}}>


### PR DESCRIPTION
**This PR implements version 2.1 for Molecule Notification.**

Create new prop `variation` to add positive colors to the types. So now you could have negative (bold colors) by default, and a positive one with colors washed out.

It keeps compatibility with the previous version as the default prop for `variation` is `negative`.

👀 [Demo](https://sui-components-pr-molecule-notification-2-1.now.sh/workbench/molecule/notification/demo)
🎨   [Paper](https://paper.dropbox.com/doc/SUI-Notifications-nM2P1iTfKFUlPZ3GPGUoI)

![image](https://user-images.githubusercontent.com/1561955/48543016-dcc40980-e8c0-11e8-8284-d1493b0cdabc.png)
