### PR TITLE
fix(molecule/autosuggest): remove not needed axios dependency causing warning

### DIFF
--- a/components/molecule/autosuggest/package.json
+++ b/components/molecule/autosuggest/package.json
@@ -14,8 +14,7 @@
     "@s-ui/js": "2",
     "@s-ui/react-atom-input": "3",
     "@s-ui/react-molecule-dropdown-list": "1",
-    "@s-ui/react-molecule-input-tags": "2",
-    "axios": "0.18.0"
+    "@s-ui/react-molecule-input-tags": "2"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Axios dependency should not be inside the component package.json: First because it's not being used and second because is causing a vulnerability warning when installing the component.