### PR TITLE
feat(molecule/select): implement readOnly property on MultipleSelection and SingleSelection

### DIFF
--- a/components/molecule/select/src/components/MultipleSelection.js
+++ b/components/molecule/select/src/components/MultipleSelection.js
@@ -22,6 +22,7 @@ const MoleculeSelectFieldMultiSelection = props => {
     keysSelection,
     id,
     size,
+    readOnly,
     optionsData = {}
   } = props
 
@@ -56,6 +57,7 @@ const MoleculeSelectFieldMultiSelection = props => {
         optionsData={optionsData}
         autocomplete="off"
         noBorder
+        readOnly={readOnly}
       />
       <MoleculeDropdownList
         checkbox

--- a/components/molecule/select/src/components/SingleSelection.js
+++ b/components/molecule/select/src/components/SingleSelection.js
@@ -21,6 +21,7 @@ const MoleculeSelectSingleSelection = props => {
     placeholder,
     id,
     disabled,
+    readOnly,
     optionsData = {}
   } = props
 
@@ -33,6 +34,7 @@ const MoleculeSelectSingleSelection = props => {
   return (
     <Fragment>
       <MoleculeInputSelect
+        readOnly={readOnly}
         disabled={disabled}
         id={id}
         isOpen={isOpen}

--- a/demo/molecule/select/demo/index.js
+++ b/demo/molecule/select/demo/index.js
@@ -136,6 +136,25 @@ const Demo = () => (
     </div>
 
     <div className={CLASS_DEMO_SECTION}>
+      <h3>With preselected Value and readOnly attr</h3>
+      <MoleculeSelectWithState
+        placeholder="Select some countries..."
+        value={['India', 'Luxembourg']}
+        onChange={(_, {value}) => console.log(value)}
+        iconCloseTag={<IconCloseTag />}
+        iconArrowDown={<IconArrowDown />}
+        multiselection
+        readOnly
+      >
+        {countriesList.map((country, i) => (
+          <MoleculeSelectOption key={i} value={country}>
+            {country}
+          </MoleculeSelectOption>
+        ))}
+      </MoleculeSelectWithState>
+    </div>
+
+    <div className={CLASS_DEMO_SECTION}>
       <h3>With different value and displayed text</h3>
       <MoleculeSelectWithState
         placeholder="Select some countries..."


### PR DESCRIPTION
On mobile web, when tapping on a `MoleculeSelectFieldMultiSelection` or `MoleculeSelectFieldSingleSelection`, the input keyboard pops up.
The `readOnly` property prevents that from happening on the input component at an atomic level but it seemed like the molecules were not passing down that property. Now it is.
I've added markup to the `molecule/select` demo for that case. A demo can be found here: https://public.jordimunoz.now.sh