### PR TITLE
feat(molecule/modal): add a dialogSibling prop to render content outs…

### DIFF
--- a/components/molecule/modal/src/index.js
+++ b/components/molecule/modal/src/index.js
@@ -111,7 +111,8 @@ class MoleculeModal extends Component {
       fitWindow,
       fitContent,
       isClosing,
-      onAnimationEnd
+      onAnimationEnd,
+      dialogSibling
     } = this.props
     toggleWindowScroll(isOpen)
     const wrapperClassName = cx(suitClass(), {
@@ -152,6 +153,7 @@ class MoleculeModal extends Component {
             {this.extendedChildren}
           </div>
         </div>
+        {dialogSibling}
       </div>
     )
   }
@@ -224,7 +226,11 @@ MoleculeModal.propTypes = {
   /**
    * Determines if modal will be rendered using a React Portal.
    */
-  usePortal: PropTypes.bool
+  usePortal: PropTypes.bool,
+  /**
+   * Sibling of dialog
+   */
+  dialogSibling: PropTypes.node
 }
 
 MoleculeModal.defaultProps = {


### PR DESCRIPTION
### Actual

Right now the modal structure is as follows:

```
<sui-MoleculeModal>
	<sui-MoleculeModal-dialog>
		<sui-MoleculeModal-content>
                     {children}
                 </>
	 </>
</>
```
#
### Proposal

If this PR is approved the structure will be the same as the previous one, but a new node can be added which will be the brother of the dialog node (`<sui-MoleculeModal-dialog>`).

The result will be the following:

```
<sui-MoleculeModal>
	<sui-MoleculeModal-dialog>
		<sui-MoleculeModal-content />
	</>
	<sui-MoleculeModal-dialogSibling> <-- NEW NODE!
</>
```

### Why?

Right now the only content that is passed as children to the modal is rendered within the **content** (`sui-MoleculeModal-content`)

In Milanuncios I'm developing a modal (onboarding style), with a navigation inside the modal, which is really impossible to put the navigation buttons with the current modal.

<img width="976" alt="Captura de pantalla 2019-05-13 a las 12 26 14" src="https://user-images.githubusercontent.com/32937662/57615787-d1eee680-757c-11e9-8425-ca38bdc7655a.png">

![Captura de pantalla 2019-05-13 a las 12 19 22](https://user-images.githubusercontent.com/32937662/57615716-a79d2900-757c-11e9-87be-90e01339e030.png)

### Implementation Details

The implementation is through a new prop: **dialogSibling**
