### PR TITLE
Atom tag responsive functionality

### DIFF
--- a/components/atom/tag/src/index.js
+++ b/components/atom/tag/src/index.js
@@ -34,12 +34,13 @@ const filterKeys = (obj, listOfProps) =>
   }, {})
 
 const AtomTag = props => {
-  const {href, icon, onClick, size} = props
+  const {href, icon, onClick, size, responsive} = props
 
   const isActionable = onClick || href
   const classNames = cx(
     'sui-AtomTag',
     `sui-AtomTag-${size}`,
+    responsive && 'sui-AtomTag--responsive',
     icon && 'sui-AtomTag-hasIcon'
   )
 
@@ -103,7 +104,11 @@ AtomTag.propTypes = {
   /**
    * Tag size
    */
-  size: PropTypes.oneOf(Object.values(SIZES))
+  size: PropTypes.oneOf(Object.values(SIZES)),
+  /**
+   * true for make responsive layout. keep large size in mobile
+   */
+  responsive: PropTypes.bool
 }
 
 AtomTag.defaultProps = {

--- a/components/atom/tag/src/index.scss
+++ b/components/atom/tag/src/index.scss
@@ -11,7 +11,6 @@ $p-atom-tag-l: 0 $p-l !default;
 $p-atom-tag-m: 0 $p-l !default;
 $p-atom-tag-s: 0 $p-m !default;
 $w-atom-tag-clickable: 32px !default;
-$mq-atom-tag-responsive-breakpoint: 's' !default;
 
 @mixin icon-atom-tag($type) {
   @include sui-icon--small;
@@ -147,7 +146,7 @@ $mq-atom-tag-responsive-breakpoint: 's' !default;
   }
 
   &--responsive {
-    @include media-breakpoint-down($mq-atom-tag-responsive-breakpoint) {
+    @include media-breakpoint-down(s) {
       border-radius: ceil($h-atom-tag-l / 2);
       height: $h-atom-tag-l;
       padding: $p-atom-tag-l;

--- a/components/atom/tag/src/index.scss
+++ b/components/atom/tag/src/index.scss
@@ -1,3 +1,4 @@
+@import '~@schibstedspain/sui-theme/lib/settings-compat-v7/index';
 @import '~@schibstedspain/sui-theme/lib/index';
 
 $bgc-atom-tag: color-variation($c-gray, 3) !default;
@@ -10,6 +11,7 @@ $p-atom-tag-l: 0 $p-l !default;
 $p-atom-tag-m: 0 $p-l !default;
 $p-atom-tag-s: 0 $p-m !default;
 $w-atom-tag-clickable: 32px !default;
+$mq-atom-tag-responsive-breakpoint: 's' !default;
 
 @mixin icon-atom-tag($type) {
   @include sui-icon--small;
@@ -141,6 +143,22 @@ $w-atom-tag-clickable: 32px !default;
 
     .sui-AtomTag-closeable {
       @include icon-secondary-clickable-area($h-atom-tag-l);
+    }
+  }
+
+  &--responsive {
+    @include media-breakpoint-down($mq-atom-tag-responsive-breakpoint) {
+      border-radius: ceil($h-atom-tag-l / 2);
+      height: $h-atom-tag-l;
+      padding: $p-atom-tag-l;
+
+      & .sui-AtomTag-label {
+        line-height: $h-atom-tag-l;
+      }
+
+      .sui-AtomTag-closeable {
+        @include icon-secondary-clickable-area($h-atom-tag-l);
+      }
     }
   }
 }

--- a/demo/atom/tag/playground
+++ b/demo/atom/tag/playground
@@ -15,6 +15,34 @@ const CloseIcon = () => (
 
 return (
   <div style={{float: 'left'}}>
+    <h2>Responsive Tags</h2>
+    <p>
+      <AtomTag
+        label="Icon & Close Tag"
+        icon={<Icon />}
+        onClose={() => alert('close!')}
+        closeIcon={<CloseIcon />}
+        size={atomTagSizes.SMALL}
+        responsive
+      />
+      <AtomTag
+        label="Icon & Close Tag"
+        icon={<Icon />}
+        onClose={() => alert('close!')}
+        closeIcon={<CloseIcon />}
+        responsive
+      />
+      <AtomTag
+        label="Icon & Close Tag"
+        icon={<Icon />}
+        onClose={() => alert('close!')}
+        closeIcon={<CloseIcon />}
+        size={atomTagSizes.LARGE}
+        responsive
+      />
+    </p>
+
+
     <h2>Standard Tags</h2>
     <p>
       <AtomTag label="Tag Structure" />{' '}

--- a/demo/atom/tag/playground
+++ b/demo/atom/tag/playground
@@ -15,34 +15,6 @@ const CloseIcon = () => (
 
 return (
   <div style={{float: 'left'}}>
-    <h2>Responsive Tags</h2>
-    <p>
-      <AtomTag
-        label="Icon & Close Tag"
-        icon={<Icon />}
-        onClose={() => alert('close!')}
-        closeIcon={<CloseIcon />}
-        size={atomTagSizes.SMALL}
-        responsive
-      />
-      <AtomTag
-        label="Icon & Close Tag"
-        icon={<Icon />}
-        onClose={() => alert('close!')}
-        closeIcon={<CloseIcon />}
-        responsive
-      />
-      <AtomTag
-        label="Icon & Close Tag"
-        icon={<Icon />}
-        onClose={() => alert('close!')}
-        closeIcon={<CloseIcon />}
-        size={atomTagSizes.LARGE}
-        responsive
-      />
-    </p>
-
-
     <h2>Standard Tags</h2>
     <p>
       <AtomTag label="Tag Structure" />{' '}
@@ -187,6 +159,41 @@ return (
         label="Icon placement left"
         href="https://www.google.com"
         target="_blank"
+      />
+    </p>
+
+    <h2>Responsive Tags</h2>
+    <p>
+      <AtomTag
+        label="Icon & Close Tag"
+        icon={<Icon />}
+        onClose={() => alert('close!')}
+        closeIcon={<CloseIcon />}
+        size={atomTagSizes.SMALL}
+        responsive
+      />
+      <AtomTag
+        label="Icon & Close Tag"
+        icon={<Icon />}
+        onClose={() => alert('close!')}
+        closeIcon={<CloseIcon />}
+        responsive
+      />
+      <AtomTag
+        label="Icon & Close Tag"
+        icon={<Icon />}
+        onClose={() => alert('close!')}
+        closeIcon={<CloseIcon />}
+        size={atomTagSizes.LARGE}
+        responsive
+      />
+      <AtomTag
+        iconPlacement="right"
+        icon={<Icon />}
+        label="Icon placement right"
+        href="https://www.google.com"
+        target="_blank"
+        responsive
       />
     </p>
   </div>


### PR DESCRIPTION
MoleculeSelect uses InputTags and this one uses Tags.
In MoleculeSelect and also in InputTags, the tags should be displayed as "large" in mobile in order to keep the best possible UX getting a bigger "close button clickable area"