### PR TITLE
fix(molecule/select): fix input disabled

### DIFF
--- a/components/molecule/select/src/hoc/withSelectUI.js
+++ b/components/molecule/select/src/hoc/withSelectUI.js
@@ -28,12 +28,13 @@ export default BaseComponent => {
         iconArrowUp,
         isOpen,
         disabled,
+        readOnly,
         ...props
       } = this.props
       const {classNames} = this
       return (
         <div className={CLASS_CONTAINER} onClick={!disabled ? onClick : null}>
-          <BaseComponent {...props} disabled readOnly={!disabled} />
+          <BaseComponent {...props} disabled={disabled} readOnly={readOnly} />
           <span className={classNames}>{iconArrow}</span>
         </div>
       )

--- a/components/molecule/select/src/index.js
+++ b/components/molecule/select/src/index.js
@@ -224,14 +224,18 @@ MoleculeSelect.propTypes = {
   errorState: PropTypes.bool,
 
   /** This Boolean attribute prevents the user from interacting with the select */
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+
+  /** This Boolean attribute prevents the user from interacting with the input but without disabled styles  */
+  readOnly: PropTypes.bool
 }
 
 MoleculeSelect.defaultProps = {
+  disabled: false,
+  keysSelection: [' ', 'Enter'],
   onChange: () => {},
   onToggle: () => {},
-  keysSelection: [' ', 'Enter'],
-  disabled: false
+  readOnly: false
 }
 
 export default withOpenToggle(MoleculeSelect)


### PR DESCRIPTION
### Problem

`sui-Atom-input` is always disabled because of this:

https://github.com/SUI-Components/sui-components/blob/master/components/atom/input/src/Input/Component/index.js#L89

### Solution

Add `readOnly` prop, with default `false`