### PR TITLE
feat(molecule/autosuggest): allow right icon on atom-input

### DIFF
--- a/components/molecule/autosuggest/src/components/MultipleSelection.js
+++ b/components/molecule/autosuggest/src/components/MultipleSelection.js
@@ -21,6 +21,7 @@ const MoleculeAutosuggestFieldMultiSelection = ({
   onInputKeyDown,
   onChange,
   onChangeTags,
+  onSelect,
   disabled
 }) => {
   const MoleculeInputTagsRef = useRef()
@@ -31,6 +32,10 @@ const MoleculeAutosuggestFieldMultiSelection = ({
       : [...tags, value]
 
     onChangeTags(ev, {
+      value: '',
+      tags: newTags
+    })
+    onSelect(ev, {
       value: '',
       tags: newTags
     })

--- a/components/molecule/autosuggest/src/components/SingleSelection.js
+++ b/components/molecule/autosuggest/src/components/SingleSelection.js
@@ -14,11 +14,13 @@ const MoleculeAutosuggestSingleSelection = ({
   isOpen,
   onToggle,
   onChange,
+  onClickRightIcon,
   onInputKeyDown,
   onSelect,
   size,
   innerRefInput,
   refMoleculeAutosuggest,
+  rightIcon,
   iconClear,
   placeholder,
   disabled
@@ -39,6 +41,10 @@ const MoleculeAutosuggestSingleSelection = ({
     onChange(null, {value: ''})
   }
 
+  const handleRightClick = ev => {
+    onClickRightIcon(ev, {value})
+  }
+
   return (
     <>
       <AtomInputWithClearUI
@@ -47,6 +53,8 @@ const MoleculeAutosuggestSingleSelection = ({
         onClickClear={handleClear}
         onChange={handleChange}
         iconClear={!disabled && iconClear}
+        rightIcon={rightIcon}
+        onClickRightIcon={handleRightClick}
         reference={innerRefInput}
         placeholder={placeholder}
         onKeyDown={onInputKeyDown}

--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -207,8 +207,14 @@ MoleculeAutosuggest.propTypes = {
   /** callback triggered when the user press enter when the suggestion is closed */
   onEnter: PropTypes.func,
 
+  /** callback triggered when the user clicks on right icon */
+  onClickRightIcon: PropTypes.func,
+
   /** callback triggered when the user selects the suggested item */
   onSelect: PropTypes.func,
+
+  /** Right UI Icon */
+  rightIcon: PropTypes.node,
 
   /** list of key identifiers that will trigger a selection */
   keysSelection: PropTypes.array,


### PR DESCRIPTION
Allow to pass right icon to atominput and its click handler.

Also, add missing onSelect callback for multiple selection variation.