### PR TITLE
Feat/remove fixed type

### DIFF
--- a/components/molecule/buttonGroup/package.json
+++ b/components/molecule/buttonGroup/package.json
@@ -9,8 +9,7 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
-    "@schibstedspain/sui-atom-button": "1"
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/molecule/buttonGroup/src/index.js
+++ b/components/molecule/buttonGroup/src/index.js
@@ -2,8 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
-import {atomButtonTypes} from '@schibstedspain/sui-atom-button'
-
 const BASE_CLASS = 'sui-MoleculeButtonGroup'
 
 const getGroupPosition = (groupPositions, numChildren, index) => {
@@ -16,7 +14,6 @@ const MoleculeButtonGroup = ({
   children,
   fullWidth,
   groupPositions,
-  type,
   ...props
 }) => {
   const numChildren = children.length
@@ -31,7 +28,6 @@ const MoleculeButtonGroup = ({
       const groupPosition = getGroupPositionByIndex(index)
       return React.cloneElement(child, {
         ...props,
-        type,
         groupPosition,
         fullWidth
       })
@@ -47,8 +43,6 @@ MoleculeButtonGroup.displayName = 'MoleculeButtonGroup'
 
 MoleculeButtonGroup.propTypes = {
   children: PropTypes.arrayOf(PropTypes.element),
-  /** Type of button: 'primary' (default), 'accent', 'secondary', 'tertiary' */
-  type: PropTypes.oneOf(atomButtonTypes),
 
   /** If buttons should stretch to fit the width of container */
   fullWidth: PropTypes.bool,
@@ -62,8 +56,7 @@ MoleculeButtonGroup.defaultProps = {
     FIRST: 'first',
     MIDDLE: 'middle',
     LAST: 'last'
-  },
-  type: 'secondary'
+  }
 }
 
 export default MoleculeButtonGroup

--- a/demo/molecule/buttonGroup/demo/index.js
+++ b/demo/molecule/buttonGroup/demo/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types, no-unused-vars, no-console */
 
-import React, {useState} from 'react'
+import React from 'react'
 
 import MoleculeButtonGroup from '../../../../components/molecule/buttonGroup/src'
 import AtomButtom, {

--- a/demo/molecule/buttonGroup/demo/index.js
+++ b/demo/molecule/buttonGroup/demo/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types, no-unused-vars, no-console */
 
-import React from 'react'
+import React, {useState} from 'react'
 
 import MoleculeButtonGroup from '../../../../components/molecule/buttonGroup/src'
 import AtomButtom, {
@@ -11,13 +11,45 @@ import SimpleOptionsRadioForm from './inputRadio'
 import SimpleOptionsCheckboxForm from './inputCheckbox'
 import './index.scss'
 
+const ButtonDesignByState = () => {
+  const [selected, setSelected] = useState()
+
+  const _onClick = buttonId => {
+    console.log(buttonId)
+    setSelected(buttonId)
+  }
+
+  return (
+    <MoleculeButtonGroup>
+      <AtomButtom
+        design={selected !== 'A' && 'outline'}
+        onClick={() => _onClick('A')}
+      >
+        A
+      </AtomButtom>
+      <AtomButtom
+        design={selected !== 'B' && 'outline'}
+        onClick={() => _onClick('B')}
+      >
+        B
+      </AtomButtom>
+      <AtomButtom
+        design={selected !== 'C' && 'outline'}
+        onClick={() => _onClick('C')}
+      >
+        C
+      </AtomButtom>
+    </MoleculeButtonGroup>
+  )
+}
+
 const Demo = () => {
   return (
     <div className="DemoMoleculeButtonGroup">
       <h1>MoleculeButtonGroup</h1>
       <div className="DemoMoleculeButtonGroup-section">
         <h2>As a group of buttons that trigger some action (or link)</h2>
-        <MoleculeButtonGroup type="secondary">
+        <MoleculeButtonGroup>
           <AtomButtom onClick={e => window.alert('clicked A')}>A</AtomButtom>
           <AtomButtom onClick={e => window.alert('clicked B')}>B</AtomButtom>
           <AtomButtom onClick={e => window.alert('clicked C')}>C</AtomButtom>
@@ -35,52 +67,17 @@ const Demo = () => {
         </h2>
         <SimpleOptionsCheckboxForm />
       </div>
-      <div className="DemoMoleculeButtonGroup-section--fullWidth">
-        <h2>Secondary (Full Width)</h2>
-        <MoleculeButtonGroup type="secondary" fullWidth>
-          <AtomButtom>A</AtomButtom>
-          <AtomButtom>B</AtomButtom>
-          <AtomButtom>C</AtomButtom>
-        </MoleculeButtonGroup>
-      </div>
       <div style={{width: '500px'}} className="DemoMoleculeButtonGroup-section">
-        <h2>Secondary (specifying groupPositions)</h2>
-        <MoleculeButtonGroup
-          type="secondary"
-          groupPositions={atomButtonGroupPositions}
-        >
+        <h2>specifying groupPositions</h2>
+        <MoleculeButtonGroup groupPositions={atomButtonGroupPositions}>
           <AtomButtom>A</AtomButtom>
           <AtomButtom>B</AtomButtom>
           <AtomButtom>C</AtomButtom>
         </MoleculeButtonGroup>
       </div>
       <div className="DemoMoleculeButtonGroup-section">
-        <h2>Tertiary</h2>
-        <MoleculeButtonGroup type="tertiary">
-          <AtomButtom>A</AtomButtom>
-          <AtomButtom>B</AtomButtom>
-          <AtomButtom>C</AtomButtom>
-        </MoleculeButtonGroup>
-      </div>
-      <div className="DemoMoleculeButtonGroup-section">
-        <h2>Secondary (Negative)</h2>
-        <div className="DemoMoleculeButtonGroup-section--negative">
-          <MoleculeButtonGroup type="secondary" negative>
-            <AtomButtom>A</AtomButtom>
-            <AtomButtom>B</AtomButtom>
-            <AtomButtom>C</AtomButtom>
-          </MoleculeButtonGroup>
-        </div>
-      </div>
-      <div className="DemoMoleculeButtonGroup-section">
-        <h2>Tertiary (Negative)</h2>
-        <div className="DemoMoleculeButtonGroup-section--negative">
-          <MoleculeButtonGroup type="tertiary" negative>
-            <AtomButtom>A</AtomButtom>
-            <AtomButtom>B</AtomButtom>
-            <AtomButtom>C</AtomButtom>
-          </MoleculeButtonGroup>
-        </div>
+        <h2>different design dependeding on state</h2>
+        <ButtonDesignByState />
       </div>
     </div>
   )

--- a/demo/molecule/buttonGroup/demo/index.js
+++ b/demo/molecule/buttonGroup/demo/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types, no-unused-vars, no-console */
 
-import React from 'react'
+import React, {useState} from 'react'
 
 import MoleculeButtonGroup from '../../../../components/molecule/buttonGroup/src'
 import AtomButtom, {


### PR DESCRIPTION
main reason of this change is that we need to be able to set different `designs` to different buttons inside this component but it's setting the same for all. 

I'm going to remove it completely and create a major because of:
- The button component prioritizes the `type` property higher than `design` or `color` which could be handled by adding some logic here but would make this component even more sui-atom-button dependent
- The`type` prop is already deprecated within the atom button component
- Removing the `type` prop makes this component reusable wrapping other type of buttons or components that aren't the sui-atom-button component, the dependency would be completely removed