### PR TITLE
feat(molecule/collapsible): added vars & CSS properties to custom align

### DIFF
--- a/components/molecule/collapsible/src/_settings.scss
+++ b/components/molecule/collapsible/src/_settings.scss
@@ -13,3 +13,5 @@ $mt-collapsible-btn: $m-l !default;
 $p-collapsible-btn: $p-s !default;
 $bd-collapsible-btn-focus: 0 0 0 1px  $c-gray inset !default;
 $trs-collapsible-content: all .25s ease-in-out !default;
+$ta-collapsible-content: left !default;
+$ta-collapsible-container: left !default;

--- a/components/molecule/collapsible/src/index.scss
+++ b/components/molecule/collapsible/src/index.scss
@@ -11,10 +11,10 @@
     background: none;
     border: 0;
     color: $c-collapsible-btn;
+    cursor: pointer;
     height: $mh-collapsible-btn;
     margin-top: $mt-collapsible-btn;
     padding: $p-collapsible-btn 0;
-    cursor: pointer;
 
     &:focus,
     &-content:focus {
@@ -28,6 +28,7 @@
 
   &-content {
     overflow: hidden;
+    text-align: $ta-collapsible-content;
 
     &--withTransition {
       transition: $trs-collapsible-content;
@@ -37,6 +38,7 @@
   &-container {
     background-color: $bgc-collapsible-container;
     position: relative;
+    text-align: $ta-collapsible-container;
     width: 100%;
 
     &#{&}--withGradient.is-collapsed {


### PR DESCRIPTION
Added Sass vars & CSS properties to custom align content & container.

> In this example the content text it's aligned to left and container (button) it's aligned to the center

![Screenshot 2019-04-29 at 14 38 37](https://user-images.githubusercontent.com/1307927/56897272-5a09c200-6a8e-11e9-9105-c544e665f519.jpg)
