### PR TITLE
fix(molecule/select): remove useEffect when populating data

### DIFF
--- a/components/molecule/select/src/index.js
+++ b/components/molecule/select/src/index.js
@@ -1,4 +1,4 @@
-import React, {useState, useEffect, useRef} from 'react'
+import React, {useState, useRef} from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 

--- a/components/molecule/select/src/index.js
+++ b/components/molecule/select/src/index.js
@@ -47,7 +47,7 @@ const MoleculeSelect = props => {
   } = props
   const refMoleculeSelect = useRef(refMoleculeSelectFromProps)
   const refsMoleculeSelectOptions = useRef([])
-  const refOptionsData = useRef(getOptionData(children))
+  const optionsData = getOptionData(children)
 
   const [focus, setFocus] = useState(false)
 
@@ -69,10 +69,6 @@ const MoleculeSelect = props => {
     },
     getErrorStateClass(errorState)
   )
-
-  useEffect(() => {
-    refOptionsData.current = getOptionData(children)
-  }, [children])
 
   const closeList = ev => {
     const {current: domMoleculeSelect} = refMoleculeSelect
@@ -137,7 +133,6 @@ const MoleculeSelect = props => {
   }
 
   const {multiselection, ...propsFromProps} = props
-  const {current: optionsData} = refOptionsData
 
   return (
     <div

--- a/demo/molecule/select/demo/components/MoleculeSelectUseEffect.js
+++ b/demo/molecule/select/demo/components/MoleculeSelectUseEffect.js
@@ -1,0 +1,53 @@
+/* eslint-disable no-console */
+import React, {useState, useEffect} from 'react'
+import PropTypes from 'prop-types'
+
+import {withStateValue} from '@s-ui/hoc'
+
+import MoleculeSelect from '../../../../../components/molecule/select/src'
+
+import MoleculeSelectOption from '@s-ui/react-molecule-dropdown-option'
+
+import {IconArrowDown} from '../Icons/'
+import regions from '../data/regions.json'
+
+const MoleculeSelectWithState = withStateValue(MoleculeSelect)
+
+const MoleculeSelectUseEffect = props => {
+  const {value} = props
+  console.log('initial value: ', value)
+  const handleRegionChange = (_, {value: region}) => {
+    console.log({region})
+    setCurrentValue(region)
+  }
+  const [options, setOptions] = useState([])
+  const [currentValue, setCurrentValue] = useState(value)
+
+  useEffect(() => {
+    const getRegions = async () => {
+      setOptions(regions)
+    }
+    getRegions()
+  }, [])
+
+  return (
+    <MoleculeSelectWithState
+      placeholder="Select a Region..."
+      iconArrowDown={<IconArrowDown />}
+      onChange={handleRegionChange}
+      value={currentValue}
+    >
+      {options.map(({code, text}, i) => (
+        <MoleculeSelectOption key={i} value={code}>
+          {text}
+        </MoleculeSelectOption>
+      ))}
+    </MoleculeSelectWithState>
+  )
+}
+
+MoleculeSelectUseEffect.propTypes = {
+  value: PropTypes.string
+}
+
+export default MoleculeSelectUseEffect

--- a/demo/molecule/select/demo/index.js
+++ b/demo/molecule/select/demo/index.js
@@ -10,6 +10,7 @@ import MoleculeSelectOption from '@s-ui/react-molecule-dropdown-option'
 import {IconCloseTag, IconArrowDown} from './Icons'
 
 import ComboCountries from './components/ComboCountries'
+import MoleculeSelectUseEffect from './components/MoleculeSelectUseEffect'
 
 import {countries as countriesList} from './data'
 import countriesData from './data/countries.json'
@@ -50,6 +51,11 @@ const Demo = () => (
           </MoleculeSelectOption>
         ))}
       </MoleculeSelectWithState>
+    </div>
+
+    <div className={CLASS_DEMO_SECTION}>
+      <h3>With useEffect and preselected Value</h3>
+      <MoleculeSelectUseEffect value="EFTA" />
     </div>
 
     <div className={CLASS_DEMO_SECTION}>


### PR DESCRIPTION
Not sure if we're actually fixing a bug here.

`MoleculeSelect` is using useRef and useEffect to inform its `MoleculeSingleSelection` and `MoleculeMultipleSelection`'s  `optionsData` prop.

When we use a `useEffect` hook on a parent component to fetch data and populate the `MoleculeSelect`'s children *AND* we have a preselected value (i.e. a `value` prop passed down from the parent) the user is not seeing it as selected unless the user interacts with the component.

Before these changes:
![moleculeSelect_useeffect2](https://user-images.githubusercontent.com/18154356/69349529-326f8680-0c78-11ea-89fa-52c02a41776a.gif)

With these changes:
![moleculeSelect_useeffect](https://user-images.githubusercontent.com/18154356/69349259-bffea680-0c77-11ea-804a-6384aee4c5f3.gif)
