### PR TITLE
Feat/inline label

### DIFF
--- a/components/atom/label/README.md
+++ b/components/atom/label/README.md
@@ -13,6 +13,7 @@ $ npm install @s-ui/react-atom-label --save
 ## Usage
 
 ### Basic usage
+Labels are shown on top of the input form elements by default due to their block type display. Use `inline = 'left'` or `inline = 'right'` props to make them inline. 
 ```js
 import AtomLabel from '@s-ui/react-atom-label'
 
@@ -22,7 +23,8 @@ return (
       name='atomLabelName'
       for='labelName'
       text='Hello label'
-      optional='(optional text)' />
+      optional='(optional text)'
+      inline='( left || right )' />
 
     <input id='atomLabelName' type='text' />
   </div>

--- a/components/atom/label/src/index.js
+++ b/components/atom/label/src/index.js
@@ -9,10 +9,15 @@ const TYPES = {
   ERROR: 'error'
 }
 
-const getClass = ({type}) => cx(CLASSNAME, type && `${CLASSNAME}--${type}`)
+const getClass = ({type, inline}) =>
+  cx(CLASSNAME, {
+    [`${CLASSNAME}--${type}`]: type,
+    [`${CLASSNAME}--inlineLeft`]: inline === 'left',
+    [`${CLASSNAME}--inlineRight`]: inline === 'right'
+  })
 
-const AtomLabel = ({name, text, optionalText, type, onClick}) => (
-  <label htmlFor={name} className={getClass({type})} onClick={onClick}>
+const AtomLabel = ({name, inline, text, optionalText, type, onClick}) => (
+  <label htmlFor={name} className={getClass({type, inline})} onClick={onClick}>
     {text}
     {optionalText && (
       <span className="sui-AtomLabel-optionalText">{optionalText}</span>
@@ -31,6 +36,10 @@ AtomLabel.propTypes = {
    * The label itself
    */
   text: PropTypes.string.isRequired,
+  /**
+   * Allows label to be displayed inline to de left
+   */
+  inline: PropTypes.string,
   /**
    * The optional label text
    */

--- a/components/atom/label/src/index.scss
+++ b/components/atom/label/src/index.scss
@@ -8,11 +8,20 @@ $c-atom-label-type: success $c-success, error $c-error;
   display: block;
   font-size: $fz-base;
   margin-bottom: $m-s;
-  margin-right: $m-m;
 
   &-optionalText {
     color: $c-atom-label-optional;
     margin-left: $m-s;
+  }
+
+  &--inlineLeft {
+    display: inline;
+    margin-right: $m-m;
+  }
+
+  &--inlineRight {
+    display: inline;
+    margin-left: $m-m;
   }
 
   @each $type, $color in $c-atom-label-type {

--- a/demo/atom/label/playground
+++ b/demo/atom/label/playground
@@ -1,31 +1,58 @@
 return (
   <div>
+    <br />
+    <br />
     <div style={{marginBottom: '16px'}}>
       <AtomLabel
-        name='atomLabelName'
-        for='labelName'
-        text='Hello label'
-        optionalText='*' />
+        name="atomLabelName1"
+        for="labelName1"
+        text="Hello label"
+        optionalText="*"
+      />
 
-      <input id='atomLabelName' type='text' />
+      <input id="atomLabelName1" type="text" />
     </div>
     <div style={{marginBottom: '16px'}}>
       <AtomLabel
-        name='atomLabelName'
-        for='labelName'
-        text='Hello label'
-        type={AtomLabelTypes.SUCCESS}/>
+        name="atomLabelName2"
+        for="labelName2"
+        text="Hello label"
+        type={AtomLabelTypes.SUCCESS}
+      />
 
-      <input id='atomLabelName' type='text' />
+      <input id="atomLabelName2" type="text" />
     </div>
+
     <div style={{marginBottom: '16px'}}>
       <AtomLabel
-        name='atomLabelName'
-        for='labelName'
-        text='Hello label'
-        type={AtomLabelTypes.ERROR} />
+        name="atomLabelName"
+        for="labelName"
+        text="Hello label"
+        type={AtomLabelTypes.ERROR}
+      />
 
-      <input id='atomLabelName' type='text' />
+      <input id="atomLabelName" type="text" />
+    </div>
+
+    <div style={{marginBottom: '16px'}}>
+      <AtomLabel
+        name="atomLabelLeft"
+        for="atomLabelLeft"
+        text="Hello inline left label"
+        inline="left"
+      />
+
+      <input id="atomLabelLeft" type="text" />
+    </div>
+
+    <div style={{marginBottom: '16px'}}>
+      <input id="atomLabelRight" type="checkbox" />
+      <AtomLabel
+        name="atomLabelRight"
+        for="atomLabelRight"
+        text="Hello inline right label"
+        inline="right"
+      />
     </div>
   </div>
 )


### PR DESCRIPTION
### PR Summary
In order to allow labels to be displayed next to form inputs a new prop can be passed with `left` or `right` values. This prop will make `sui-atom-labels` inline.

#### Screenshot
<img width="485" alt="Screenshot 2019-06-13 at 18 14 42" src="https://user-images.githubusercontent.com/10925540/59450327-47163b80-8e09-11e9-9db2-82fe39d23c7a.png">

Please review