### PR TITLE
fix(molecule/select): set opacity: 1 and appearance: none to disabled input element

### DIFF
--- a/components/molecule/select/src/index.scss
+++ b/components/molecule/select/src/index.scss
@@ -40,6 +40,11 @@ $bgc-atom-input-disabled: $c-gray-lightest !default;
         }
       }
 
+      #{$class-select-atom-input-input}:disabled {
+        opacity: 1;
+        -webkit-appearance: none;
+      }
+
       #{$class-select-atom-input-input}:first-child,
       #{$class-select-atom-input-tags} {
         padding-right: $pr-select-atom-input-tags;


### PR DESCRIPTION
… when used in molecule select.

**Background**
iOS Safari is rendering the input element of a disabled Atom Input within a Molecule Select with a 0.4 opacity and a subtle shade under the top border which makes it inconsistent with the look & feel of other SUI components. 

**Goal**
To fix this inconsistency.

Before this change: 
![image](https://user-images.githubusercontent.com/18154356/65151074-aa75c200-da25-11e9-9432-a733f9fd8852.png)

After this change:
![image](https://user-images.githubusercontent.com/18154356/65151099-b497c080-da25-11e9-9cd6-1f87410b3e8c.png)

**Tradeoffs**
This adds a bit of browser-specific attributes to the codebase.