### PR TITLE
fix(molecule/select): fix onClick propTypes warning

### DIFF
--- a/components/molecule/select/src/hoc/withSelectUI.js
+++ b/components/molecule/select/src/hoc/withSelectUI.js
@@ -32,7 +32,7 @@ export default BaseComponent => {
       } = this.props
       const {classNames} = this
       return (
-        <div className={CLASS_CONTAINER} onClick={!disabled && onClick}>
+        <div className={CLASS_CONTAINER} onClick={!disabled ? onClick : null}>
           <BaseComponent {...props} disabled readOnly={!disabled} />
           <span className={classNames}>{iconArrow}</span>
         </div>


### PR DESCRIPTION
> PR to fix a small error in the implementation of the onClick method that generated a warning in the propTypes because it expected a function, but if it received the prop disabled to true, it returned a boolean.