### PR TITLE
SUIC-106 fix(atom/input): fix min-height setting in atom input

### DIFF
--- a/components/atom/input/src/Input/Component/index.scss
+++ b/components/atom/input/src/Input/Component/index.scss
@@ -9,6 +9,7 @@ $class-read-only: '#{$base-class}--readOnly';
 
 #{$base-class} {
   @extend %sui-atom-input-input;
+  min-height: auto;
   border-radius: $bdrs-atom-input;
   
   &--size {
@@ -60,6 +61,7 @@ $class-read-only: '#{$base-class}--readOnly';
   @each $type, $attr in $sizes-atom-input {
     &-#{$type} {
       height: $attr;
+      min-height: $attr;
     }
   }
 

--- a/components/atom/input/src/Input/Component/index.scss
+++ b/components/atom/input/src/Input/Component/index.scss
@@ -9,8 +9,8 @@ $class-read-only: '#{$base-class}--readOnly';
 
 #{$base-class} {
   @extend %sui-atom-input-input;
-  min-height: auto;
   border-radius: $bdrs-atom-input;
+  min-height: auto;
   
   &--size {
     width: inherit;


### PR DESCRIPTION
This PR fixes a bug with the atom-input size ([https://jira.scmspain.com/browse/SUIC-106](https://jira.scmspain.com/browse/SUIC-106)) where the "small" size is not correctly applying its styles.

Although the best approach would have been modifying in SUI-theme the placeholder `%sui-atom-input-input` used, that would have been a breaking change, so I have opted for the more conservative approach of resetting the min-height for the component and declaring it for every size modifier.