### PR TITLE
fix(atom/input): add default prop value to onChange prop

### DIFF
--- a/components/atom/input/src/Password/index.js
+++ b/components/atom/input/src/Password/index.js
@@ -60,7 +60,8 @@ Password.propTypes = {
 
 Password.defaultProps = {
   pwShowLabel: SHOW_LABEL,
-  pwHideLabel: HIDE_LABEL
+  pwHideLabel: HIDE_LABEL,
+  onChange: () => {}
 }
 
 export default Password


### PR DESCRIPTION
- Add default prop to `onChange` prop in `atom/input/Password/index.js` component (like in atom/input/Input/Component/index.js). 
- Without the default prop, if not `onChange` prop is passed it throws an `Uncaught TypeError: onChange is not a function` error