### PR TITLE
fix(molecule/autosuggest): fix focusOut

### DIFF
--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -121,7 +121,7 @@ const MoleculeAutosuggest = ({multiselection, ...props}) => {
       )
       if (focusOutFromOutside && isOpen) closeList(ev)
     }, 1)
-    setFocus(true)
+    setFocus(false)
   }
 
   const handleInputKeyDown = ev => {


### PR DESCRIPTION
I've fix focus when is out. It seems an error from this change

https://github.com/SUI-Components/sui-components/commit/f29cfe8c43de7080d84ad0d675fe1be69e10ab45#diff-e06867cce6e47d40e66fdc4184a8bf60L128