### PR TITLE
feat(molecule/inputTags): icons passed as components

### DIFF
--- a/components/molecule/inputTags/package.json
+++ b/components/molecule/inputTags/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@s-ui/component-dependencies": "1",
     "@s-ui/react-atom-input": "2",
-    "@schibstedspain/sui-atom-tag": "1"
+    "@schibstedspain/sui-atom-tag": "2"
   },
   "keywords": [],
   "author": "",

--- a/components/molecule/inputTags/src/index.js
+++ b/components/molecule/inputTags/src/index.js
@@ -94,7 +94,8 @@ MoleculeInputTags.displayName = 'MoleculeInputTags'
 
 MoleculeInputTags.propTypes = {
   /* close icon to be displayed on tags */
-  tagsCloseIcon: PropTypes.node.isRequired,
+  tagsCloseIcon: PropTypes.oneOfType([PropTypes.node, PropTypes.func])
+    .isRequired,
 
   /* list of values displayed as tags */
   tags: PropTypes.array,

--- a/components/molecule/inputTags/src/index.js
+++ b/components/molecule/inputTags/src/index.js
@@ -94,8 +94,7 @@ MoleculeInputTags.displayName = 'MoleculeInputTags'
 
 MoleculeInputTags.propTypes = {
   /* close icon to be displayed on tags */
-  tagsCloseIcon: PropTypes.oneOfType([PropTypes.node, PropTypes.func])
-    .isRequired,
+  tagsCloseIcon: PropTypes.node.isRequired,
 
   /* list of values displayed as tags */
   tags: PropTypes.array,

--- a/demo/molecule/inputTags/playground
+++ b/demo/molecule/inputTags/playground
@@ -1,6 +1,6 @@
 const beatles = ['john', 'paul', 'george', 'ringo']
 
-const closeIcon = () => (
+const CloseIcon = () => (
   <svg viewBox="0 0 24 24">
     <path
       id="a"
@@ -71,7 +71,7 @@ return (
       <h4>Basic</h4>
       <MoleculeInputTagsWithState
         value="George Martin"
-        tagsCloseIcon={closeIcon}
+        tagsCloseIcon={ <CloseIcon /> }
         tags={[
           'John Lennon',
           'Paul McCartney',
@@ -87,7 +87,7 @@ return (
       <h4>Entering tags on "Tab" press</h4>
       <MoleculeInputTagsWithState
         value="George Martin"
-        tagsCloseIcon={closeIcon}
+        tagsCloseIcon={ <CloseIcon /> }
         tags={[
           'John Lennon',
           'Paul McCartney',
@@ -104,7 +104,7 @@ return (
       <h4>Entering tags on "comma" press</h4>
       <MoleculeInputTagsWithState
         value="George Martin"
-        tagsCloseIcon={closeIcon}
+        tagsCloseIcon={ <CloseIcon /> }
         tags={[
           'John Lennon',
           'Paul McCartney',
@@ -120,7 +120,7 @@ return (
     <div style={fieldStyles}>
       <h4>With size=SMALL</h4>
       <MoleculeInputTagsWithState
-        tagsCloseIcon={closeIcon}
+        tagsCloseIcon={ <CloseIcon /> }
         tags={['Robert Plant', 'Jimmy Page', 'John Paul Jones', 'John Bonham']}
         size={inputSizes.SMALL}
         onChangeTags={(_, {tags}) => {
@@ -131,7 +131,7 @@ return (
     <div style={fieldStyles}>
       <h4>With error</h4>
       <MoleculeInputTagsWithState
-        tagsCloseIcon={closeIcon}
+        tagsCloseIcon={ <CloseIcon /> }
         tags={['Brian May', 'Freddie Mercury', 'John Deacon', 'Roger Taylor']}
         errorState={true}
         onChangeTags={(_, {tags}) => {
@@ -142,7 +142,7 @@ return (
     <div style={fieldStyles}>
       <h4>With onChange handler</h4>
       <MoleculeInputTagsWithState
-        tagsCloseIcon={closeIcon}
+        tagsCloseIcon={ <CloseIcon /> }
         tags={['Brian May', 'Freddie Mercury', 'John Deacon', 'Roger Taylor']}
         onChangeTags={(_, {tags}) => {
           console.log(tags)

--- a/demo/molecule/inputTags/playground
+++ b/demo/molecule/inputTags/playground
@@ -1,6 +1,6 @@
 const beatles = ['john', 'paul', 'george', 'ringo']
 
-const closeIcon = (
+const closeIcon = () => (
   <svg viewBox="0 0 24 24">
     <path
       id="a"


### PR DESCRIPTION
Icons passed as components according to https://github.schibsted.io/scmspain/frontend-all-wiki/pull/48

🌎 Online demo → https://sui-components-molecule-input-tags-icons.now.sh/workbench/molecule/inputTags/demo

⚠️ BREAKING CHANGE:
icons passed as components

⚠️ This PR is fully dependant on https://github.com/SUI-Components/sui-components/pull/590 so when this PR is approved and merged, and `AtomTag` is published w/ the new version → this PR should be updated w/ the new version of `AtomTag`