### PR TITLE
fix(atom/checkbox): prevent execute onChangeFromProps as undefined

### DIFF
--- a/components/atom/checkbox/src/index.js
+++ b/components/atom/checkbox/src/index.js
@@ -21,8 +21,8 @@ const AtomCheckbox = ({
   id,
   name,
   disabled,
-  checked,
-  onChange: onChangeFromProps,
+  checked = false,
+  onChange: onChangeFromProps = () => {},
   errorState,
   ...props
 }) => {
@@ -50,10 +50,6 @@ const AtomCheckbox = ({
 }
 
 AtomCheckbox.displayName = 'AtomCheckbox'
-
-AtomCheckbox.defaultProps = {
-  checked: false
-}
 
 AtomCheckbox.propTypes = {
   /* The DOM id global attribute. */

--- a/components/atom/checkbox/src/index.js
+++ b/components/atom/checkbox/src/index.js
@@ -65,7 +65,7 @@ AtomCheckbox.propTypes = {
   checked: PropTypes.bool,
 
   /* onChange callback */
-  onChange: PropTypes.func.isRequired,
+  onChange: PropTypes.func,
 
   /* Will set a red/green border if set to true/false */
   errorState: PropTypes.bool


### PR DESCRIPTION
Fix error when onChange is undefined.
![image](https://user-images.githubusercontent.com/5390428/69970178-0ed0f980-151e-11ea-99eb-ddab9a50b974.png)


EDIT: MoleculeSelect is not passing this prop