### PR TITLE
Feat/atom label font size customization

### DIFF
--- a/components/atom/label/src/index.js
+++ b/components/atom/label/src/index.js
@@ -9,15 +9,23 @@ const TYPES = {
   ERROR: 'error'
 }
 
-const getClass = ({type, inline}) =>
+const FONT_SIZES = {
+  LARGE: 'large',
+  MEDIUM: 'medium',
+  SMALL: 'small',
+  XSMALL: 'xsmall'
+}
+
+const getClass = ({type, inline, fontSize}) =>
   cx(CLASSNAME, {
+    [`${CLASSNAME}--${fontSize}`]: fontSize,
     [`${CLASSNAME}--${type}`]: type,
     [`${CLASSNAME}--inlineLeft`]: inline === 'left',
     [`${CLASSNAME}--inlineRight`]: inline === 'right'
   })
 
-const AtomLabel = ({name, inline, text, optionalText, type, onClick}) => (
-  <label htmlFor={name} className={getClass({type, inline})} onClick={onClick}>
+const AtomLabel = ({name, inline, text, optionalText, type, fontSize, onClick}) => (
+  <label htmlFor={name} className={getClass({type, inline, fontSize})} onClick={onClick}>
     {text}
     {optionalText && (
       <span className="sui-AtomLabel-optionalText">{optionalText}</span>
@@ -26,6 +34,10 @@ const AtomLabel = ({name, inline, text, optionalText, type, onClick}) => (
 )
 
 AtomLabel.displayName = 'AtomLabel'
+
+AtomLabel.defaultProps = {
+  fontSize: FONT_SIZES.BASE
+}
 
 AtomLabel.propTypes = {
   /**
@@ -48,6 +60,10 @@ AtomLabel.propTypes = {
    * Label type: 'success' or 'error', use AtomLabelTypes
    */
   type: PropTypes.oneOf(Object.values(TYPES)),
+  /**
+   * Font size: set different font sizes, use AtomLabelFontSizes
+   */
+  fontSize: PropTypes.oneOf(Object.values(FONT_SIZES)),
 
   /** onClick event handler */
   onClick: PropTypes.func
@@ -55,3 +71,4 @@ AtomLabel.propTypes = {
 
 export default AtomLabel
 export {TYPES as AtomLabelTypes}
+export {FONT_SIZES as AtomLabelFontSizes}

--- a/components/atom/label/src/index.js
+++ b/components/atom/label/src/index.js
@@ -35,10 +35,6 @@ const AtomLabel = ({name, inline, text, optionalText, type, fontSize, onClick}) 
 
 AtomLabel.displayName = 'AtomLabel'
 
-AtomLabel.defaultProps = {
-  fontSize: FONT_SIZES.MEDIUM
-}
-
 AtomLabel.propTypes = {
   /**
    * used as for attribute. Must be the same as the form element id

--- a/components/atom/label/src/index.js
+++ b/components/atom/label/src/index.js
@@ -36,7 +36,7 @@ const AtomLabel = ({name, inline, text, optionalText, type, fontSize, onClick}) 
 AtomLabel.displayName = 'AtomLabel'
 
 AtomLabel.defaultProps = {
-  fontSize: FONT_SIZES.BASE
+  fontSize: FONT_SIZES.MEDIUM
 }
 
 AtomLabel.propTypes = {

--- a/components/atom/label/src/index.scss
+++ b/components/atom/label/src/index.scss
@@ -6,12 +6,27 @@ $c-atom-label-type: success $c-success, error $c-error;
 
 .sui-AtomLabel {
   display: block;
-  font-size: $fz-base;
   margin-bottom: $m-s;
 
   &-optionalText {
     color: $c-atom-label-optional;
     margin-left: $m-s;
+  }
+
+  &--xsmall {
+    font-size: $fz-xs;
+  }
+
+  &--small {
+    font-size: $fz-s;
+  }
+
+  &--medium {
+    font-size: $fz-base;
+  }
+
+  &--large {
+    font-size: $fz-l;
   }
 
   &--inlineLeft {

--- a/components/atom/label/src/index.scss
+++ b/components/atom/label/src/index.scss
@@ -6,6 +6,7 @@ $c-atom-label-type: success $c-success, error $c-error;
 
 .sui-AtomLabel {
   display: block;
+  font-size: $fz-base;
   margin-bottom: $m-s;
 
   &-optionalText {
@@ -22,7 +23,7 @@ $c-atom-label-type: success $c-success, error $c-error;
   }
 
   &--medium {
-    font-size: $fz-base;
+    font-size: $fz-m;
   }
 
   &--large {

--- a/demo/atom/label/playground
+++ b/demo/atom/label/playground
@@ -54,5 +54,27 @@ return (
         inline="right"
       />
     </div>
+
+    <div style={{marginBottom: '16px'}}>
+      <input id="atomLabelRight" type="checkbox" />
+      <AtomLabel
+        name="atomLabelRight"
+        for="atomLabelRight"
+        text="Hello large font size label"
+        inline="right"
+        fontSize={AtomLabelFontSizes.LARGE}
+      />
+    </div>
+
+    <div style={{marginBottom: '16px'}}>
+      <input id="atomLabelRight" type="checkbox" />
+      <AtomLabel
+        name="atomLabelRight"
+        for="atomLabelRight"
+        text="Hello xsmall font size label"
+        inline="right"
+        fontSize={AtomLabelFontSizes.XSMALL}
+      />
+    </div>
   </div>
 )


### PR DESCRIPTION
**What does this PR do?**
Add fontSize prop in order to be able to customize AtomLabel font size.

**Demo link**
Waiting to be generated...

**Demo Screenshot**
![image](https://user-images.githubusercontent.com/1105226/62279733-f60ae700-b44a-11e9-9bf9-7f601040812c.png)
