### PR TITLE
fix(atom/tooltip): disable linter for external lib case use

### DIFF
--- a/components/atom/tooltip/src/index.js
+++ b/components/atom/tooltip/src/index.js
@@ -217,7 +217,7 @@ class AtomTooltip extends Component {
           <Tooltip
             {...restrictedProps}
             isOpen={isOpen}
-            toggle={this.handleToggle}
+            toggle={this.handleToggle} // eslint-disable-line
             className={BASE_CLASS}
             innerClassName={CLASS_INNER}
             arrowClassName={CLASS_ARROW}


### PR DESCRIPTION
After merging latest changes from `master` to my current `branch`, I cannot  commit until some inherited linter issues are solved:

```
/Users/juanma/PROJECTS/2019/SCHIBSTED/sui-components/components/atom/tooltip/src/index.js
  220:13  warning  Prop key for handleToggle must begin with 'on'  react/jsx-handler-names
```
