### PR TITLE
feat(molecule/breadcrumb): align icons and add margin right

### DIFF
--- a/components/molecule/breadcrumb/src/index.scss
+++ b/components/molecule/breadcrumb/src/index.scss
@@ -31,8 +31,10 @@
     flex-wrap: wrap;
 
     &Item {
+      align-items: center;
       display: flex;
       font-size: $fz-breadcrumb-item;
+      margin-right: $m-breadcrumb-items-mobile;
 
       &:not(:last-child) {
         display: none;
@@ -40,7 +42,6 @@
 
       @include media-breakpoint-up(m) {
         &:not(:last-child) {
-          align-items: center;
           display: inline-flex;
           margin-right: $m-breadcrumb-items;
         }

--- a/components/molecule/breadcrumb/src/settings.scss
+++ b/components/molecule/breadcrumb/src/settings.scss
@@ -7,6 +7,7 @@ $c-breadcrumb-link-hover: $c-accent !default;
 $c-breadcrumb-link: $c-primary !default;
 $c-breadcrumb: $c-text-base !default;
 $m-breadcrumb-items: $m-s !default;
+$m-breadcrumb-items-mobile: 0 !default;
 $size-breadcrumb-icon: 18px !default;
 $td-breadcrumb-link-hover: none !default;
 $fz-breadcrumb-item: $fz-m !default;


### PR DESCRIPTION
This visual issue appeared  yesterday in the last dependencies update.

![image](https://user-images.githubusercontent.com/886033/68294560-c7775a80-0090-11ea-92a9-a25d020cd181.png)

so, since our breadcrumb has a small icon, we need to center it vertically and add a margin right to the list items.

to do so, i've just moved the center vertical declaration and added a `$m-breadcrumb-items-mobile` variable that we'll overwrite in our theme.

