### PR TITLE
Feature/enable color and space to label

### DIFF
--- a/components/atom/label/src/index.scss
+++ b/components/atom/label/src/index.scss
@@ -1,13 +1,16 @@
 @import '~@schibstedspain/sui-theme/lib/settings';
 @import '~@schibstedspain/sui-theme/lib/index';
 
+$c-atom-label: inherit !default;
 $c-atom-label-optional: $c-gray-light !default;
+$mb-atom-label: $m-s !default;
 $c-atom-label-type: success $c-success, error $c-error;
 
 .sui-AtomLabel {
   display: block;
+  color: $c-atom-label;
   font-size: $fz-base;
-  margin-bottom: $m-s;
+  margin-bottom: $mb-atom-label;
 
   &-optionalText {
     color: $c-atom-label-optional;

--- a/components/atom/label/src/index.scss
+++ b/components/atom/label/src/index.scss
@@ -3,7 +3,7 @@
 
 $c-atom-label: inherit !default;
 $c-atom-label-optional: $c-gray-light !default;
-$fw-atom-label: $fw-semi-bold !default;
+$fw-atom-label: inherit !default;
 $mb-atom-label: $m-s !default;
 $c-atom-label-type: success $c-success, error $c-error;
 

--- a/components/atom/label/src/index.scss
+++ b/components/atom/label/src/index.scss
@@ -3,6 +3,7 @@
 
 $c-atom-label: inherit !default;
 $c-atom-label-optional: $c-gray-light !default;
+$fw-atom-label: $fw-semi-bold !default;
 $mb-atom-label: $m-s !default;
 $c-atom-label-type: success $c-success, error $c-error;
 
@@ -10,6 +11,7 @@ $c-atom-label-type: success $c-success, error $c-error;
   display: block;
   color: $c-atom-label;
   font-size: $fz-base;
+  font-weight: $fw-atom-label;
   margin-bottom: $mb-atom-label;
 
   &-optionalText {


### PR DESCRIPTION
Allow the customization of the `font-weight`, `inferior spacing` and `color` of `AtomLabel`. I added the `inherit` as a default value to ensure compatibility.