### PR TITLE
Case sensitive issue with select ui

### DIFF
--- a/components/molecule/select/CHANGELOG.md
+++ b/components/molecule/select/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+

--- a/components/molecule/select/package.json
+++ b/components/molecule/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/react-molecule-select",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/components/molecule/select/src/components/MultipleSelection.js
+++ b/components/molecule/select/src/components/MultipleSelection.js
@@ -3,9 +3,9 @@ import React, {Fragment} from 'react'
 import MoleculeDropdownList from '@s-ui/react-molecule-dropdown-list'
 import MoleculeInputTags from '@s-ui/react-molecule-input-tags'
 
-import WithSelectUi from '../hoc/withSelectUi'
+import WithSelectUI from '../hoc/withSelectUI'
 
-const MoleculeInputSelect = WithSelectUi(MoleculeInputTags)
+const MoleculeInputSelect = WithSelectUI(MoleculeInputTags)
 
 const MoleculeSelectFieldMultiSelection = props => {
   /* eslint-disable react/prop-types */

--- a/components/molecule/select/src/components/SingleSelection.js
+++ b/components/molecule/select/src/components/SingleSelection.js
@@ -3,9 +3,9 @@ import React, {Fragment} from 'react'
 import MoleculeDropdownList from '@s-ui/react-molecule-dropdown-list'
 import AtomInput from '@s-ui/react-atom-input'
 
-import WithSelectUi from '../hoc/withSelectUi'
+import WithSelectUI from '../hoc/withSelectUI'
 
-const MoleculeInputSelect = WithSelectUi(AtomInput)
+const MoleculeInputSelect = WithSelectUI(AtomInput)
 
 const MoleculeSelectSingleSelection = props => {
   /* eslint-disable react/prop-types */

--- a/components/molecule/select/src/hoc/withSelectUI.js
+++ b/components/molecule/select/src/hoc/withSelectUI.js
@@ -9,8 +9,8 @@ const CLASS_ARROW_UP = `${CLASS_ARROW}--up`
 
 export default BaseComponent => {
   const displayName = BaseComponent.displayName
-  return class WithSelectUi extends Component {
-    static displayName = `WithSelectUi(${displayName})`
+  return class WithSelectUI extends Component {
+    static displayName = `WithSelectUI(${displayName})`
 
     get classNames() {
       const {isOpen} = this.props // eslint-disable-line react/prop-types


### PR DESCRIPTION
This issue was causing an error in Travis when deploying

```
Module not found: Error: Can't resolve '../hoc/withSelectUi' in '/home/travis/build/SUI-Components/sui-components/components/molecule/select/src/components'
resolve '../hoc/withSelectUi' in '/home/travis/build/SUI-Components/sui-components/components/molecule/select/src/components'
  using description file: /home/travis/build/SUI-Components/sui-components/components/molecule/select/package.json (relative path: ./src/components)
    Field 'browser' doesn't contain a valid alias configuration
    using description file: /home/travis/build/SUI-Components/sui-components/components/molecule/select/package.json (relative path: ./src/hoc/withSelectUi)
      no extension
```
