### PR TITLE
feat(atom/tag): normalize form of icons passed via props according to agreement

### DIFF
--- a/components/atom/tag/src/Actionable/index.js
+++ b/components/atom/tag/src/Actionable/index.js
@@ -11,7 +11,7 @@ const getClassNames = function({className}) {
 }
 
 const ActionableTag = function({
-  icon: Icon,
+  icon,
   href,
   iconPlacement,
   label,
@@ -28,20 +28,16 @@ const ActionableTag = function({
       href={href}
       target={target}
     >
-      {Icon &&
+      {icon &&
         iconPlacement === LEFT_ICON_PLACEMENT && (
-          <span className="sui-AtomTag-icon">
-            <Icon />
-          </span>
+          <span className="sui-AtomTag-icon">{icon}</span>
         )}
       <span className="sui-AtomTag-label" title={label}>
         {label}
       </span>
-      {Icon &&
+      {icon &&
         iconPlacement === RIGHT_ICON_PLACEMENT && (
-          <span className="sui-AtomTag-secondary-icon">
-            <Icon />
-          </span>
+          <span className="sui-AtomTag-secondary-icon">{icon}</span>
         )}
     </ActionableTagContainer>
   )

--- a/components/atom/tag/src/Actionable/index.js
+++ b/components/atom/tag/src/Actionable/index.js
@@ -11,7 +11,7 @@ const getClassNames = function({className}) {
 }
 
 const ActionableTag = function({
-  icon,
+  icon: Icon,
   href,
   iconPlacement,
   label,
@@ -28,16 +28,20 @@ const ActionableTag = function({
       href={href}
       target={target}
     >
-      {icon &&
+      {Icon &&
         iconPlacement === LEFT_ICON_PLACEMENT && (
-          <span className="sui-AtomTag-icon">{icon}</span>
+          <span className="sui-AtomTag-icon">
+            <Icon />
+          </span>
         )}
       <span className="sui-AtomTag-label" title={label}>
         {label}
       </span>
-      {icon &&
+      {Icon &&
         iconPlacement === RIGHT_ICON_PLACEMENT && (
-          <span className="sui-AtomTag-secondary-icon">{icon}</span>
+          <span className="sui-AtomTag-secondary-icon">
+            <Icon />
+          </span>
         )}
     </ActionableTagContainer>
   )
@@ -46,7 +50,7 @@ const ActionableTag = function({
 ActionableTag.propTypes = {
   className: PropTypes.string,
   label: PropTypes.string.isRequired,
-  icon: PropTypes.node,
+  icon: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   href: PropTypes.string,
   iconPlacement: PropTypes.oneOf([LEFT_ICON_PLACEMENT, RIGHT_ICON_PLACEMENT]),
   onClick: PropTypes.func,

--- a/components/atom/tag/src/Actionable/index.js
+++ b/components/atom/tag/src/Actionable/index.js
@@ -46,7 +46,7 @@ const ActionableTag = function({
 ActionableTag.propTypes = {
   className: PropTypes.string,
   label: PropTypes.string.isRequired,
-  icon: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+  icon: PropTypes.node,
   href: PropTypes.string,
   iconPlacement: PropTypes.oneOf([LEFT_ICON_PLACEMENT, RIGHT_ICON_PLACEMENT]),
   onClick: PropTypes.func,

--- a/components/atom/tag/src/Standard.js
+++ b/components/atom/tag/src/Standard.js
@@ -8,9 +8,15 @@ class StandardTag extends Component {
     return cx(className, closeIcon && 'sui-AtomTag-hasClose')
   }
 
-  render() {
-    const {closeIcon: CloseIcon, icon: Icon, label, onClose} = this.props
+  handleClick = ev => {
+    const {onClose} = this.props
+    onClose(ev)
+    ev.stopPropagation()
+  }
 
+  render() {
+    const {closeIcon: CloseIcon, icon: Icon, label} = this.props
+    const {handleClick} = this
     return (
       <span className={this._classNames}>
         {Icon && (
@@ -21,10 +27,10 @@ class StandardTag extends Component {
         <span className="sui-AtomTag-label" title={label}>
           {label}
         </span>
-        {onClose && (
+        {CloseIcon && (
           <span
             className="sui-AtomTag-secondary-closeable sui-AtomTag-secondary-icon"
-            onClick={ev => onClose(ev)}
+            onClick={handleClick}
           >
             <CloseIcon />
           </span>
@@ -40,6 +46,10 @@ StandardTag.propTypes = {
   icon: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   label: PropTypes.string.isRequired,
   className: PropTypes.string
+}
+
+StandardTag.propTypes = {
+  onClose: () => {}
 }
 
 export default StandardTag

--- a/components/atom/tag/src/Standard.js
+++ b/components/atom/tag/src/Standard.js
@@ -9,11 +9,15 @@ class StandardTag extends Component {
   }
 
   render() {
-    const {closeIcon, icon, label, onClose} = this.props
+    const {closeIcon: CloseIcon, icon: Icon, label, onClose} = this.props
 
     return (
       <span className={this._classNames}>
-        {icon && <span className="sui-AtomTag-icon">{icon}</span>}
+        {Icon && (
+          <span className="sui-AtomTag-icon">
+            <Icon />
+          </span>
+        )}
         <span className="sui-AtomTag-label" title={label}>
           {label}
         </span>
@@ -22,7 +26,7 @@ class StandardTag extends Component {
             className="sui-AtomTag-secondary-closeable sui-AtomTag-secondary-icon"
             onClick={ev => onClose(ev)}
           >
-            {closeIcon}
+            <CloseIcon />
           </span>
         )}
       </span>
@@ -32,8 +36,8 @@ class StandardTag extends Component {
 
 StandardTag.propTypes = {
   onClose: PropTypes.func,
-  closeIcon: PropTypes.node,
-  icon: PropTypes.node,
+  closeIcon: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+  icon: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   label: PropTypes.string.isRequired,
   className: PropTypes.string
 }

--- a/components/atom/tag/src/Standard.js
+++ b/components/atom/tag/src/Standard.js
@@ -38,8 +38,8 @@ class StandardTag extends Component {
 
 StandardTag.propTypes = {
   onClose: PropTypes.func,
-  closeIcon: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
-  icon: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+  closeIcon: PropTypes.node,
+  icon: PropTypes.node,
   label: PropTypes.string.isRequired,
   className: PropTypes.string
 }

--- a/components/atom/tag/src/Standard.js
+++ b/components/atom/tag/src/Standard.js
@@ -15,24 +15,20 @@ class StandardTag extends Component {
   }
 
   render() {
-    const {closeIcon: CloseIcon, icon: Icon, label} = this.props
+    const {closeIcon, icon, label} = this.props
     const {handleClick} = this
     return (
       <span className={this._classNames}>
-        {Icon && (
-          <span className="sui-AtomTag-icon">
-            <Icon />
-          </span>
-        )}
+        {icon && <span className="sui-AtomTag-icon">{icon}</span>}
         <span className="sui-AtomTag-label" title={label}>
           {label}
         </span>
-        {CloseIcon && (
+        {closeIcon && (
           <span
             className="sui-AtomTag-secondary-closeable sui-AtomTag-secondary-icon"
             onClick={handleClick}
           >
-            <CloseIcon />
+            {closeIcon}
           </span>
         )}
       </span>

--- a/components/atom/tag/src/index.js
+++ b/components/atom/tag/src/index.js
@@ -14,7 +14,7 @@ class AtomTag extends Component {
   static MAX_LABEL_LENGTH = 100
 
   /**
-   * @return {string}
+   * @return {string}w
    */
   get _classNames() {
     const {icon, size} = this.props
@@ -100,12 +100,12 @@ AtomTag.propTypes = {
    */
   className: PropTypes.string,
   label: PropTypes.string.isRequired,
-  icon: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+  icon: PropTypes.node,
   onClose: PropTypes.func,
   /**
    * Will only be shown if the onClose fn is defined
    */
-  closeIcon: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+  closeIcon: PropTypes.node,
   /**
    * If defined, onClose will be ignored
    */

--- a/components/atom/tag/src/index.js
+++ b/components/atom/tag/src/index.js
@@ -100,12 +100,12 @@ AtomTag.propTypes = {
    */
   className: PropTypes.string,
   label: PropTypes.string.isRequired,
-  icon: PropTypes.node,
+  icon: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   onClose: PropTypes.func,
   /**
    * Will only be shown if the onClose fn is defined
    */
-  closeIcon: PropTypes.node,
+  closeIcon: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   /**
    * If defined, onClose will be ignored
    */

--- a/components/atom/tag/src/index.scss
+++ b/components/atom/tag/src/index.scss
@@ -84,6 +84,9 @@ $p-atom-tag-s: 0 $p-m !default;
     &:hover,
     &:active {
       background-color: $c-primary-dark;
+      color: $c-atom-tag-actionable;
+      cursor: pointer;
+      fill: $c-atom-tag-actionable;
     }
   }
 

--- a/demo/atom/tag/playground
+++ b/demo/atom/tag/playground
@@ -1,10 +1,10 @@
-const icon = () => (
+const Icon = () => (
   <svg viewBox="0 0 24 24">
     <path d="M17.25 2.83V2.5a.75.75 0 1 0-1.5 0v.25h-7.5V2.5a.75.75 0 0 0-1.5 0v.33a4.73 4.73 0 0 0-4 4.67v9a4.76 4.76 0 0 0 4.75 4.75h9a4.76 4.76 0 0 0 4.75-4.75v-9a4.73 4.73 0 0 0-4-4.67zm2.5 6.42v7.25a3.25 3.25 0 0 1-3.25 3.25h-9a3.25 3.25 0 0 1-3.25-3.25V9.25h15.5zm0-1.75v.25H4.25V7.5A3.25 3.25 0 0 1 7.5 4.25h9a3.25 3.25 0 0 1 3.25 3.25zM14.5 18.25a2.75 2.75 0 0 1-2.75-2.75v-1a2.75 2.75 0 0 1 2.75-2.75h1a2.75 2.75 0 0 1 2.75 2.75v1a2.75 2.75 0 0 1-2.75 2.75h-1zm-1.25-3.75v1a1.25 1.25 0 0 0 1.25 1.25h1c.69 0 1.25-.56 1.25-1.25v-1c0-.69-.56-1.25-1.25-1.25h-1c-.69 0-1.25.56-1.25 1.25z" />
   </svg>
 )
 
-const closeIcon = () => (
+const CloseIcon = () => (
   <svg viewBox="0 0 24 24">
     <path
       id="a"
@@ -21,30 +21,30 @@ return (
       <AtomTag
         label="Close Tag"
         onClose={() => alert('close!')}
-        closeIcon={closeIcon}
+        closeIcon={<CloseIcon />}
       />
-      <AtomTag label="Icon Tag" icon={icon} />
+      <AtomTag label="Icon Tag" icon={<Icon />} />
       <AtomTag
         label="Icon & Close Tag"
-        icon={icon}
+        icon={<Icon />}
         onClose={() => alert('close!')}
-        closeIcon={closeIcon}
+        closeIcon={<CloseIcon />}
       />
       <AtomTag label="Maximum Tag Width. Truncated text, without close nor icon" />
       <AtomTag
         label="Maximum Tag Width. Truncated text, no icon, close"
         onClose={() => alert('close!')}
-        closeIcon={closeIcon}
+        closeIcon={<CloseIcon />}
       />
       <AtomTag
         label="Maximum Tag Width. Truncated text, icon, no close"
-        icon={icon}
+        icon={<Icon />}
       />
       <AtomTag
         label="Maximum Tag Width. Truncated text, with icon and close"
-        icon={icon}
+        icon={<Icon />}
         onClose={() => alert('close!')}
-        closeIcon={closeIcon}
+        closeIcon={<CloseIcon />}
       />
       <AtomTag label="101 char length, truncated to 100 char890123456789012345678901234567890123456789012345678901234567890" />
     </p>
@@ -55,15 +55,15 @@ return (
       <AtomTag
         label="Close Tag"
         onClose={() => alert('close!')}
-        closeIcon={closeIcon}
+        closeIcon={<CloseIcon />}
         size={atomTagSizes.SMALL}
       />
-      <AtomTag label="Icon Tag" icon={icon} size={atomTagSizes.SMALL} />
+      <AtomTag label="Icon Tag" icon={<Icon />} size={atomTagSizes.SMALL} />
       <AtomTag
         label="Icon & Close Tag"
-        icon={icon}
+        icon={<Icon />}
         onClose={() => alert('close!')}
-        closeIcon={closeIcon}
+        closeIcon={<CloseIcon />}
         size={atomTagSizes.SMALL}
       />
       <AtomTag
@@ -73,19 +73,19 @@ return (
       <AtomTag
         label="Maximum Tag Width. Truncated text, no icon, close"
         onClose={() => alert('close!')}
-        closeIcon={closeIcon}
+        closeIcon={<CloseIcon />}
         size={atomTagSizes.SMALL}
       />
       <AtomTag
         label="Maximum Tag Width. Truncated text, icon, no close"
-        icon={icon}
+        icon={<Icon />}
         size={atomTagSizes.SMALL}
       />
       <AtomTag
         label="Maximum Tag Width. Truncated text, with icon and close"
-        icon={icon}
+        icon={<Icon />}
         onClose={() => alert('close!')}
-        closeIcon={closeIcon}
+        closeIcon={<CloseIcon />}
         size={atomTagSizes.SMALL}
       />
       <AtomTag
@@ -104,13 +104,13 @@ return (
       />
       <AtomTag
         iconPlacement="right"
-        icon={icon}
+        icon={<Icon />}
         label="Icon placement right"
         href="https://www.google.com"
         target="_blank"
       />
       <AtomTag
-        icon={icon}
+        icon={<Icon />}
         label="Icon placement left"
         href="https://www.google.com"
         target="_blank"

--- a/demo/atom/tag/playground
+++ b/demo/atom/tag/playground
@@ -1,12 +1,15 @@
-const icon = (
-  <svg viewBox='0 0 24 24'>
-    <path d='M17.25 2.83V2.5a.75.75 0 1 0-1.5 0v.25h-7.5V2.5a.75.75 0 0 0-1.5 0v.33a4.73 4.73 0 0 0-4 4.67v9a4.76 4.76 0 0 0 4.75 4.75h9a4.76 4.76 0 0 0 4.75-4.75v-9a4.73 4.73 0 0 0-4-4.67zm2.5 6.42v7.25a3.25 3.25 0 0 1-3.25 3.25h-9a3.25 3.25 0 0 1-3.25-3.25V9.25h15.5zm0-1.75v.25H4.25V7.5A3.25 3.25 0 0 1 7.5 4.25h9a3.25 3.25 0 0 1 3.25 3.25zM14.5 18.25a2.75 2.75 0 0 1-2.75-2.75v-1a2.75 2.75 0 0 1 2.75-2.75h1a2.75 2.75 0 0 1 2.75 2.75v1a2.75 2.75 0 0 1-2.75 2.75h-1zm-1.25-3.75v1a1.25 1.25 0 0 0 1.25 1.25h1c.69 0 1.25-.56 1.25-1.25v-1c0-.69-.56-1.25-1.25-1.25h-1c-.69 0-1.25.56-1.25 1.25z' />
+const icon = () => (
+  <svg viewBox="0 0 24 24">
+    <path d="M17.25 2.83V2.5a.75.75 0 1 0-1.5 0v.25h-7.5V2.5a.75.75 0 0 0-1.5 0v.33a4.73 4.73 0 0 0-4 4.67v9a4.76 4.76 0 0 0 4.75 4.75h9a4.76 4.76 0 0 0 4.75-4.75v-9a4.73 4.73 0 0 0-4-4.67zm2.5 6.42v7.25a3.25 3.25 0 0 1-3.25 3.25h-9a3.25 3.25 0 0 1-3.25-3.25V9.25h15.5zm0-1.75v.25H4.25V7.5A3.25 3.25 0 0 1 7.5 4.25h9a3.25 3.25 0 0 1 3.25 3.25zM14.5 18.25a2.75 2.75 0 0 1-2.75-2.75v-1a2.75 2.75 0 0 1 2.75-2.75h1a2.75 2.75 0 0 1 2.75 2.75v1a2.75 2.75 0 0 1-2.75 2.75h-1zm-1.25-3.75v1a1.25 1.25 0 0 0 1.25 1.25h1c.69 0 1.25-.56 1.25-1.25v-1c0-.69-.56-1.25-1.25-1.25h-1c-.69 0-1.25.56-1.25 1.25z" />
   </svg>
 )
 
-const closeIcon = (
-  <svg viewBox='0 0 24 24'>
-    <path id='a' d='M13.42 12l4.79-4.8a1 1 0 0 0-1.41-1.41L12 10.58 7.21 5.79A1 1 0 0 0 5.8 7.2l4.79 4.8-4.79 4.79a1 1 0 1 0 1.41 1.41L12 13.41l4.8 4.79a1 1 0 0 0 1.41-1.41L13.42 12z'/>
+const closeIcon = () => (
+  <svg viewBox="0 0 24 24">
+    <path
+      id="a"
+      d="M13.42 12l4.79-4.8a1 1 0 0 0-1.41-1.41L12 10.58 7.21 5.79A1 1 0 0 0 5.8 7.2l4.79 4.8-4.79 4.79a1 1 0 1 0 1.41 1.41L12 13.41l4.8 4.79a1 1 0 0 0 1.41-1.41L13.42 12z"
+    />
   </svg>
 )
 
@@ -14,35 +17,104 @@ return (
   <div style={{float: 'left'}}>
     <h2>Standard Tags</h2>
     <p>
-      <AtomTag label='Tag Structure' /> <AtomTag label='Close Tag' onClose={() => alert('close!')} closeIcon={closeIcon} />
-      <AtomTag label='Icon Tag' icon={icon} />
-      <AtomTag label='Icon & Close Tag' icon={icon} onClose={() => alert('close!')} closeIcon={closeIcon} />
-      <AtomTag label='Maximum Tag Width. Truncated text, without close nor icon' />
-      <AtomTag label='Maximum Tag Width. Truncated text, no icon, close' onClose={() => alert('close!')} closeIcon={closeIcon} />
-      <AtomTag label='Maximum Tag Width. Truncated text, icon, no close' icon={icon} />
-      <AtomTag label='Maximum Tag Width. Truncated text, with icon and close' icon={icon} onClose={() => alert('close!')} closeIcon={closeIcon} />
-      <AtomTag label='101 char length, truncated to 100 char890123456789012345678901234567890123456789012345678901234567890' />
+      <AtomTag label="Tag Structure" />{' '}
+      <AtomTag
+        label="Close Tag"
+        onClose={() => alert('close!')}
+        closeIcon={closeIcon}
+      />
+      <AtomTag label="Icon Tag" icon={icon} />
+      <AtomTag
+        label="Icon & Close Tag"
+        icon={icon}
+        onClose={() => alert('close!')}
+        closeIcon={closeIcon}
+      />
+      <AtomTag label="Maximum Tag Width. Truncated text, without close nor icon" />
+      <AtomTag
+        label="Maximum Tag Width. Truncated text, no icon, close"
+        onClose={() => alert('close!')}
+        closeIcon={closeIcon}
+      />
+      <AtomTag
+        label="Maximum Tag Width. Truncated text, icon, no close"
+        icon={icon}
+      />
+      <AtomTag
+        label="Maximum Tag Width. Truncated text, with icon and close"
+        icon={icon}
+        onClose={() => alert('close!')}
+        closeIcon={closeIcon}
+      />
+      <AtomTag label="101 char length, truncated to 100 char890123456789012345678901234567890123456789012345678901234567890" />
     </p>
 
     <h2>Small Tags</h2>
     <p>
-      <AtomTag label='Tag Structure' size={atomTagSizes.SMALL} /> 
-      <AtomTag label='Close Tag' onClose={() => alert('close!')} closeIcon={closeIcon} size={atomTagSizes.SMALL} />
-      <AtomTag label='Icon Tag' icon={icon} size={atomTagSizes.SMALL}/>
-      <AtomTag label='Icon & Close Tag' icon={icon} onClose={() => alert('close!')} closeIcon={closeIcon} size={atomTagSizes.SMALL} />
-      <AtomTag label='Maximum Tag Width. Truncated text, without close nor icon' size={atomTagSizes.SMALL} />
-      <AtomTag label='Maximum Tag Width. Truncated text, no icon, close' onClose={() => alert('close!')} closeIcon={closeIcon} size={atomTagSizes.SMALL} />
-      <AtomTag label='Maximum Tag Width. Truncated text, icon, no close' icon={icon} size={atomTagSizes.SMALL} />
-      <AtomTag label='Maximum Tag Width. Truncated text, with icon and close' icon={icon} onClose={() => alert('close!')} closeIcon={closeIcon} size={atomTagSizes.SMALL} />
-      <AtomTag label='101 char length, truncated to 100 char890123456789012345678901234567890123456789012345678901234567890' size={atomTagSizes.SMALL} />
+      <AtomTag label="Tag Structure" size={atomTagSizes.SMALL} />
+      <AtomTag
+        label="Close Tag"
+        onClose={() => alert('close!')}
+        closeIcon={closeIcon}
+        size={atomTagSizes.SMALL}
+      />
+      <AtomTag label="Icon Tag" icon={icon} size={atomTagSizes.SMALL} />
+      <AtomTag
+        label="Icon & Close Tag"
+        icon={icon}
+        onClose={() => alert('close!')}
+        closeIcon={closeIcon}
+        size={atomTagSizes.SMALL}
+      />
+      <AtomTag
+        label="Maximum Tag Width. Truncated text, without close nor icon"
+        size={atomTagSizes.SMALL}
+      />
+      <AtomTag
+        label="Maximum Tag Width. Truncated text, no icon, close"
+        onClose={() => alert('close!')}
+        closeIcon={closeIcon}
+        size={atomTagSizes.SMALL}
+      />
+      <AtomTag
+        label="Maximum Tag Width. Truncated text, icon, no close"
+        icon={icon}
+        size={atomTagSizes.SMALL}
+      />
+      <AtomTag
+        label="Maximum Tag Width. Truncated text, with icon and close"
+        icon={icon}
+        onClose={() => alert('close!')}
+        closeIcon={closeIcon}
+        size={atomTagSizes.SMALL}
+      />
+      <AtomTag
+        label="101 char length, truncated to 100 char890123456789012345678901234567890123456789012345678901234567890"
+        size={atomTagSizes.SMALL}
+      />
     </p>
 
     <h2>Actionable Tag</h2>
     <p>
-      <AtomTag label='Navigation Tag' onClick={() => alert('click!')} />
-      <AtomTag label='Anchor Tag' href='https://www.google.com' target='_blank' />
-      <AtomTag iconPlacement='right' icon={icon} label='Icon placement right' href='https://www.google.com' target='_blank' />
-      <AtomTag icon={icon} label='Icon placement left' href='https://www.google.com' target='_blank' />
+      <AtomTag label="Navigation Tag" onClick={() => alert('click!')} />
+      <AtomTag
+        label="Anchor Tag"
+        href="https://www.google.com"
+        target="_blank"
+      />
+      <AtomTag
+        iconPlacement="right"
+        icon={icon}
+        label="Icon placement right"
+        href="https://www.google.com"
+        target="_blank"
+      />
+      <AtomTag
+        icon={icon}
+        label="Icon placement left"
+        href="https://www.google.com"
+        target="_blank"
+      />
     </p>
   </div>
 )


### PR DESCRIPTION
Normalize way of passing icons to the component according to https://github.schibsted.io/scmspain/frontend-all-wiki/pull/48

Also added stopPropagation on `onClose` event

BREAKING CHANGE:
icons passed as components

- 🌎 Online Demo → https://sui-components-atom-tag-icons.now.sh/workbench/atom/tag/demo