### PR TITLE
feat(atom/upload): no background for spinner and agreed way of passing icons to component

### DIFF
--- a/components/atom/upload/src/index.js
+++ b/components/atom/upload/src/index.js
@@ -51,9 +51,7 @@ class AtomUpload extends PureComponent {
         className={cx(BASE_CLASS, `${BASE_CLASS}--${status}`)}
         onClick={this.handleClick}
       >
-        <span className={classNameIcon}>
-          <IconStatus />
-        </span>
+        <span className={classNameIcon}>{IconStatus}</span>
         <div className={CLASS_BLOCK_TEXT}>
           <h4 className={CLASS_BLOCK_TEXT_MAIN}>{textStatus}</h4>
           {status === STATUSES.ACTIVE &&

--- a/demo/atom/upload/demo/index.js
+++ b/demo/atom/upload/demo/index.js
@@ -83,7 +83,7 @@ const Demo = () => {
           iconActive={<IconActive />}
           textActive={textActive}
           textExplanation={textExplanation}
-          iconUpload={<AtomSpinner noBackground/>}
+          iconUpload={<AtomSpinner noBackground />}
           textUpload={textUpload}
           iconSuccess={<IconSuccess />}
           textSuccess={textSuccess}
@@ -144,7 +144,7 @@ const Demo = () => {
         <h3>Upload</h3>
         <AtomUpload
           status={uploadStatuses.UPLOAD}
-          iconUpload={<AtomSpinner noBackground/>}
+          iconUpload={<AtomSpinner noBackground />}
           textUpload={textUpload}
         />
       </div>

--- a/demo/atom/upload/demo/index.js
+++ b/demo/atom/upload/demo/index.js
@@ -80,14 +80,14 @@ const Demo = () => {
           simulation
         </p>
         <DynamicStatusContainer
-          iconActive={IconActive}
+          iconActive={<IconActive />}
           textActive={textActive}
           textExplanation={textExplanation}
-          iconUpload={AtomSpinner}
+          iconUpload={<AtomSpinner noBackground/>}
           textUpload={textUpload}
-          iconSuccess={IconSuccess}
+          iconSuccess={<IconSuccess />}
           textSuccess={textSuccess}
-          iconError={IconError}
+          iconError={<IconError />}
           textError={textError}
         />
       </div>
@@ -100,7 +100,7 @@ const Demo = () => {
               return (
                 <AtomUpload
                   status={uploadStatuses.ACTIVE}
-                  iconActive={IconActive}
+                  iconActive={<IconActive />}
                   textActive={textActive}
                   textExplanation={textExplanation}
                 />
@@ -109,7 +109,7 @@ const Demo = () => {
             return (
               <AtomUpload
                 status={uploadStatuses.ACTIVE}
-                iconActive={IconActive}
+                iconActive={<IconActive />}
                 textActive={textActive}
               />
             )
@@ -124,7 +124,7 @@ const Demo = () => {
               return (
                 <AtomUpload
                   status={uploadStatuses.ACTIVE}
-                  iconActive={IconActive}
+                  iconActive={<IconActive />}
                   textActive={textActive}
                   textExplanation={textExplanation}
                 />
@@ -133,7 +133,7 @@ const Demo = () => {
             return (
               <AtomUpload
                 status={uploadStatuses.ACTIVE}
-                iconActive={IconActive}
+                iconActive={<IconActive />}
                 textActive={textActive}
               />
             )
@@ -144,7 +144,7 @@ const Demo = () => {
         <h3>Upload</h3>
         <AtomUpload
           status={uploadStatuses.UPLOAD}
-          iconUpload={AtomSpinner}
+          iconUpload={<AtomSpinner noBackground/>}
           textUpload={textUpload}
         />
       </div>
@@ -152,14 +152,14 @@ const Demo = () => {
         <h3>Success</h3>
         <AtomUpload
           status={uploadStatuses.SUCCESS}
-          iconSuccess={IconSuccess}
+          iconSuccess={<IconSuccess />}
           textSuccess={textSuccess}
         />
       </div>
       <div className="DemoAtomUpload-section DemoAtomUpload-section--responsive">
         <h3>Error</h3>
         <AtomUpload
-          iconError={IconError}
+          iconError={<IconError />}
           textError={textError}
           status={uploadStatuses.ERROR}
         />

--- a/demo/atom/upload/demo/package.json
+++ b/demo/atom/upload/demo/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@s-ui/react-atom-spinner": "1.3.0",
-    "@s-ui/react-layout-media-query": "1.2.0"
+    "@s-ui/react-atom-spinner": "1",
+    "@s-ui/react-layout-media-query": "1"
   }
 }


### PR DESCRIPTION
- ⚙︎Task → https://jira.scmspain.com/browse/SUIC-80
- 🌍Demo Online → https://sui-components-atom-upload-spinner-no-background.now.sh/workbench/atom/upload/demo

BREAKING CHANGE:
Component Icons are now passed in the agreed way