### PR TITLE
[fix] avoid onClose execution when show prop is false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ package-lock.json
 demo/**/**/themes
 .tern-port
 .DS_Store
+.npmrc

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-prefer-online=false

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+prefer-online=false

--- a/components/molecule/notification/src/index.js
+++ b/components/molecule/notification/src/index.js
@@ -66,10 +66,9 @@ const MoleculeNotification = ({
     setShow(showFromProps)
   }, [showFromProps])
 
-  const getAutoCloseTime = useCallback(() => {
-    const time = AUTO_CLOSE_TIME[autoCloseTiming]
-    return time
-  }, [autoCloseTiming])
+  const autoCloseTimeInSeconds = AUTO_CLOSE_TIME[autoCloseTiming]
+    ? AUTO_CLOSE_TIME[autoCloseTiming]
+    : null
 
   const removeDelay = show => {
     const delay = show ? 1 : TRANSITION_DELAY
@@ -78,49 +77,37 @@ const MoleculeNotification = ({
     }, delay)
   }
 
+  const handleClose = useCallback(() => {
+    setShow(false)
+    onClose()
+  }, [onClose])
+
   const triggerAutoClose = useCallback(
     time => {
       autoCloseTimeout.current = setTimeout(() => {
-        setShow(false)
+        handleClose()
       }, time)
     },
-    [autoCloseTimeout]
+    [handleClose]
   )
 
-  const handleClickClose = e => {
-    setShow(false)
-  }
-
   useEffect(() => {
-    const autoCloseTimeInSeconds = getAutoCloseTime()
-
-    if (show && autoCloseTimeInSeconds) triggerAutoClose(autoCloseTimeInSeconds)
+    if (show) {
+      if (autoCloseTimeInSeconds) {
+        triggerAutoClose(autoCloseTimeInSeconds)
+      }
+    }
 
     if (effect) {
       setDelay(true)
       removeDelay(show)
     }
 
-    if (show) {
-      if (autoCloseTimeInSeconds) triggerAutoClose(autoCloseTimeInSeconds)
-    } else {
-      clearTimeout(autoCloseTimeout.current)
-      onClose()
-    }
-
     return () => {
       clearTimeout(autoCloseTimeout.current)
       clearTimeout(transitionTimeout.current)
     }
-  }, [
-    autoCloseTimeout,
-    transitionTimeout,
-    show,
-    triggerAutoClose,
-    effect,
-    onClose,
-    getAutoCloseTime
-  ])
+  }, [show, triggerAutoClose, effect, autoCloseTimeInSeconds])
 
   const getButtons = () =>
     buttons
@@ -154,7 +141,7 @@ const MoleculeNotification = ({
         </div>
         <div className={innerWrapperClassName}>{children || text}</div>
         {showCloseButton && (
-          <div className={`${CLASS}-iconClose`} onClick={handleClickClose}>
+          <div className={`${CLASS}-iconClose`} onClick={handleClose}>
             <span className={`${CLASS}-icon`}>
               <IconClose />
             </span>

--- a/components/molecule/notification/src/index.js
+++ b/components/molecule/notification/src/index.js
@@ -92,11 +92,7 @@ const MoleculeNotification = ({
   )
 
   useEffect(() => {
-    if (show) {
-      if (autoCloseTimeInSeconds) {
-        triggerAutoClose(autoCloseTimeInSeconds)
-      }
-    }
+    if (show && autoCloseTimeInSeconds) triggerAutoClose(autoCloseTimeInSeconds)
 
     if (effect) {
       setDelay(true)

--- a/components/molecule/notification/src/index.js
+++ b/components/molecule/notification/src/index.js
@@ -66,9 +66,8 @@ const MoleculeNotification = ({
     setShow(showFromProps)
   }, [showFromProps])
 
-  const autoCloseTimeInSeconds = AUTO_CLOSE_TIME[autoCloseTiming]
-    ? AUTO_CLOSE_TIME[autoCloseTiming]
-    : null
+  const autoCloseTimeInSeconds =
+    AUTO_CLOSE_TIME[autoCloseTiming] || AUTO_CLOSE_TIME.manual
 
   const removeDelay = show => {
     const delay = show ? 1 : TRANSITION_DELAY

--- a/components/molecule/notification/src/index.js
+++ b/components/molecule/notification/src/index.js
@@ -84,9 +84,7 @@ const MoleculeNotification = ({
 
   const triggerAutoClose = useCallback(
     time => {
-      autoCloseTimeout.current = setTimeout(() => {
-        handleClose()
-      }, time)
+      autoCloseTimeout.current = setTimeout(handleClose, time)
     },
     [handleClose]
   )

--- a/package.json
+++ b/package.json
@@ -64,5 +64,6 @@
   },
   "stylelint": {
     "extends": "./node_modules/@s-ui/lint/stylelint.config.js"
-  }
+  },
+  "prettier": "./node_modules/@s-ui/lint/.prettierrc.js"
 }


### PR DESCRIPTION
Fix to avoid the execution of the `onClose` prop in the first render.

If you see the demo as soon as you mount the notification component, the callback of the `onClose` prop is executed.
Look at console messages in: https://codesandbox.io/s/bug-onclose-sui-notification-tdcrx

The tasks that I have solved are:
- I group in a single function to close `handleClose` the `setIsOpen(false)` and the callback of the `onClose` prop.
- It eliminates dependencies of the `useEffect` that I consider unnecessary because they are values pointing to references through `useRef` (They do not change in the different renders).
- I delete the unnecessary `onClose` callback execution when the notification does not open. Code that was in the `else` of` if (show)`