### PR TITLE
feat(molecule/rating): better implementation for fix custom rating star

### DIFF
--- a/components/molecule/rating/README.md
+++ b/components/molecule/rating/README.md
@@ -36,12 +36,12 @@ import MoleculeRating, {MoleculeRatingSizes} from '@s-ui/react-molecule-rating'
 ### With CUSTOM icons
 
 ```js
-import {IconStarFilled, IconStarHalfFilled, IconStarOutline} from './Icons'
+import {IconStarFilled, IconStarHalfFilled, IconStarEmpty} from './Icons'
 
 const customPropsStar = {
   IconStarFilled,
   IconStarHalfFilled,
-  IconStarOutline
+  IconStarEmpty
 }
 
 <MoleculeRating

--- a/components/molecule/rating/README.md
+++ b/components/molecule/rating/README.md
@@ -33,6 +33,24 @@ import MoleculeRating, {MoleculeRatingSizes} from '@s-ui/react-molecule-rating'
 <MoleculeRating value={4} label="25 opiniones" size={MoleculeRatingSizes.MEDIUM} link href="https://www.adevinta.com/"/>        
 ```
 
+### With CUSTOM icons
+
+```js
+import {IconStarFilled, IconStarHalfFilled, IconStarOutline} from './Icons'
+
+const customPropsStar = {
+  IconStarFilled,
+  IconStarHalfFilled,
+  IconStarOutline
+}
+
+<MoleculeRating
+    value={3.5}
+    size={MoleculeRatingSizes.LARGE}
+    label="25 opiniones"
+    {...customPropsStar}
+/>
+```
 
 
 

--- a/components/molecule/rating/src/index.js
+++ b/components/molecule/rating/src/index.js
@@ -22,7 +22,8 @@ const MoleculeRating = ({
   label,
   href,
   target,
-  linkFactory: Link = ({children, ...rest} = {}) => <a {...rest}>{children}</a>
+  linkFactory: Link = ({children, ...rest} = {}) => <a {...rest}>{children}</a>,
+  ...props
 }) => {
   const className = cx(BASE_CLASS, `${BASE_CLASS}--${size}`, {
     [CLASS_LINK]: href
@@ -45,7 +46,9 @@ const MoleculeRating = ({
       <div className={CLASS_CONTAINER_STARS}>
         {new Array(numStars)
           .fill(0)
-          .map((_, index) => <Star key={index} index={index} value={value} />)}
+          .map((_, index) => (
+            <Star key={index} index={index} value={value} {...props} />
+          ))}
       </div>
       <p className={CLASS_LABEL}>{labelLink}</p>
     </div>

--- a/demo/molecule/rating/demo/Icons/index.js
+++ b/demo/molecule/rating/demo/Icons/index.js
@@ -1,0 +1,5 @@
+import IconStarFilled from './starFilled'
+import IconStarHalfFilled from './starHalfFilled'
+import IconStarOutline from './starOutline'
+
+export {IconStarFilled, IconStarHalfFilled, IconStarOutline}

--- a/demo/molecule/rating/demo/Icons/starFilled.js
+++ b/demo/molecule/rating/demo/Icons/starFilled.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const StarFilled = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z" />
+  </svg>
+)
+
+export default StarFilled

--- a/demo/molecule/rating/demo/Icons/starHalfFilled.js
+++ b/demo/molecule/rating/demo/Icons/starHalfFilled.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const StarHalfFilled = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <path d="M22 9.24l-7.19-.62L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27 18.18 21l-1.63-7.03L22 9.24zM12 15.4V6.1l1.71 4.04 4.38.38-3.32 2.88 1 4.28L12 15.4z" />
+  </svg>
+)
+
+export default StarHalfFilled

--- a/demo/molecule/rating/demo/Icons/starOutline.js
+++ b/demo/molecule/rating/demo/Icons/starOutline.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const StarOutline = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <path d="M22 9.24l-7.19-.62L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27 18.18 21l-1.63-7.03L22 9.24zM12 15.4l-3.76 2.27 1-4.28-3.32-2.88 4.38-.38L12 6.1l1.71 4.04 4.38.38-3.32 2.88 1 4.28L12 15.4z" />
+  </svg>
+)
+
+export default StarOutline

--- a/demo/molecule/rating/demo/index.js
+++ b/demo/molecule/rating/demo/index.js
@@ -1,0 +1,98 @@
+/* eslint-disable no-console */
+
+import React from 'react'
+import cx from 'classnames'
+import './index.scss'
+
+import MoleculeRating, {
+  MoleculeRatingSizes
+} from '../../../../components/molecule/rating/src'
+
+import {IconStarFilled, IconStarHalfFilled, IconStarOutline} from './Icons'
+
+const BASE_CLASS_DEMO = 'DemoMoleculeRating'
+const CLASS_DEMO_SECTION = `${BASE_CLASS_DEMO}-section`
+const CLASS_DEMO_SECTION_ICONS = `${CLASS_DEMO_SECTION}-icons`
+
+const customPropsStar = {
+  IconStarFilled,
+  IconStarHalfFilled,
+  IconStarOutline
+}
+
+const Demo = () => (
+  <div className={BASE_CLASS_DEMO}>
+    <h2>Size SMALL</h2>
+    <div className={CLASS_DEMO_SECTION}>
+      <MoleculeRating value={0} label="25 opiniones" />
+      <MoleculeRating value={2.5} label="25 opiniones" />
+    </div>
+    <h3>With Link</h3>
+    <div className={CLASS_DEMO_SECTION}>
+      <MoleculeRating
+        value={4}
+        label="25 opiniones"
+        link
+        href="https://www.adevinta.com/"
+      />
+    </div>
+    <h2>Size MEDIUM</h2>
+    <div className={CLASS_DEMO_SECTION}>
+      <MoleculeRating
+        value={0}
+        size={MoleculeRatingSizes.MEDIUM}
+        label="25 opiniones"
+      />
+      <MoleculeRating
+        value={2.5}
+        size={MoleculeRatingSizes.MEDIUM}
+        label="25 opiniones"
+      />
+    </div>
+    <h3>With Link</h3>
+    <div className={CLASS_DEMO_SECTION}>
+      <MoleculeRating
+        value={4}
+        size={MoleculeRatingSizes.MEDIUM}
+        label="25 opiniones"
+        href="https://www.adevinta.com/"
+      />
+    </div>
+
+    <h2>Size LARGE</h2>
+    <div className={CLASS_DEMO_SECTION}>
+      <MoleculeRating
+        value={0}
+        size={MoleculeRatingSizes.LARGE}
+        label="25 opiniones"
+      />
+      <MoleculeRating
+        value={2.5}
+        size={MoleculeRatingSizes.LARGE}
+        label="25 opiniones"
+      />
+    </div>
+    <h3>With Link</h3>
+    <div className={CLASS_DEMO_SECTION}>
+      <MoleculeRating
+        value={4}
+        size={MoleculeRatingSizes.LARGE}
+        label="25 opiniones"
+        href="https://www.adevinta.com/"
+      />
+    </div>
+
+    <h3>Custom Star</h3>
+    <div className={cx(CLASS_DEMO_SECTION, CLASS_DEMO_SECTION_ICONS)}>
+      <MoleculeRating
+        value={3.5}
+        size={MoleculeRatingSizes.LARGE}
+        label="25 opiniones"
+        href="https://www.adevinta.com/"
+        {...customPropsStar}
+      />
+    </div>
+  </div>
+)
+
+export default Demo

--- a/demo/molecule/rating/demo/index.js
+++ b/demo/molecule/rating/demo/index.js
@@ -17,7 +17,7 @@ const CLASS_DEMO_SECTION_ICONS = `${CLASS_DEMO_SECTION}-icons`
 const customPropsStar = {
   IconStarFilled,
   IconStarHalfFilled,
-  IconStarOutline
+  IconStarEmpty: IconStarOutline
 }
 
 const Demo = () => (

--- a/demo/molecule/rating/demo/index.scss
+++ b/demo/molecule/rating/demo/index.scss
@@ -1,0 +1,19 @@
+.DemoMoleculeRating {
+  padding: 20px;
+
+  &-section {
+    margin: 10px;
+
+    &-icons {
+      svg,
+      use {
+        fill: #5398c1;
+      }
+    }
+  }
+
+  pre {
+    padding: 16px;
+    width: 300px;
+  }
+}

--- a/demo/molecule/rating/demo/package.json
+++ b/demo/molecule/rating/demo/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "demo",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/demo/molecule/rating/playground
+++ b/demo/molecule/rating/playground
@@ -1,21 +1,3 @@
 return (
-    <div>
-        <h2>Size SMALL</h2>  
-        <MoleculeRating value={0} label="25 opiniones"/>
-        <MoleculeRating value={2.5} label="25 opiniones"/>
-        <h3>With Link</h3>  
-        <MoleculeRating value={4} label="25 opiniones" link href="https://www.adevinta.com/"/>
-
-        <h2>Size MEDIUM</h2>  
-        <MoleculeRating value={0} size={MoleculeRatingSizes.MEDIUM} label="25 opiniones"/>
-        <MoleculeRating value={2.5} size={MoleculeRatingSizes.MEDIUM} label="25 opiniones"/>
-        <h3>With Link</h3>  
-        <MoleculeRating value={4} size={MoleculeRatingSizes.MEDIUM} label="25 opiniones" href="https://www.adevinta.com/"/>
-
-        <h2>Size LARGE</h2>  
-        <MoleculeRating value={0} size={MoleculeRatingSizes.LARGE} label="25 opiniones"/>
-        <MoleculeRating value={2.5} size={MoleculeRatingSizes.LARGE} label="25 opiniones"/>
-        <h3>With Link</h3>  
-        <MoleculeRating value={4} size={MoleculeRatingSizes.LARGE} label="25 opiniones" href="https://www.adevinta.com/"/>
-    </div>
+    <p>this shouldn't be displayed</p>   
 )


### PR DESCRIPTION
Fix custom star. Now the star can be customized in this way...

```js
import {IconStarFilled, IconStarHalfFilled, IconStarOutline} from './Icons'

const customPropsStar = {
  IconStarFilled,
  IconStarHalfFilled,
  IconStarOutline
}

<MoleculeRating
    value={3.5}
    size={MoleculeRatingSizes.LARGE}
    label="25 opiniones"
    {...customPropsStar}
/>
```

- 🌎Demo Online → https://sui-components-fix-custom-star-molecule-rating.now.sh/workbench/molecule/rating/demo