### PR TITLE
fix(molecule/autosuggest): fix handle focus out issue

### DIFF
--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -68,6 +68,7 @@ const MoleculeAutosuggest = ({multiselection, ...props}) => {
     onToggle(ev, {isOpen: false})
     if (multiselection) onChange(ev, {value: ''})
     domMoleculeAutosuggest.focus()
+    setFocus(false)
     ev.preventDefault()
     ev.stopPropagation()
   }
@@ -119,9 +120,11 @@ const MoleculeAutosuggest = ({multiselection, ...props}) => {
       const focusOutFromOutside = ![domInnerInput, ...options].includes(
         currentElementFocused
       )
-      if (focusOutFromOutside && isOpen) closeList(ev)
+      if (focusOutFromOutside) {
+        isOpen ? closeList(ev) : setFocus(false)
+      }
     }, 1)
-    setFocus(false)
+    setFocus(true)
   }
 
   const handleInputKeyDown = ev => {

--- a/components/molecule/autosuggest/src/index.scss
+++ b/components/molecule/autosuggest/src/index.scss
@@ -13,6 +13,7 @@ $w-autosuggest-icon-clear: 20px !default;
 
 #{$base-class} {
   position: relative;
+  outline: none;
 
   .sui-MoleculeDropdownList {
     position: absolute;


### PR DESCRIPTION
DEMO: https://sui-components-pr-847.now.sh/workbench/molecule/autosuggest/demo

Fix issue that was causing the dropdown to close after navigate some options

After the changes on this PR: https://github.com/SUI-Components/sui-components/pull/829/files te dropdown was getting closed after navigate on a couple of options.
I reverted this change and added code to fix the focus on the input after a selection