### PR TITLE
fix(molecule/textareaField): fix textareaField missing first event value

### DIFF
--- a/components/molecule/textareaField/src/hoc/WithCharacterCount.js
+++ b/components/molecule/textareaField/src/hoc/WithCharacterCount.js
@@ -9,11 +9,6 @@ const WithCharacterCount = BaseComponent => {
       messageAtomTextarea: ''
     }
 
-    static getDerivedStateFromProps(nextProps) {
-      if (nextProps.value === '') return {value: ''}
-      return null
-    }
-
     componentDidMount() {
       const {value, maxChars} = this.props
       const lengthInitialText = value ? value.length : 0


### PR DESCRIPTION
### With getDerivedStateFromProps
> Using the getDerivedStateFromProps method in this component generates unwanted behavior when writing the first character, since it returns it as an empty string.

![text-area-field-bug](https://user-images.githubusercontent.com/31726966/56744995-d09a7d00-6779-11e9-93b4-320a1b66779d.gif)

### Without getDerivedStateFromProps
![text-area-field](https://user-images.githubusercontent.com/31726966/56745012-d728f480-6779-11e9-9b07-580f742e5ad5.gif)
