### PR TITLE
fix(molecule/textareaField): fix issue first character & prop-types texts

### DIFF
--- a/components/molecule/textareaField/src/hoc/WithCharacterCount.js
+++ b/components/molecule/textareaField/src/hoc/WithCharacterCount.js
@@ -6,22 +6,28 @@ const WithCharacterCount = BaseComponent => {
   return class extends Component {
     state = {
       value: this.props.value,
-      messageAtomTextarea: ''
+      messageAtomTextarea: '',
+      initialMessageAtomTextarea: ''
     }
 
-    static getDerivedStateFromProps(nextProps) {
-      if (nextProps.value === '') return {value: ''}
+    get initialMessageAtomTextarea() {
+      const {value, maxChars} = this.props
+      const lengthInitialText = value ? value.length : 0
+      return this.getHelpTextArea(lengthInitialText, maxChars)
+    }
+
+    static getDerivedStateFromProps(nextProps, nextState) {
+      if (nextProps.value === '' && nextState.value.length > 1) {
+        const {initialMessageAtomTextarea} = nextState
+        return {value: '', messageAtomTextarea: initialMessageAtomTextarea}
+      }
       return null
     }
 
     componentDidMount() {
-      const {value, maxChars} = this.props
-      const lengthInitialText = value ? value.length : 0
-      const messageAtomTextarea = this.getHelpTextArea(
-        lengthInitialText,
-        maxChars
-      )
-      this.setState({messageAtomTextarea})
+      const {initialMessageAtomTextarea} = this
+      const messageAtomTextarea = initialMessageAtomTextarea
+      this.setState({messageAtomTextarea, initialMessageAtomTextarea})
     }
 
     getHelpTextArea = (numCharacters, maxChars) => {
@@ -39,6 +45,7 @@ const WithCharacterCount = BaseComponent => {
     }
 
     handleChange = ev => {
+      ev.persist()
       const value = ev.target.value
       const {onChange, maxChars} = this.props
       if (value.length > maxChars) return

--- a/components/molecule/textareaField/src/index.js
+++ b/components/molecule/textareaField/src/index.js
@@ -9,16 +9,27 @@ import AtomTextarea, {
 import WithCharacterCount from './hoc/WithCharacterCount'
 
 const MoleculeTextareaField = WithCharacterCount(
-  ({id, placeholder, onChange, maxChars, label, value, size, ...props}) => {
+  ({
+    id,
+    label,
+    maxChars,
+    textCharacters,
+    successText,
+    errorText,
+    helpText,
+    ...props
+  }) => {
     return (
-      <MoleculeField {...props} label={label} name={id}>
-        <AtomTextarea
-          id={id}
-          onChange={onChange}
-          placeholder={placeholder}
-          value={value}
-          size={size}
-        />
+      <MoleculeField
+        name={id}
+        label={label}
+        textCharacters={textCharacters}
+        successText={successText}
+        errorText={errorText}
+        helpText={helpText}
+        maxChars={maxChars}
+      >
+        <AtomTextarea id={id} {...props} />
       </MoleculeField>
     )
   }
@@ -55,14 +66,14 @@ MoleculeTextareaField.propTypes = {
   /** used as for attribute and textarea id */
   id: PropTypes.string,
 
-  /** Success message to be displayed */
-  successText: PropTypes.string,
+  /** Success message to display when success state  */
+  successText: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
 
-  /** Error message to be displayed */
-  errorText: PropTypes.string,
+  /** Error message to display when error state  */
+  errorText: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
 
-  /** Help Text to be displayed */
-  helpText: PropTypes.string,
+  /** Help Text to display */
+  helpText: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
 
   /** Boolean to decide if field elements should be set inline */
   inline: PropTypes.bool


### PR DESCRIPTION
This PR fixes the issue in `MoleculeTextArea` detected by @AgonisticKatai → first character is not taken into account in the first example of the demo

Also fixes prop-types errors that appear when passed some values in this way 
```
errorText={touched.message && errors.message}
successText={
  touched.message &&
  !errors.message &&
  'Everything OK with this message'
}
```
