### PR TITLE
feat(molecule/inputField): update AtomInput version to v2

### DIFF
--- a/components/molecule/inputField/package.json
+++ b/components/molecule/inputField/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@s-ui/component-dependencies": "1",
-    "@s-ui/react-atom-input": "1",
+    "@s-ui/react-atom-input": "2",
     "@s-ui/react-molecule-field": "1"
   },
   "keywords": [],

--- a/components/molecule/inputField/src/index.js
+++ b/components/molecule/inputField/src/index.js
@@ -45,6 +45,9 @@ MoleculeInputField.propTypes = {
   /** Success message to display when success state  */
   successText: PropTypes.string,
 
+  /* onChange callback */
+  onChange: PropTypes.func,
+
   /** Error message to display when error state  */
   errorText: PropTypes.string,
 

--- a/demo/molecule/inputField/playground
+++ b/demo/molecule/inputField/playground
@@ -2,7 +2,7 @@ const withState = BaseComponent => {
   return class BaseComponentWithState extends React.Component {
     state = {value: this.props.value || ''}
 
-    onChange = ({value}) => {
+    onChange = (e, {value}) => {
       this.setState({value})
     }
 


### PR DESCRIPTION
feat(molecule/inputField): updated version AtomInput to v2 & updated demo

⚠ This change contain `BREAKING_CHANGES` so it will generate a `MAJOR` version as it provokes a change in the API of the event handlers  (`onChange` and so) caused by this update of the `AtomInput` version to v2

