### PR TITLE
feat(atom/button): fixed bug selection focus

### DIFF
--- a/components/atom/button/src/index.scss
+++ b/components/atom/button/src/index.scss
@@ -76,7 +76,6 @@ $bdc-atom-button-accent: $c-accent !default;
   &:not(.sui-AtomButton--disabled) {
     &.sui-AtomButton--focused,
     &:active,
-    &:focus,
     &:hover {
       @content;
     }


### PR DESCRIPTION
The `focus` styles should only be handled by the `focus` property to avoid undesired behaviours like the one described in the task → https://jira.scmspain.com/browse/SUIC-74