### PR TITLE
feat(molecule/dropdownOption): better handling for checkbox focus inside option

### DIFF
--- a/components/molecule/dropdownOption/src/index.js
+++ b/components/molecule/dropdownOption/src/index.js
@@ -58,6 +58,11 @@ const MoleculeDropdownOption = ({
     ev.stopPropagation()
   }
 
+  const handleInnerCheckboxFocus = ev => {
+    ev.preventDefault()
+    innerRef.current.focus()
+  }
+
   return (
     <div
       ref={innerRef}
@@ -68,7 +73,12 @@ const MoleculeDropdownOption = ({
       onFocus={handleFocus}
     >
       {checkbox && (
-        <AtomInput type="checkbox" checked={selected} disabled={disabled} />
+        <AtomInput
+          type="checkbox"
+          checked={selected}
+          disabled={disabled}
+          onFocus={handleInnerCheckboxFocus}
+        />
       )}
       {highlightQuery ? (
         <span
@@ -118,7 +128,8 @@ MoleculeDropdownOption.defaultProps = {
   disabled: false,
   onSelect: () => {},
   selected: false,
-  onSelectKey: 'Enter'
+  onSelectKey: 'Enter',
+  innerRef: React.createRef()
 }
 
 export default MoleculeDropdownOption


### PR DESCRIPTION
To simplify management of the focus in this component, any focus on the inner checkbox will be "translated" to the parent container so we only have to worry about the "focus" of the `MoleculeDropdownOption` and not the focus of any of its inner elements