### PR TITLE
feat(atom/image): add ref to img to ensure image complete loaded in SSR

### DIFF
--- a/components/atom/image/src/index.js
+++ b/components/atom/image/src/index.js
@@ -27,6 +27,8 @@ class AtomImage extends Component {
     error: false
   }
 
+  imageRef = React.createRef()
+
   get classNames() {
     const {loading, error} = this.state
     return cx(
@@ -60,6 +62,13 @@ class AtomImage extends Component {
     onError && onError()
   }
 
+  componentDidMount() {
+    const img = this.imageRef.current
+    if (img && img.complete && this.state.loading) {
+      this.handleLoad()
+    }
+  }
+
   render() {
     const {
       placeholder,
@@ -89,6 +98,7 @@ class AtomImage extends Component {
             className={CLASS_IMAGE}
             onLoad={this.handleLoad}
             onError={this.handleError}
+            ref={this.imageRef}
             {...imgProps}
           />
         </figure>


### PR DESCRIPTION
The component `atom/image` is not fully compatible with SSR, because there is a problem when the images are loaded before the react app is fully loaded and the SSR plain HTML is hydrated.

The problem is better explained in the following link:
https://stackoverflow.com/questions/39777833/image-onload-event-in-isomorphic-universal-react-register-event-after-image-is

In order to solve this, I have implemented a fix using a ref in the image to check in its componentDidMount method whether the image has already been loaded before the component is "alive" (in order to trigger manually the `handleLoad` method), or if image is still loading and then it will work as expected handling it in the img onLoad event handler.
