### PR TITLE
Feat/molecule notification rounded corners

### DIFF
--- a/components/molecule/notification/README.md
+++ b/components/molecule/notification/README.md
@@ -9,6 +9,10 @@ $ npm install @s-ui/react-molecule-notification --save
 ```
 
 ## Usage
+- Yo can set the amount of `border-radius` for the rounded version (square always to 0, rounded always to 50%) assigning a value to its Sass var:
+```scss
+$bdrs-notification: 50%;
+```
 
 ### Basic usage
 ```js
@@ -33,6 +37,7 @@ return (
     type='success'
     autoclose='short'
     buttons={BUTTONS}
+    roundedCorners
   >
     <p>Lorem fistrum</p>
   </MoleculeNotification>

--- a/components/molecule/notification/README.md
+++ b/components/molecule/notification/README.md
@@ -8,15 +8,9 @@
 $ npm install @s-ui/react-molecule-notification --save
 ```
 
-## Usage
-- Yo can set the amount of `border-radius` for the rounded version (square always to 0, rounded always to 50%) assigning a value to its Sass var:
-```scss
-$bdrs-notification: 50%;
-```
-
 ### Basic usage
 ```js
-import MoleculeNotification from '@s-ui/react-molecule-notification'
+import MoleculeNotification, {BRDS_SIZE} from '@s-ui/react-molecule-notification'
 
 // sui-atom-button
 const BUTTONS = [
@@ -32,16 +26,29 @@ const BUTTONS = [
   }
 ]
 
+// import named export sizes from component as seen above
+BRDS_SIZE = {
+  extraLarge: 'xl',
+  large: 'l',
+  medium: 'm',
+  small: 's',
+  extraSmall: 'xs'
+}
+
 return (
   <MoleculeNotification
     type='success'
     autoclose='short'
     buttons={BUTTONS}
-    roundedCorners
+    roundedCorners={BRDS_SIZE.medium}
   >
     <p>Lorem fistrum</p>
   </MoleculeNotification>
 )
 ```
+
+## Border Radius usage
+- Define a `$bdrs-base` Sass var value in your vertical theme to get 5 different border radius sizes. Then import the `BRDS_SIZE` object to get `extraSmall`, `small`, `medium`, `large` and `extraLarge` sizes in declarative way.
+
 
 > **Find full description and more examples in the [demo page](https://sui-components.now.sh/workbench/molecule/notification).**

--- a/components/molecule/notification/UXDEF.md
+++ b/components/molecule/notification/UXDEF.md
@@ -120,9 +120,8 @@ Bear in mind that relative position messages with transition will pull the conte
 
 ![](https://d2mxuefqeaa7sj.cloudfront.net/s_8772120B34E0CB7B174A0EEA386772318CAF9D1A92F3091FED38E365CE95C47C_1507200463973_3.1-Notification-Metrics.png)
 
-The component should have two versions (positive and negative). The color of the positive one should be the L4.
-
-![](https://d2mxuefqeaa7sj.cloudfront.net/s_E092CE3EB611E387327F26BBC63239DAFC64F84BCDF8D5C533DE374AA594FD10_1542105969752_05-Content+NotificacionesSUI.jpg)
+- The component should have two versions (positive and negative). The color of the positive one should be the L4.
+- Rounded corners might be applied by using a declarative `roundedCorners` property.
 
 ## Responsive
 

--- a/components/molecule/notification/src/_settings.scss
+++ b/components/molecule/notification/src/_settings.scss
@@ -2,6 +2,7 @@ $w-notification: 100% !default;
 $z-notification: 1000 !default;
 $mh-notification: 500px !default;
 $sz-notification-icon: $sz-icon-m !default;
+$bdrs-notification: 8px !default;
 
 // Colors
 
@@ -19,6 +20,26 @@ $notification-type-font-colors: (
   warning: $c-white,
   error: $c-white,
   system: $c-white
+) !default;
+
+// Positive Text color
+
+$notification-type-positive-text-colors: (
+  info: $c-primary,
+  success: $c-success,
+  warning: $c-alert,
+  error: $c-error,
+  system: $c-system
+) !default;
+
+// Positive Icon color
+
+$notification-type-positive-icon-colors: (
+  info: $c-primary,
+  success: $c-success,
+  warning: $c-alert,
+  error: $c-error,
+  system: $c-system
 ) !default;
 
 // Effects

--- a/components/molecule/notification/src/_settings.scss
+++ b/components/molecule/notification/src/_settings.scss
@@ -3,8 +3,6 @@ $z-notification: 1000 !default;
 $mh-notification: 500px !default;
 $sz-notification-icon: $sz-icon-m !default;
 
-$bdrs-base: 8px !default; // To BE Defined in SUI-THEME
-
 $bdrs-notification: (
   xl: $bdrs-base * 4,
   l: $bdrs-base * 2,

--- a/components/molecule/notification/src/_settings.scss
+++ b/components/molecule/notification/src/_settings.scss
@@ -2,7 +2,16 @@ $w-notification: 100% !default;
 $z-notification: 1000 !default;
 $mh-notification: 500px !default;
 $sz-notification-icon: $sz-icon-m !default;
-$bdrs-notification: 8px !default;
+
+$bdrs-base: 8px !default; // To BE Defined in SUI-THEME
+
+$bdrs-notification: (
+  xl: $bdrs-base * 4,
+  l: $bdrs-base * 2,
+  m: $bdrs-base,
+  s: $bdrs-base / 2,
+  xs: $bdrs-base / 4
+) !default;
 
 // Colors
 

--- a/components/molecule/notification/src/index.js
+++ b/components/molecule/notification/src/index.js
@@ -33,6 +33,14 @@ const VARIATIONS = {
   positive: 'positive'
 }
 
+const BRDS_SIZE = {
+  extraLarge: 'xl',
+  large: 'l',
+  medium: 'm',
+  small: 's',
+  extraSmall: 'xs'
+}
+
 const MoleculeNotification = ({
   autoClose: autoCloseTiming,
   onClose,
@@ -125,7 +133,7 @@ const MoleculeNotification = ({
       [`${CLASS}--${variation}`]: variation === VARIATIONS.positive,
       [`${CLASS}-effect--${position}`]: effect,
       [`${CLASS}-effect--hide`]: effect && delay,
-      [`${CLASS}--roundedCorners`]: roundedCorners
+      [`${CLASS}-roundedCorners--${roundedCorners}`]: roundedCorners
     }
   )
 
@@ -184,8 +192,15 @@ MoleculeNotification.propTypes = {
   /** Positions: 'top', 'bottom', 'relative' */
   position: PropTypes.string,
 
-  /** Adds / Remove rounded corners */
-  roundedCorners: PropTypes.bool,
+  /**
+   * Border Radius sizes:
+   * 'xl',
+   * 'l',
+   * 'm' (default),
+   * 's',
+   * 'xs',
+   */
+  roundedCorners: PropTypes.oneOf(Object.values(BRDS_SIZE)),
 
   /** Show / hide notification */
   show: PropTypes.bool,
@@ -208,11 +223,13 @@ MoleculeNotification.defaultProps = {
   effect: true,
   onClose: () => {},
   position: 'relative',
-  roundedCorners: false,
+  roundedCorners: null,
   show: true,
   showCloseButton: true,
   type: 'info',
   variation: VARIATIONS.negative
 }
+
+export {BRDS_SIZE}
 
 export default React.memo(MoleculeNotification)

--- a/components/molecule/notification/src/index.js
+++ b/components/molecule/notification/src/index.js
@@ -41,6 +41,7 @@ const MoleculeNotification = ({
   children,
   icon,
   position,
+  roundedCorners,
   showCloseButton,
   text,
   type,
@@ -123,7 +124,8 @@ const MoleculeNotification = ({
     {
       [`${CLASS}--${variation}`]: variation === VARIATIONS.positive,
       [`${CLASS}-effect--${position}`]: effect,
-      [`${CLASS}-effect--hide`]: effect && delay
+      [`${CLASS}-effect--hide`]: effect && delay,
+      [`${CLASS}--roundedCorners`]: roundedCorners
     }
   )
 
@@ -182,6 +184,9 @@ MoleculeNotification.propTypes = {
   /** Positions: 'top', 'bottom', 'relative' */
   position: PropTypes.string,
 
+  /** Adds / Remove rounded corners */
+  roundedCorners: PropTypes.bool,
+
   /** Show / hide notification */
   show: PropTypes.bool,
 
@@ -203,6 +208,7 @@ MoleculeNotification.defaultProps = {
   effect: true,
   onClose: () => {},
   position: 'relative',
+  roundedCorners: false,
   show: true,
   showCloseButton: true,
   type: 'info',

--- a/components/molecule/notification/src/index.scss
+++ b/components/molecule/notification/src/index.scss
@@ -66,8 +66,18 @@ $base-class: '.sui-MoleculeNotification';
   &--positive {
     color: $c-black;
 
-    #{$base-class}-icon svg {
-      fill: $c-gray !important;
+    // Type text in positive variations
+    @each $key, $value in $notification-type-positive-text-colors {
+      &#{$base-class}--#{$key} {
+        color: $value !important;
+      }
+    }
+
+    // Type text in positive variations
+    @each $key, $value in $notification-type-positive-icon-colors {
+      &#{$base-class}--#{$key} #{$base-class}-icon svg {
+        fill: $value !important;
+      }
     }
 
     // Type variations
@@ -76,6 +86,11 @@ $base-class: '.sui-MoleculeNotification';
         background-color: color-variation($value, $c-light-step * 2);
       }
     }
+  }
+
+  // Rounded corners
+  &--roundedCorners {
+    border-radius: $bdrs-notification;
   }
 
   // Position

--- a/components/molecule/notification/src/index.scss
+++ b/components/molecule/notification/src/index.scss
@@ -89,8 +89,10 @@ $base-class: '.sui-MoleculeNotification';
   }
 
   // Rounded corners
-  &--roundedCorners {
-    border-radius: $bdrs-notification;
+  @each $key, $value in $bdrs-notification {
+    &#{$base-class}-roundedCorners--#{$key} {
+      border-radius: $value;
+    }
   }
 
   // Position

--- a/demo/molecule/notification/playground
+++ b/demo/molecule/notification/playground
@@ -99,7 +99,7 @@ return (
       autoClose="manual"
       type="info"
       onClose={logClose}
-      roundedCorners
+      roundedCorners={BRDS_SIZE.medium}
     >
       <span>
         Lorem ipsum dolor sit amet, <a href="#">consectetur adipiscing</a> elit.

--- a/demo/molecule/notification/playground
+++ b/demo/molecule/notification/playground
@@ -71,7 +71,7 @@ const TYPES = ['info', 'success', 'warning', 'error', 'system']
 const VARIATIONS = ['positive', 'negative']
 
 return (
-  <div>
+  <div style={{margin: '32px'}}>
     <h1>Notification</h1>
     <h2>Types and variations</h2>
     {TYPES.map(type =>
@@ -93,6 +93,21 @@ return (
       ))
     )}
     <br />
+
+    <h2>With rounded corners</h2>
+    <MoleculeNotification
+      autoClose="manual"
+      type="info"
+      onClose={logClose}
+      roundedCorners
+    >
+      <span>
+        Lorem ipsum dolor sit amet, <a href="#">consectetur adipiscing</a> elit.
+        Duis vitae orci consectetur ligula vel.
+      </span>
+    </MoleculeNotification>
+    <br />
+
     <h2>With children content</h2>
     <MoleculeNotification autoClose="manual" type="info" onClose={logClose}>
       <span>


### PR DESCRIPTION
## PR Summary

This PR allows any vertical to implement a better-customized icon and text color in `Sui-Molecule-Notification`

In addition, now you can decide if you want the notification with rounded corners via a prop with pre-defined sizes:

```javascript
BRDS_SIZE = {
  extraLarge: 'xl',
  large: 'l',
  medium: 'm',
  small: 's',
  extraSmall: 'xs'
}
```

### Screenshot

![Screenshot 2019-10-10 at 12 53 32](https://user-images.githubusercontent.com/10925540/66563363-ed771100-eb5d-11e9-9be2-16042b27f99c.png)
