### PR TITLE
fix(atom/input): set css property pointer-events to none

### DIFF
--- a/components/atom/input/src/Input/Component/index.scss
+++ b/components/atom/input/src/Input/Component/index.scss
@@ -35,6 +35,7 @@ $class-read-only: '#{$base-class}--readOnly';
   }
 
   &:disabled {
+    pointer-events: none;
     &:not(#{$class-read-only}) {
       background: $bgc-atom-input-disabled;
     }


### PR DESCRIPTION
Previous behaviour on Firefox:
![molecule_select_old](https://user-images.githubusercontent.com/18154356/68676565-9ef0d400-055a-11ea-8c80-bc4a7b70570c.gif)

Behaviour with this PR:
![molecule_select_new](https://user-images.githubusercontent.com/18154356/68676586-a912d280-055a-11ea-8cd2-999def6927fb.gif)
