### PR TITLE
fix(molecule/field): fix issue w/ prop-types messages props

### DIFF
--- a/components/molecule/field/src/index.js
+++ b/components/molecule/field/src/index.js
@@ -77,13 +77,13 @@ MoleculeField.propTypes = {
   name: PropTypes.string.isRequired,
 
   /** Success message to display when success state  */
-  successText: PropTypes.string,
+  successText: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
 
   /** Error message to display when error state  */
-  errorText: PropTypes.string,
+  errorText: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
 
   /** Help Text to display */
-  helpText: PropTypes.string,
+  helpText: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
 
   /** Boolean to decide if elements should be set inline */
   inline: PropTypes.bool,


### PR DESCRIPTION
Fix prop-types errors that appear when passed some values in this way 
```
errorText={touched.message && errors.message}
successText={
  touched.message &&
  !errors.message &&
  'Everything OK with this message'
}
```
