### PR TITLE
feat(atom/switch): Allow value prop

### DIFF
--- a/components/atom/switch/README.md
+++ b/components/atom/switch/README.md
@@ -22,15 +22,16 @@ import AtomSwitch from '@s-ui/react-atom-switch'
 
 return (
   <AtomSwitch
-    initialValue={false}
-    size='default'
-    type='toggle'
     disabled={false}
+    initialValue={false}
     label='Label'
     labelLeft='Off'
-    labelRight='On'
     labelOptionalText='Optional label'
+    labelRight='On'
     onToggle={flag => console.log(`Switch value is ${flag}`)}
+    size='default'
+    type='toggle'
+    value={true}
   />
 )
 ```

--- a/components/atom/switch/README.md
+++ b/components/atom/switch/README.md
@@ -16,7 +16,7 @@ $ npm install @s-ui/react-atom-switch --save
 
 ## Usage
 
-### Basic usage
+### Basic usage - Uncontrolled component
 ```js
 import AtomSwitch from '@s-ui/react-atom-switch'
 
@@ -31,10 +31,23 @@ return (
     onToggle={flag => console.log(`Switch value is ${flag}`)}
     size='default'
     type='toggle'
-    value={true}
   />
 )
 ```
 
+### Basic usage - Controlled component
+```js
+import AtomSwitch from '@s-ui/react-atom-switch'
+
+return (
+  <AtomSwitch
+    labelLeft='Off'
+    labelRight='On'
+    onToggle={value => handleChangeFromParent(value)}
+    type="toggle"
+    value={value}
+  />
+)
+```
 
 > **Find full description and more examples in the [demo page](https://sui-components.now.sh/workbench/atom/switch/demo).**

--- a/components/atom/switch/src/SwitchType/single.js
+++ b/components/atom/switch/src/SwitchType/single.js
@@ -18,15 +18,18 @@ export const SingleSwitchTypeRender = ({
   onKeyDown,
   onToggle,
   size,
-  type
+  type,
+  value
 }) => {
+  const isActive = value !== undefined ? value : isToggle
+
   return (
     <div
       className={switchClassNames(
         size,
         type,
         'singleType',
-        isToggle,
+        isActive,
         isFocus,
         isClick,
         disabled
@@ -45,7 +48,7 @@ export const SingleSwitchTypeRender = ({
         <div className={suitClass({element: 'inputContainer'})}>
           <div
             className={cx(suitClass({element: 'circle'}), {
-              [suitClass({modifier: 'toggle'})]: isToggle
+              [suitClass({modifier: 'toggle'})]: isActive
             })}
           />
         </div>
@@ -112,5 +115,9 @@ SingleSwitchTypeRender.propTypes = {
   /**
    * Callback on keydown on the switch
    */
-  onKeyDown: PropTypes.func
+  onKeyDown: PropTypes.func,
+  /**
+   * Component value
+   */
+  value: PropTypes.bool
 }

--- a/components/atom/switch/src/SwitchType/single.js
+++ b/components/atom/switch/src/SwitchType/single.js
@@ -117,7 +117,7 @@ SingleSwitchTypeRender.propTypes = {
    */
   onKeyDown: PropTypes.func,
   /**
-   * Component value
+   * Value for controlled component
    */
   value: PropTypes.bool
 }

--- a/components/atom/switch/src/SwitchType/toggle.js
+++ b/components/atom/switch/src/SwitchType/toggle.js
@@ -147,7 +147,7 @@ ToggleSwitchTypeRender.propTypes = {
    */
   onKeyDown: PropTypes.func,
   /**
-   * Component value
+   * Value for controlled component
    */
   value: PropTypes.bool
 }

--- a/components/atom/switch/src/SwitchType/toggle.js
+++ b/components/atom/switch/src/SwitchType/toggle.js
@@ -20,15 +20,18 @@ export const ToggleSwitchTypeRender = ({
   onKeyDown,
   onToggle,
   size,
-  type
+  type,
+  value
 }) => {
+  const isActive = value !== undefined ? value : isToggle
+
   return (
     <div
       className={switchClassNames(
         size,
         type,
         'toggleType',
-        isToggle,
+        isActive,
         isFocus,
         isClick,
         disabled
@@ -58,7 +61,7 @@ export const ToggleSwitchTypeRender = ({
         >
           <div
             className={cx(suitClass({element: 'circle'}), {
-              [suitClass({modifier: 'toggle'})]: isToggle
+              [suitClass({modifier: 'toggle'})]: isActive
             })}
           />
         </div>
@@ -142,5 +145,9 @@ ToggleSwitchTypeRender.propTypes = {
   /**
    * Callback on keydown on the switch
    */
-  onKeyDown: PropTypes.func
+  onKeyDown: PropTypes.func,
+  /**
+   * Component value
+   */
+  value: PropTypes.bool
 }

--- a/components/atom/switch/src/index.js
+++ b/components/atom/switch/src/index.js
@@ -75,7 +75,7 @@ AtomSwitch.displayName = 'AtomSwitch'
 
 AtomSwitch.propTypes = {
   /**
-   * Wheter switch is checked on init
+   * Whether switch is checked on init. Uncontrolled state component
    */
   initialValue: PropTypes.bool,
   /**
@@ -115,7 +115,7 @@ AtomSwitch.propTypes = {
    */
   onToggle: PropTypes.func.isRequired,
   /**
-   * Wheter switch is checked
+   * Whether switch is checked. Controlled state component. Don't combine with initialValue prop!
    */
   value: PropTypes.bool
 }

--- a/components/atom/switch/src/index.js
+++ b/components/atom/switch/src/index.js
@@ -21,9 +21,15 @@ class AtomSwitch extends Component {
   }
 
   _onToggle = forceValue => {
-    if (this.props.disabled === true) return
+    const {disabled, onToggle, value} = this.props
+
+    if (disabled === true) return
+
+    if (value !== undefined) {
+      return onToggle(!value)
+    }
+
     const {isToggle: stateToggle} = this.state
-    const {onToggle} = this.props
     const isToggle = forceValue !== undefined ? forceValue : !stateToggle
     this.setState({isToggle}, () => onToggle(isToggle))
   }
@@ -107,7 +113,11 @@ AtomSwitch.propTypes = {
   /**
    * Callback to be called when switch. Flag whenever switch is active or not sent
    */
-  onToggle: PropTypes.func.isRequired
+  onToggle: PropTypes.func.isRequired,
+  /**
+   * Wheter switch is checked
+   */
+  value: PropTypes.bool
 }
 
 AtomSwitch.defaultProps = {

--- a/demo/atom/switch/playground
+++ b/demo/atom/switch/playground
@@ -8,6 +8,22 @@ const stylesSection = {
 const itemInlineFlex = {padding: '10px'}
 const log = flag => console.log(flag)
 
+const ValueParameter = () => {
+  const [myValue, setMyValue] = React.useState(false)
+  
+  const changeValue = () => setMyValue(!myValue)
+
+  return (
+    <div style={ {...flexInlineContainer, ...stylesSection} } >
+      <div style={itemInlineFlex}>
+        <h4>Value</h4>
+        <AtomSwitch name='inputSwitchTest' label='Label title' value={myValue} />
+        <button onClick={changeValue}>Change value</button>
+      </div>
+    </div>
+  )
+}
+
 return (
 <div>
   <h2>Atom Switch</h2>
@@ -39,7 +55,10 @@ return (
     </div>
     <div style={itemInlineFlex}>
       <h4>Single</h4>
-      <AtomSwitch type='single' labelLeft='Lorem ipsum option'  name='inputSwitchTest' label='Label title' onToggle={log}/>
+      <AtomSwitch type='single' labelLeft='Lorem ipsum option' name='inputSwitchTest' label='Label title' onToggle={log}/>
     </div>
   </div>
+
+  <h3>Parameters</h3>
+  <ValueParameter />
 </div>)

--- a/demo/atom/switch/playground
+++ b/demo/atom/switch/playground
@@ -16,7 +16,7 @@ const ValueParameter = () => {
   return (
     <div style={ {...flexInlineContainer, ...stylesSection} } >
       <div style={itemInlineFlex}>
-        <h4>Value</h4>
+        <h4>Value - Controlled component | Don't combine with <code>initialValue</code> prop! </h4>
         <AtomSwitch name='inputSwitchTest' label='Label title' value={myValue} />
         <button onClick={changeValue}>Change value</button>
       </div>


### PR DESCRIPTION
## Description

`AtomSwitch` component reads `initialValue` prop once but I need to load a value depending on an API request.

**Now the toggle value can be managed from its parent component** using the new `value` prop I added.

🎉 This version is backwards compatible with the existing version. 


## Tasks

- [x] Add new `value` prop.
- [x] Apply logic to read `value` prop.


## Demo

![Grabaciondepantalla201904](https://user-images.githubusercontent.com/13108014/56558648-b311bb80-659f-11e9-9fcc-ad4ccfcaeb9b.gif)
