### PR TITLE
feat(atom/input): normalize way of passing icons to components

### DIFF
--- a/components/atom/input/src/Input/Features/Icon/index.js
+++ b/components/atom/input/src/Input/Features/Icon/index.js
@@ -20,10 +20,10 @@ const IconHoC = WrappedInput =>
   class Icon extends React.Component {
     static propTypes = {
       /* Left icon component */
-      leftIcon: PropTypes.any,
+      leftIcon: PropTypes.node,
 
       /* Left icon component */
-      rightIcon: PropTypes.any,
+      rightIcon: PropTypes.node,
 
       /* Left icon click callback */
       onClickLeftIcon: PropTypes.func,
@@ -44,43 +44,38 @@ const IconHoC = WrappedInput =>
 
     render() {
       const {
-        leftIcon: LeftIcon,
-        rightIcon: RightIcon,
+        leftIcon,
+        rightIcon,
         onClickLeftIcon,
         onClickRightIcon,
         ...props
       } = this.props
-      return LeftIcon || RightIcon ? (
+      return leftIcon || rightIcon ? (
         <div
-          className={cx(
-            CLASS_ICON,
-            LeftIcon && CLASS_ICON_LEFT,
-            RightIcon && CLASS_ICON_RIGHT
-          )}
+          className={cx(CLASS_ICON, {
+            [CLASS_ICON_LEFT]: leftIcon,
+            [CLASS_ICON_RIGHT]: rightIcon
+          })}
         >
-          {LeftIcon && (
+          {leftIcon && (
             <span
-              className={cx(
-                CLASS_ICON_COMPONENT,
-                CLASS_ICON_COMPONENT_LEFT,
-                onClickLeftIcon && CLASS_ICON_COMPONENT_HANDLER
-              )}
+              className={cx(CLASS_ICON_COMPONENT, CLASS_ICON_COMPONENT_LEFT, {
+                [CLASS_ICON_COMPONENT_HANDLER]: onClickLeftIcon
+              })}
               onClick={this.handleLeftClick}
             >
-              <LeftIcon />
+              {leftIcon}
             </span>
           )}
           <WrappedInput {...props} />
-          {RightIcon && (
+          {rightIcon && (
             <span
-              className={cx(
-                CLASS_ICON_COMPONENT,
-                CLASS_ICON_COMPONENT_RIGHT,
-                onClickRightIcon && CLASS_ICON_COMPONENT_HANDLER
-              )}
+              className={cx(CLASS_ICON_COMPONENT, CLASS_ICON_COMPONENT_RIGHT, {
+                [CLASS_ICON_COMPONENT_HANDLER]: onClickRightIcon
+              })}
               onClick={this.handleRightClick}
             >
-              <RightIcon />
+              {rightIcon}
             </span>
           )}
         </div>

--- a/components/atom/input/src/index.js
+++ b/components/atom/input/src/index.js
@@ -40,10 +40,10 @@ AtomInput.propTypes = {
   rightAddon: PropTypes.any,
 
   /** Left Icon */
-  leftIcon: PropTypes.any,
+  leftIcon: PropTypes.node,
 
   /** Left Icon */
-  rightIcon: PropTypes.any,
+  rightIcon: PropTypes.node,
 
   /** Left icon click callback */
   onClickLeftIcon: PropTypes.func,

--- a/demo/atom/input/playground
+++ b/demo/atom/input/playground
@@ -195,7 +195,7 @@ const logoLocation = 'https://image.flaticon.com/icons/svg/67/67347.svg'
 const IconLocation = () => <img src={logoLocation} />
 
 return (
-  <div style={{ padding: '20px'}}>
+  <div style={{padding: '20px'}}>
     <div style={field}>
       <h4>Size SMALL</h4>
       <AtomInput
@@ -251,7 +251,7 @@ return (
       <AtomInput
         name="second"
         placeholder="Medium Input"
-        leftIcon={IconLocation}
+        leftIcon={<IconLocation />}
       />
     </div>
     <div style={field}>
@@ -259,7 +259,7 @@ return (
       <AtomInput
         name="second"
         placeholder="Medium Input"
-        leftIcon={IconLocation}
+        leftIcon={<IconLocation />}
         rightAddon="Location"
       />
     </div>
@@ -293,7 +293,7 @@ return (
       <AtomInput
         name="second"
         placeholder="Medium Input"
-        rightIcon={IconLocation}
+        rightIcon={<IconLocation />}
       />
     </div>
     <div style={field}>
@@ -302,7 +302,7 @@ return (
         name="second"
         placeholder="Medium Input"
         leftAddon="City"
-        rightIcon={IconLocation}
+        rightIcon={<IconLocation />}
       />
     </div>
     <div style={field}>
@@ -310,7 +310,7 @@ return (
       <AtomInput
         name="second"
         placeholder="Medium Input"
-        rightIcon={IconLocation}
+        rightIcon={<IconLocation />}
         onClickRightIcon={e => alert('clicked right icon')}
       />
     </div>


### PR DESCRIPTION
Normalize way fo passing icons to components according to WIKI agreement → https://github.schibsted.io/scmspain/frontend-all-wiki/wiki/Recommendations-components-development#how-to-work-with-icons

BREAKING CHANGE:
change of format for icons passed to the component