### PR TITLE
fix(atom/input): fix input:disabled look on iOS/safari

### DIFF
--- a/components/atom/input/src/Input/Component/index.scss
+++ b/components/atom/input/src/Input/Component/index.scss
@@ -38,6 +38,8 @@ $class-read-only: '#{$base-class}--readOnly';
     &:not(#{$class-read-only}) {
       background: $bgc-atom-input-disabled;
     }
+    opacity: 1;
+    -webkit-appearance: none;
   }
 
   &:focus {


### PR DESCRIPTION
**Background**
iOS Safari is rendering the input element of a disabled input atom with a 0.4 opacity and a subtle shade under the top border which makes it inconsistent with the look & feel of other SUI components that make use of the input atom such as Molecule Select. 

**Goal**
To fix this inconsistency.
Before this change: 
![image](https://user-images.githubusercontent.com/18154356/65137488-b9e71200-da09-11e9-8160-6f644539bb07.png)
After this change:
![image](https://user-images.githubusercontent.com/18154356/65137694-15b19b00-da0a-11e9-9e6c-c4cd618b3581.png)

**Tradeoffs**
This adds a bit of browser-specific attributes to the codebase.