### PR TITLE
fix(molecule/breadcrumb): breadcrumb item alignment and font size

### DIFF
--- a/components/molecule/breadcrumb/src/index.scss
+++ b/components/molecule/breadcrumb/src/index.scss
@@ -31,6 +31,9 @@
     flex-wrap: wrap;
 
     &Item {
+      display: flex;
+      font-size: $fz-breadcrumb-item;
+
       &:not(:last-child) {
         display: none;
       }

--- a/components/molecule/breadcrumb/src/settings.scss
+++ b/components/molecule/breadcrumb/src/settings.scss
@@ -9,3 +9,4 @@ $c-breadcrumb: $c-text-base !default;
 $m-breadcrumb-items: $m-s !default;
 $size-breadcrumb-icon: 18px !default;
 $td-breadcrumb-link-hover: none !default;
+$fz-breadcrumb-item: $fz-m !default;


### PR DESCRIPTION
**What does this PR do?**
Fix breadcrumb item alignment and font size

**What are the relevant tickets?**
https://jira.scmspain.com/browse/MMAA-9784

**Screenshot:**

**Before**
<img width="653" alt="Captura de pantalla 2019-10-17 a las 9 42 35" src="https://user-images.githubusercontent.com/1105226/67082859-45cf9380-f19a-11e9-9a42-9c080d5a0cfc.png">

**After**
![image (1)](https://user-images.githubusercontent.com/1105226/67082795-28022e80-f19a-11e9-86c2-12358f1f9ee3.png)
