### PR TITLE
fix(molecule/modal): fix border radius for modal when header has no transparent background-color

### DIFF
--- a/components/molecule/modal/src/index.scss
+++ b/components/molecule/modal/src/index.scss
@@ -129,6 +129,8 @@ body.is-MoleculeModal-open {
     align-items: center;
     background-color: $bg-molecule-modal-header;
     border-bottom: $bd-molecule-modal-header;
+    border-top-left-radius: $bdrs-molecule-modal-dialog;
+    border-top-right-radius: $bdrs-molecule-modal-dialog;
     color: $c-molecule-modal-header;
     display: flex;
     flex: 0 0 auto;


### PR DESCRIPTION
There was no problem when header has a `background-color: transparent;`, but when is some specific color, `border-radius` from header was missing. I've added on header