### PR TITLE
chore(molecule/notification): add changelog and upgrade version

### DIFF
--- a/components/molecule/notification/CHANGELOG.md
+++ b/components/molecule/notification/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+<a name="1.13.0"></a>
+# 1.13.0 (2019-11-22)
+
+
+### Bug Fixes
+
+* fix execution of onClose when show is false ([76584a6](https://github.com/SUI-Components/sui-components/commit/76584a6))
+
+
+
 <a name="1.12.0"></a>
 # 1.12.0 (2019-10-11)
 

--- a/components/molecule/notification/package.json
+++ b/components/molecule/notification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/react-molecule-notification",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Version upload manually because I got an error when execute `npm run release`.
The `Notification` component is already published in NPM with version` 1.13.0`