### PR TITLE
fix(atom/checkbox): linter issue w/ the use of Fragment

### DIFF
--- a/components/atom/checkbox/src/index.js
+++ b/components/atom/checkbox/src/index.js
@@ -1,4 +1,4 @@
-import React, {Fragment} from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
@@ -31,7 +31,7 @@ const AtomCheckbox = ({
   const className = cx(BASE_CLASS, getErrorStateClass(errorState))
 
   return (
-    <Fragment>
+    <>
       <input
         className={className}
         type="checkbox"
@@ -41,7 +41,7 @@ const AtomCheckbox = ({
         onChange={handleChange}
         {...props}
       />
-    </Fragment>
+    </>
   )
 }
 


### PR DESCRIPTION
After merging latest changes from `master` to my current `branch`, I cannot  commit until some inherited linter issues are solved:

```
/Users/juanma/PROJECTS/2019/SCHIBSTED/sui-components/components/atom/checkbox/src/index.js
  34:5  error  Prefer fragment shorthand over React.Fragment  react/jsx-fragments
```
