### PR TITLE
fix(atom/spinner): avoid page scroll when full page spinner is loaded

### DIFF
--- a/components/atom/spinner/src/index.scss
+++ b/components/atom/spinner/src/index.scss
@@ -27,8 +27,13 @@ $z-atom-spinner: 1 !default;
   }
 
   &--fullPage {
+    height: 100vh;
+    position: fixed;
+    width: 100%;
+
     &::before {
       @extend %spinner-layer;
+      height: 100vh;
       position: fixed;
     }
 


### PR DESCRIPTION
Avoid scroll when spinner in full page mode, is loaded