### PR TITLE
[feat] allow to set custom atom tag types

### DIFF
--- a/components/atom/tag/README.md
+++ b/components/atom/tag/README.md
@@ -25,4 +25,29 @@ import AtomTag from '@schibstedspain/sui-atom-tag'
 />
 ```
 
+### Tag types
+
+If you want to customize your tag you can pass a prop to identify this type and you also need to set your custom set of types in Sass:
+
+**Your theme file** (Sass)
+
+```css
+$atom-tag-types: (
+  "alert": (
+    bgc: red,
+    c: white
+  ),
+  "warning": (
+    bgc: orange,
+    c: white
+  )
+);
+```
+
+**Your high order component**
+
+```js
+<AtomTag type="alert" />
+```
+
 **Find full description and more examples in the [demo page](https://sui-components.now.sh/workbench/atom/tag).**

--- a/components/atom/tag/src/index.js
+++ b/components/atom/tag/src/index.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-
 import ActionableTag from './Actionable'
 import StandardTag from './Standard'
 
@@ -34,12 +33,12 @@ const filterKeys = (obj, listOfProps) =>
   }, {})
 
 const AtomTag = props => {
-  const {href, icon, onClick, size, responsive} = props
-
+  const {href, icon, onClick, size, responsive, type} = props
   const isActionable = onClick || href
   const classNames = cx(
     'sui-AtomTag',
     `sui-AtomTag-${size}`,
+    type && `sui-AtomTag--${type}`,
     responsive && 'sui-AtomTag--responsive',
     icon && 'sui-AtomTag-hasIcon'
   )
@@ -105,6 +104,11 @@ AtomTag.propTypes = {
    * Tag size
    */
   size: PropTypes.oneOf(Object.values(SIZES)),
+  /**
+   * Tag type in order to color it as desired
+   * from a high order component.
+   */
+  type: PropTypes.string,
   /**
    * true for make responsive layout. keep large size in mobile
    */

--- a/components/atom/tag/src/index.scss
+++ b/components/atom/tag/src/index.scss
@@ -167,7 +167,7 @@ $atom-tag-types: () !default;
     $bgc: map-get($type, bgc);
     $c: map-get($type, c);
 
-    &-#{$type} {
+    &--#{$type} {
       background-color: $bgc;
       color: $c;
     }

--- a/components/atom/tag/src/index.scss
+++ b/components/atom/tag/src/index.scss
@@ -167,7 +167,7 @@ $atom-tag-types: () !default;
     $bgc: map-get($type, bgc);
     $c: map-get($type, c);
 
-    &--#{$type} {
+    &--#{$name} {
       background-color: $bgc;
       color: $c;
     }

--- a/components/atom/tag/src/index.scss
+++ b/components/atom/tag/src/index.scss
@@ -12,6 +12,7 @@ $p-atom-tag-l: 0 $p-l !default;
 $p-atom-tag-m: 0 $p-l !default;
 $p-atom-tag-s: 0 $p-m !default;
 $w-atom-tag-clickable: 32px !default;
+$atom-tag-types: () !default;
 
 @mixin icon-atom-tag($type) {
   @include sui-icon--small;
@@ -159,6 +160,16 @@ $w-atom-tag-clickable: 32px !default;
       .sui-AtomTag-closeable {
         @include icon-secondary-clickable-area($h-atom-tag-l);
       }
+    }
+  }
+
+  @each $name, $type in $atom-tag-types {
+    $bgc: map-get($type, bgc);
+    $c: map-get($type, c);
+
+    &-#{$type} {
+      background-color: $bgc;
+      color: $c;
     }
   }
 }


### PR DESCRIPTION
### Description

`AtomTag` is a very atomic and fool component that in many cases needs some extra customisation by the app where is used like color and background color information. Right now it's not possible to do so despiste of overwriting the `sui` component class from the high order component that uses it, for that reason I'm suggesting to set a new prop `type` to allow this simple and controlled customisation.

### Usage

__YOUR APP THEME__ (Sass)
```css
$atom-tag-types: (
  'financed': (
    bgc: red,
    c: white
  ),
  'top': (
    bgc: blue,
    c: white
  )
);
```

__YOUR HIGH ORDER COMPONENT__
```js
<AtomTag type='financed' />
```
