### PR TITLE
feat(molecule/dropdownOption): use atom checkbox

### DIFF
--- a/components/molecule/dropdownOption/package.json
+++ b/components/molecule/dropdownOption/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@s-ui/component-dependencies": "1",
-    "@s-ui/react-atom-input": "3"
+    "@s-ui/react-atom-checkbox": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/molecule/dropdownOption/src/index.js
+++ b/components/molecule/dropdownOption/src/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 import AtomInput from '@s-ui/react-atom-input'
+import AtomCheckbox from '@s-ui/react-atom-checkbox'
 
 import handlersFactory from './handlersFactory'
 
@@ -60,8 +61,7 @@ const MoleculeDropdownOption = ({
       onFocus={handleFocus}
     >
       {checkbox && (
-        <AtomInput
-          type="checkbox"
+        <AtomCheckbox
           checked={selected}
           disabled={disabled}
           onFocus={handleInnerFocus}

--- a/components/molecule/dropdownOption/src/index.js
+++ b/components/molecule/dropdownOption/src/index.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import AtomInput from '@s-ui/react-atom-input'
 import AtomCheckbox from '@s-ui/react-atom-checkbox'
 
 import handlersFactory from './handlersFactory'

--- a/components/molecule/dropdownOption/src/index.scss
+++ b/components/molecule/dropdownOption/src/index.scss
@@ -1,5 +1,5 @@
 @import '~@schibstedspain/sui-theme/lib/index';
-@import '~@s-ui/react-atom-input/lib/index';
+@import '~@s-ui/react-atom-checkbox/lib/index';
 @import './settings';
 
 $bg-molecule-dropdown-option--highlight-mark: $c-highlight !default;


### PR DESCRIPTION
Changes on `molecule/dropdownOption` to make use of `atom/checkbox` instead of `atom/input` when `checkbox` prop is passed as true.