### PR TITLE
feat(molecule/select): add dynamic loading data

### DIFF
--- a/components/molecule/select/src/index.js
+++ b/components/molecule/select/src/index.js
@@ -20,6 +20,15 @@ const ERROR_STATES = {
   SUCCESS: 'success'
 }
 
+const getOptionData = children => {
+  const optionsData = {}
+  React.Children.forEach(children, child => {
+    const {children, value} = child.props
+    optionsData[value] = children
+  })
+  return optionsData
+}
+
 class MoleculeSelect extends Component {
   refMoleculeSelect = this.props.refMoleculeSelect || React.createRef()
   refsMoleculeSelectOptions = []
@@ -28,13 +37,14 @@ class MoleculeSelect extends Component {
     optionsData: {}
   }
 
+  static getDerivedStateFromProps({children}, state) {
+    const optionsData = getOptionData(children)
+    return {...state, optionsData}
+  }
+
   componentDidMount() {
     const {children} = this.props // eslint-disable-line react/prop-types
-    const optionsData = {}
-    React.Children.forEach(children, child => {
-      const {children, value} = child.props
-      optionsData[value] = children
-    })
+    const optionsData = getOptionData(children)
     this.setState({optionsData})
   }
 

--- a/demo/molecule/select/demo/components/ComboCountries.js
+++ b/demo/molecule/select/demo/components/ComboCountries.js
@@ -1,0 +1,67 @@
+/* eslint-disable no-console */
+import React, {useState} from 'react'
+import axios from 'axios'
+import {withStateValue} from '@s-ui/hoc'
+
+import MoleculeSelect from '../../../../../components/molecule/select/src'
+
+import MoleculeSelectOption from '@s-ui/react-molecule-dropdown-option'
+
+import {IconArrowDown} from '../Icons/'
+import regions from '../data/regions.json'
+
+const MoleculeSelectWithState = withStateValue(MoleculeSelect)
+
+const getCountriesByRegion = region => {
+  const url = `https://restcountries.eu/rest/v2/regionalbloc/${region}`
+  return axios.get(url).then(({data}) => data)
+}
+
+const ComboCountries = () => {
+  const [countries, setCountries] = useState([])
+
+  const handleChange = (_, {value: region}) => {
+    console.log({region})
+    getCountriesByRegion(region)
+      .then(countries =>
+        countries.map(({alpha3Code: code, name}) => ({
+          code,
+          name
+        }))
+      )
+      .then(setCountries)
+  }
+
+  return (
+    <div style={{display: 'flex'}}>
+      <div style={{width: '50%', margin: '0 10px'}}>
+        <MoleculeSelectWithState
+          placeholder="Select a Region..."
+          iconArrowDown={<IconArrowDown />}
+          onChange={handleChange}
+        >
+          {regions.map(({code, text}, i) => (
+            <MoleculeSelectOption key={i} value={code}>
+              {text}
+            </MoleculeSelectOption>
+          ))}
+        </MoleculeSelectWithState>
+      </div>
+      <div style={{width: '50%', margin: '0 10px'}}>
+        <MoleculeSelectWithState
+          placeholder="Select a Country..."
+          onChange={(_, {value: country}) => console.log({country})}
+          iconArrowDown={<IconArrowDown />}
+          disabled={!countries.length}
+        >
+          {countries.map(({code, name}, i) => (
+            <MoleculeSelectOption key={i} value={code}>
+              {name}
+            </MoleculeSelectOption>
+          ))}
+        </MoleculeSelectWithState>
+      </div>
+    </div>
+  )
+}
+export default ComboCountries

--- a/demo/molecule/select/demo/data/regions.json
+++ b/demo/molecule/select/demo/data/regions.json
@@ -1,0 +1,54 @@
+[
+    {
+        "code": "EU",
+        "text": "European Union"
+    },
+    {
+        "code": "EFTA",
+        "text": "European Free Trade Association"
+    },
+    {
+        "code": "CARICOM",
+        "text": "Caribbean Community"
+    },
+    {
+        "code": "PA",
+        "text": "Pacific Alliance"
+    },
+    {
+        "code": "AU",
+        "text": "African Union"
+    },
+    {
+        "code": "USAN",
+        "text": "Union of South American Nations"
+    },
+    {
+        "code": "EEU",
+        "text": "Eurasian Economic Union"
+    },
+    {
+        "code": "AL",
+        "text": "Arab League"
+    },
+    {
+        "code": "ASEAN",
+        "text": "Association of Southeast Asian Nations"
+    },
+    {
+        "code": "CAIS",
+        "text": "Central American Integration System"
+    },
+    {
+        "code": "CEFTA",
+        "text": "Central European Free Trade Agreement"
+    },
+    {
+        "code": "NAFTA",
+        "text": "North American Free Trade Agreement"
+    },
+    {
+        "code": "SAARC",
+        "text": "South Asian Association for Regional Cooperation"
+    }
+]

--- a/demo/molecule/select/demo/index.js
+++ b/demo/molecule/select/demo/index.js
@@ -9,6 +9,8 @@ import MoleculeSelectOption from '@s-ui/react-molecule-dropdown-option'
 
 import {IconCloseTag, IconArrowDown} from './Icons'
 
+import ComboCountries from './components/ComboCountries'
+
 import {countries as countriesList} from './data'
 import countriesData from './data/countries.json'
 import './index.scss'
@@ -148,6 +150,12 @@ const Demo = () => (
           </MoleculeSelectOption>
         ))}
       </MoleculeSelectWithState>
+    </div>
+
+    <h2>Dependant Selection</h2>
+    <div className={CLASS_DEMO_SECTION}>
+      <h3>With Placeholder</h3>
+      <ComboCountries />
     </div>
   </div>
 )

--- a/demo/molecule/select/demo/package.json
+++ b/demo/molecule/select/demo/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@s-ui/hoc": "1",
-    "@s-ui/react-molecule-dropdown-option": "1"
+    "@s-ui/react-molecule-dropdown-option": "1",
+    "axios": "^0.19.0"
   }
 }


### PR DESCRIPTION
`MoleculeSelect` was only generating internal object for handling values/texts in `componentDidMount` so no dynamic data loading via AJAX was working. This PR solves this problem

- 🌎Online Demo (_Dependant Selection_ section) → https://sui-components-molecule-select-dinamic-data-source.now.sh/workbench/molecule/select/demo