### PR TITLE
feat(atom/checkbox): cursor "not-allowed" for disabled checkbox

### DIFF
--- a/components/atom/checkbox/src/index.scss
+++ b/components/atom/checkbox/src/index.scss
@@ -26,6 +26,10 @@ $m-atom-checkbox-type-right: $m-m !default;
       box-shadow: none;
       outline: 0 none;
     }
+
+    &:disabled {
+      cursor: not-allowed;
+    }
   }
 
   @each $state, $color in $states-atom-input {


### PR DESCRIPTION
Disabled should have `not-allowed` cursor

- ⚙︎Task → https://jira.scmspain.com/browse/SUIC-133?focusedCommentId=904851&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-904851