### PR TITLE
fix(molecule/inputField): fix issue propTypes messages

### DIFF
--- a/components/molecule/inputField/src/index.js
+++ b/components/molecule/inputField/src/index.js
@@ -42,17 +42,17 @@ MoleculeInputField.propTypes = {
   /** used as label for attribute and input element id */
   id: PropTypes.string.isRequired,
 
-  /** Success message to display when success state  */
-  successText: PropTypes.string,
-
   /* onChange callback */
   onChange: PropTypes.func,
 
+  /** Success message to display when success state  */
+  successText: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+
   /** Error message to display when error state  */
-  errorText: PropTypes.string,
+  errorText: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
 
   /** Help Text to display */
-  helpText: PropTypes.string,
+  helpText: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
 
   /** Boolean to decide if elements should be set inline */
   inline: PropTypes.bool


### PR DESCRIPTION
Fix prop-types errors that appear when passed some values in this way 
```
errorText={touched.message && errors.message}
successText={
  touched.message &&
  !errors.message &&
  'Everything OK with this message'
}
```
