### PR TITLE
feat(atom/card): add scss responsive behavior to atom card if receive…

### DIFF
--- a/components/atom/card/src/index.js
+++ b/components/atom/card/src/index.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
@@ -7,49 +7,53 @@ const CLASS_MEDIA = `${BASE_CLASS}-media`
 const CLASS_INFO = `${BASE_CLASS}-info`
 
 const CLASS_VERTICAL = `${BASE_CLASS}--vertical`
+const CLASS_RESPONSIVE = `${BASE_CLASS}--responsive`
 const CLASS_HIGHLIGHT = `${BASE_CLASS}--highlight`
 const CLASS_LINK = `${BASE_CLASS}-link`
 
-class AtomCard extends Component {
-  redirectToHref = () => {
+const AtomCard = ({
+  media: Media,
+  content: Content,
+  vertical,
+  responsive,
+  highlight,
+  href,
+  tabIndex
+}) => {
+  const redirectToHref = () => {
     const {href} = this.props
     if (href) window.location.href = href
   }
 
-  redirectOnEnter = e => {
-    if (e.key === 'Enter') this.redirectToHref()
+  const redirectOnEnter = e => {
+    if (e.key === 'Enter') redirectToHref()
   }
 
-  render() {
-    const {
-      media: Media,
-      content: Content,
-      vertical,
-      highlight,
-      href,
-      tabIndex
-    } = this.props
-    return (
-      <div
-        className={cx(
-          BASE_CLASS,
-          vertical && CLASS_VERTICAL,
-          highlight && CLASS_HIGHLIGHT,
-          href && CLASS_LINK
-        )}
-        tabIndex={tabIndex}
-        onClick={this.redirectToHref}
-        onKeyDown={this.redirectOnEnter}
-      >
-        <div className={CLASS_MEDIA}>
-          <Media />
-        </div>
-        <div className={CLASS_INFO}>
-          <Content />
-        </div>
+  const isVertical = vertical && !responsive
+
+  const classNames = cx(
+    BASE_CLASS,
+    isVertical && CLASS_VERTICAL,
+    responsive && CLASS_RESPONSIVE,
+    highlight && CLASS_HIGHLIGHT,
+    href && CLASS_LINK
+  )
+
+  return (
+    <div
+      className={classNames}
+      tabIndex={tabIndex}
+      onClick={redirectToHref}
+      onKeyDown={redirectOnEnter}
+    >
+      <div className={CLASS_MEDIA}>
+        <Media />
       </div>
-    )
-  }
+      <div className={CLASS_INFO}>
+        <Content />
+      </div>
+    </div>
+  )
 }
 
 AtomCard.displayName = 'AtomCard'
@@ -63,6 +67,9 @@ AtomCard.propTypes = {
 
   /** true for vertical layout */
   vertical: PropTypes.bool,
+
+  /** true for make responsive layout */
+  responsive: PropTypes.bool,
 
   /** true for highlight mode */
   highlight: PropTypes.bool,

--- a/components/atom/card/src/index.scss
+++ b/components/atom/card/src/index.scss
@@ -2,8 +2,12 @@
 
 $c-atom-card-highlight: $c-highlight !default;
 $w-atom-card-media: 33% !default;
+$mq-responsive-breakpoint-name: 'm' !default;
 
-.sui-AtomCard {
+$base-class: '.sui-AtomCard';
+$class-media: '#{$base-class}-media';
+
+#{$base-class} {
   display: flex;
 
   &-media {
@@ -27,10 +31,25 @@ $w-atom-card-media: 33% !default;
   &--vertical {
     flex-direction: column;
 
-    .sui-AtomCard-media {
+    #{$class-media} {
+      width: 100%;
+    }
+  }
+
+  &--responsive {
+    flex-direction: column;
+
+    #{$class-media} {
       width: 100%;
     }
 
+    @include media-breakpoint-up($mq-responsive-breakpoint-name) {
+      flex-direction: row;
+
+      #{$class-media} {
+        width: $w-atom-card-media;
+      }
+    }
   }
 
 }

--- a/demo/atom/card/demo/index.js
+++ b/demo/atom/card/demo/index.js
@@ -84,6 +84,9 @@ const Demo = () => {
           vertical
         />
       </div>
+      <h2>
+        Responsive using <code>@s-ui/react-layout-media-query</code>
+      </h2>
       <div className="DemoAtomCard-section DemoAtomCard-section--responsive">
         <h2>From Horizontal to Vertical Responsive</h2>
         <LayoutMediaQuery>
@@ -133,6 +136,17 @@ const Demo = () => {
             )
           }}
         </LayoutMediaQuery>
+      </div>
+      <h2>Responsive using MediaQueries</h2>
+      <div className="DemoAtomCard-section DemoAtomCard-section--big">
+        <h2>From Vertical (mobile) to Horizontal (desktop)</h2>
+        <AtomCard
+          tabIndex="6"
+          media={CarImage}
+          content={CarInfo}
+          href={urlTarget}
+          responsive
+        />
       </div>
     </div>
   )

--- a/demo/atom/card/demo/index.scss
+++ b/demo/atom/card/demo/index.scss
@@ -31,6 +31,10 @@
       width: 200px;
     }
 
+    &--big {
+      max-width: 1000px;
+    }
+
   }
 
 }


### PR DESCRIPTION
Add CSS responsive behavior with media query to atom card if it receives _responsive_ prop.
You can not use as the same time than _vertical_ prop.

BONUS: It has been converted to functional component.

ISSUES CLOSED: #664