### PR TITLE
feat(atom/checkbox): internal hoc served from the component

### DIFF
--- a/components/atom/checkbox/src/hoc/withCheckedValue.js
+++ b/components/atom/checkbox/src/hoc/withCheckedValue.js
@@ -1,12 +1,8 @@
 import React, {useState} from 'react'
 import PropTypes from 'prop-types'
 
-import {withSwitchValue} from '@s-ui/hoc'
-
 const withCheckedValue = BaseComponent => {
   const displayName = BaseComponent.displayName
-
-  const BaseComponentWithStateValue = withSwitchValue(BaseComponent)
 
   const BaseComponentWithCheckedValue = ({
     checked: checkedFromProps = false,
@@ -21,7 +17,7 @@ const withCheckedValue = BaseComponent => {
     }
 
     return (
-      <BaseComponentWithStateValue
+      <BaseComponent
         {...props}
         checked={checked}
         onChange={handleChangeValue}
@@ -32,10 +28,8 @@ const withCheckedValue = BaseComponent => {
   BaseComponentWithCheckedValue.displayName = `withCheckboxValue(${displayName})`
 
   BaseComponentWithCheckedValue.propTypes = {
-    /** value */
     checked: PropTypes.any,
 
-    /** onChange callback  */
     onChange: PropTypes.func
   }
 

--- a/components/atom/checkbox/src/index.js
+++ b/components/atom/checkbox/src/index.js
@@ -2,6 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
+import withCheckedValue from './hoc/withCheckedValue'
+
 const BASE_CLASS = 'sui-AtomCheckbox'
 
 const ERROR_STATES = {
@@ -17,6 +19,7 @@ const getErrorStateClass = errorState => {
 
 const AtomCheckbox = ({
   id,
+  name,
   disabled,
   checked,
   onChange: onChangeFromProps,
@@ -36,6 +39,7 @@ const AtomCheckbox = ({
         className={className}
         type="checkbox"
         id={id}
+        name={name || id}
         disabled={disabled}
         checked={checked}
         onChange={handleChange}
@@ -55,6 +59,9 @@ AtomCheckbox.propTypes = {
   /* The DOM id global attribute. */
   id: PropTypes.string.isRequired,
 
+  /* name attribute for the input */
+  name: PropTypes.string,
+
   /* This Boolean attribute prevents the user from interacting with the input */
   disabled: PropTypes.bool,
 
@@ -69,3 +76,4 @@ AtomCheckbox.propTypes = {
 }
 
 export default AtomCheckbox
+export {withCheckedValue}

--- a/demo/atom/checkbox/demo/index.js
+++ b/demo/atom/checkbox/demo/index.js
@@ -1,10 +1,11 @@
 /* eslint-disable no-console */
 import React from 'react'
 
-import AtomCheckbox from '../../../../components/atom/checkbox/src'
+import AtomCheckbox, {
+  withCheckedValue
+} from '../../../../components/atom/checkbox/src'
 
 import './index.scss'
-import withCheckedValue from './hoc/withCheckedValue'
 
 const BASE_CLASS_DEMO = `DemoAtomCheckbox`
 const CLASS_SECTION = `${BASE_CLASS_DEMO}-section`
@@ -26,8 +27,7 @@ const Demo = () => {
             onChange={(ev, {value, name}) => {
               console.log({[name]: value})
             }}
-          />{' '}
-          Acepto los terminos
+          />
         </p>
       </div>
       <div className={CLASS_SECTION}>
@@ -42,7 +42,6 @@ const Demo = () => {
               console.log({[name]: value})
             }}
           />
-          Soy mayor de edad
         </p>
       </div>
       <h2>Use Cases</h2>


### PR DESCRIPTION
In order to simplify the use of this component an internal HOC that handles internal state has been attached to this components and it's exported so it can be used along w/ the stateless version of the component