### PR TITLE
fix(atom/tag): include classes from className prop in AtomTag classNames

### DIFF
--- a/components/atom/tag/src/index.js
+++ b/components/atom/tag/src/index.js
@@ -34,14 +34,15 @@ const filterKeys = (obj, listOfProps) =>
   }, {})
 
 const AtomTag = props => {
-  const {href, icon, onClick, size, responsive} = props
+  const {href, icon, onClick, size, responsive, className} = props
 
   const isActionable = onClick || href
   const classNames = cx(
     'sui-AtomTag',
     `sui-AtomTag-${size}`,
     responsive && 'sui-AtomTag--responsive',
-    icon && 'sui-AtomTag-hasIcon'
+    icon && 'sui-AtomTag-hasIcon',
+    className
   )
 
   /**

--- a/demo/atom/tag/playground
+++ b/demo/atom/tag/playground
@@ -23,6 +23,12 @@ return (
         onClose={() => alert('close!')}
         closeIcon={<CloseIcon />}
       />
+      <AtomTag
+        label="Tag with custom className"
+        className="custom-className"
+        onClose={() => alert('close!')}
+        closeIcon={<CloseIcon />}
+      />
       <AtomTag label="Icon Tag" icon={<Icon />} />
       <AtomTag
         label="Icon & Close Tag"


### PR DESCRIPTION
Currently, `AtomTag` is not doing anything with whatever is sent as `className` prop.
The purpose of this PR is to fix this apparent bug.