### PR TITLE
fix(atom/card): fix href prop

### DIFF
--- a/components/atom/card/src/index.js
+++ b/components/atom/card/src/index.js
@@ -21,7 +21,6 @@ const AtomCard = ({
   tabIndex
 }) => {
   const redirectToHref = () => {
-    const {href} = this.props
     if (href) window.location.href = href
   }
 


### PR DESCRIPTION
On move component from class to function I miss to remove this. on a fn 