### PR TITLE
feat(atom/backToTop): add min height prop

### DIFF
--- a/components/atom/backToTop/README.md
+++ b/components/atom/backToTop/README.md
@@ -71,5 +71,19 @@ import AtomBackToTop, {backToTopStyles} from '@s-ui/react-atom-back-to-top'
 </div>
 ```
 
+### Customizing minimum height when back to top button become visible → 1000px
+
+```javascript
+<div id="container">
+  <p>Very looong text...</p>
+  <AtomBackToTop
+    iconTop={iconTop}
+    textTop="TOP"
+    refContainer="container"
+    minHeight={1000}
+  />
+</div>
+```
+
 
 > **Find full description and more examples in the [demo page](https://sui-components.now.sh/workbench/atom/backToTop/demo).**

--- a/components/atom/backToTop/src/index.js
+++ b/components/atom/backToTop/src/index.js
@@ -18,11 +18,12 @@ const STYLES = {
 
 const AtomBackToTop = ({
   iconTop: IconTop,
+  minHeight,
   textTop,
-  scrollSteps,
-  scrollIntervalTime,
-  refContainer,
-  style
+  scrollSteps = 100,
+  scrollIntervalTime = 50,
+  refContainer = document.body,
+  style = STYLES.DARK
 }) => {
   const [show, setShow] = useState(false)
   const [hover, setHover] = useState(false)
@@ -35,7 +36,7 @@ const AtomBackToTop = ({
       const {scrollTop, scrollHeight, clientHeight} = container
       const halfHeight = Math.floor((scrollHeight - clientHeight) / 2)
 
-      if (scrollTop > halfHeight) {
+      if (scrollTop > halfHeight || scrollTop > minHeight) {
         if (!show) {
           setShow(true)
         }
@@ -51,7 +52,7 @@ const AtomBackToTop = ({
     return () => {
       container.removeEventListener('scroll', handleScroll)
     }
-  }, [refContainer, show])
+  }, [minHeight, refContainer, show])
 
   const scrollStep = () => {
     const container = getTarget(refContainer)
@@ -100,6 +101,9 @@ AtomBackToTop.propTypes = {
   /** Icon (component) to be displayed */
   iconTop: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
 
+  /** Minimum height (in pixels) to show button */
+  minHeight: PropTypes.number,
+
   /** Text to be displayed */
   textTop: PropTypes.string,
 
@@ -118,13 +122,6 @@ AtomBackToTop.propTypes = {
    *  LIGHT →'light'
    */
   style: PropTypes.oneOf(Object.values(STYLES))
-}
-
-AtomBackToTop.defaultProps = {
-  refContainer: document.body,
-  style: STYLES.DARK,
-  scrollIntervalTime: 50,
-  scrollSteps: 100
 }
 
 export {STYLES as backToTopStyles}


### PR DESCRIPTION
With that optional prop, we now can define a minimum height in pixels to show back to top button.
```
/** Minimum height (in pixels) to show button */
minHeight: PropTypes.number,
```
_The problem I want to solve_: 
To show the button when the user at the half of the scrollHeight is good but in the case, we got a scroll of maybe 6000px, the user doesn't have a quick way to back to top until he arrives at 3000px.
With that prop, we can have the option to show that button before, higher on the page, at maybe 1000px.

Please, share your thoughts about it!