### PR TITLE
feat(atom/slider): add onAfterChange

### DIFF
--- a/components/atom/slider/src/index.js
+++ b/components/atom/slider/src/index.js
@@ -40,6 +40,7 @@ const createHandler = (
 
 const AtomSlider = ({
   onChange,
+  onAfterChange,
   value,
   min,
   max,
@@ -73,10 +74,17 @@ const AtomSlider = ({
     onChange(e, {value})
   }
 
+  const handleAfterChange = value => {
+    const e = {}
+    setLabelValue(value)
+    onAfterChange(e, {value})
+  }
+
   const customProps = {
     defaultValue: defaultValue || (range ? [min, max] : value),
     handle: createHandler(refAtomSlider, handleComponent, hideTooltip),
     onChange: handleChange,
+    onAfterChange: handleAfterChange,
     disabled,
     marks: markerFactory({step, min, max, marks}),
     max,
@@ -133,6 +141,10 @@ AtomSlider.propTypes = {
 
   /* callback to be called with every update of the input value */
   onChange: PropTypes.func,
+
+  /* callback to be called with when the ontouchend or onmouseup event is triggered */
+  onAfterChange: PropTypes.func,
+
   /* only if range=false, shows a position fixed label with the current value instead of a tooltip */
   valueLabel: PropTypes.bool,
   /* Set your own mark labels */
@@ -148,6 +160,7 @@ AtomSlider.defaultProps = {
   max: 100,
   step: 1,
   onChange: () => {},
+  onAfterChange: () => {},
   hideTooltip: false
 }
 

--- a/components/atom/slider/src/index.js
+++ b/components/atom/slider/src/index.js
@@ -76,7 +76,6 @@ const AtomSlider = ({
 
   const handleAfterChange = value => {
     const e = {}
-    setLabelValue(value)
     onAfterChange(e, {value})
   }
 

--- a/demo/atom/slider/playground
+++ b/demo/atom/slider/playground
@@ -51,5 +51,13 @@ return (
     <div style={stylesSection}>
       <AtomSlider onChange={console.log} min={6000} max={60000} step={1000} valueLabel valueLabelFormatter={numberWithCommas} marks={['6K', '+60K']} hideTooltip />
     </div>
+    <h3>Range with After Change callback</h3>
+    <div style={stylesSection}>
+      <AtomSlider range step={10} onAfterChange={console.log}/>
+    </div>
+    <h3>Slider with After Change callback</h3>
+    <div style={stylesSection}>
+      <AtomSlider  step={10} onAfterChange={console.log}/>
+    </div>
   </div>
 )


### PR DESCRIPTION
add onAfterChange prop to allow to execute a callback when the user ends the interaction with the slider

Based on https://www.npmjs.com/package/rc-slider documentation