### PR TITLE
feat(molecule/select): default size for arrow icon

### DIFF
--- a/components/molecule/select/src/index.scss
+++ b/components/molecule/select/src/index.scss
@@ -12,6 +12,8 @@ $class-select-atom-input-tags: '#{$class-select-atom-input}--withTags';
 $z-select-list: $z-navigation !default;
 $mr-select-list-arrow: -$p-xxl !default;
 $pr-select-atom-input-tags: $p-xxl !default;
+$w-select-list-arrow: $sz-icon-m !default;
+$h-select-list-arrow: $sz-icon-m !default;
 
 #{$base-class} {
   outline: none;
@@ -44,6 +46,11 @@ $pr-select-atom-input-tags: $p-xxl !default;
 
       &--up {
         transform: rotate(180deg);
+      }
+
+      svg {
+        width: $w-select-list-arrow;
+        height: $h-select-list-arrow;
       }
     }
 

--- a/demo/molecule/select/demo/Icons/index.js
+++ b/demo/molecule/select/demo/Icons/index.js
@@ -10,7 +10,7 @@ const IconCloseTag = () => (
 )
 
 const IconArrowDown = () => (
-  <svg width="24" height="24" viewBox="0 0 24 24">
+  <svg>
     <defs>
       <path
         id="a"


### PR DESCRIPTION
Default size for the arrow (SVG) passed via props so it's displayed by default (now it's only displayed if the svg passed has its own height and width defined)