### PR TITLE
feat(atom/image): prevent image padding

### DIFF
--- a/components/atom/image/src/index.scss
+++ b/components/atom/image/src/index.scss
@@ -45,6 +45,7 @@ $base-class: '.sui-AtomImage';
   }
 
   &-image {
+    display: block;
     height: 100%;
     object-fit: cover;
     width: 100%;


### PR DESCRIPTION
### Before set display: block
![image](https://user-images.githubusercontent.com/31726966/53815248-9541b600-3f61-11e9-8de4-6b8855617f33.png)
👆🏻👆🏻👆🏻👆🏻👆🏻👆🏻👆🏻👆🏻

### After set display: block
![image](https://user-images.githubusercontent.com/31726966/53814977-046ada80-3f61-11e9-9974-a20a90db9b08.png)

https://stackoverflow.com/questions/4760002/how-to-remove-image-padding-that-is-showing-up-unintentionally
