### PR TITLE
feat(atom/input): read only prop

### DIFF
--- a/components/atom/input/src/Input/Component/index.js
+++ b/components/atom/input/src/Input/Component/index.js
@@ -35,13 +35,14 @@ class Input extends Component {
     return ''
   }
 
-  getClassNames({size, charsSize, hideInput, noBorder, errorState}) {
+  getClassNames({size, charsSize, hideInput, noBorder, readOnly, errorState}) {
     return cx(
       BASE_CLASS,
       `${BASE_CLASS}-${size}`,
       charsSize && `${BASE_CLASS}--size`,
       hideInput && `${BASE_CLASS}--hidden`,
       noBorder && `${BASE_CLASS}--noBorder`,
+      readOnly && `${BASE_CLASS}--readOnly`,
       this.getErrorStateClass(errorState)
     )
   }
@@ -50,6 +51,7 @@ class Input extends Component {
     const {
       checked,
       disabled,
+      readOnly,
       hideInput,
       noBorder,
       id,
@@ -72,10 +74,11 @@ class Input extends Component {
           charsSize,
           hideInput,
           noBorder,
+          readOnly,
           errorState
         })}
         checked={checked}
-        disabled={disabled}
+        disabled={disabled || readOnly}
         id={id}
         name={name}
         onChange={this.changeHandler}
@@ -95,6 +98,8 @@ class Input extends Component {
 Input.propTypes = {
   /* This Boolean attribute prevents the user from interacting with the input */
   disabled: PropTypes.bool,
+  /* This Boolean attribute prevents the user from interacting with the input but without disabled styles */
+  readOnly: PropTypes.bool,
   /* Mark the input as selected */
   checked: PropTypes.bool,
   /* The DOM id global attribute. */

--- a/components/atom/input/src/Input/Component/index.scss
+++ b/components/atom/input/src/Input/Component/index.scss
@@ -1,7 +1,10 @@
 @import 'placeholders';
 @import 'settings';
 
-.sui-AtomInput-input {
+$base-class: '.sui-AtomInput-input';
+$class-read-only: '#{$base-class}--readOnly';
+
+#{$base-class} {
   @extend %sui-atom-input-input;
 
   &--size {
@@ -35,7 +38,9 @@
   }
 
   &[disabled] {
-    background: $c-gray-lightest;
+    &:not(#{$class-read-only}) {
+      background: $c-gray-lightest;
+    }
 
     &[placeholder] {
       color: $c-gray-light;

--- a/demo/atom/input/playground
+++ b/demo/atom/input/playground
@@ -210,6 +210,10 @@ return (
       <AtomInput name="disabled" placeholder="Medium Disabled Input" disabled />
     </div>
     <div style={field}>
+      <h4>Read Only</h4>
+      <AtomInput name="disabled" value="Medium Read Only Input" readOnly />
+    </div>
+    <div style={field}>
       <h4>Type: number</h4>
       <AtomInput type="number" name="number" placeholder="Number only input" charsSize={10}/>
     </div>


### PR DESCRIPTION
`readOnly` prop needed for components like `MoleculeSelect`

Online demo can be checked at → https://sui-components-feature-atom-input-read-only.now.sh/workbench/atom/input/demo