### PR TITLE
fix(atom/button): fix error console when link is disabled

### DIFF
--- a/components/atom/button/src/Button.js
+++ b/components/atom/button/src/Button.js
@@ -17,7 +17,7 @@ const Button = ({
   return link ? (
     <Link
       {...attrs}
-      href={!disabled && href}
+      href={href}
       target={target}
       rel={target === '_blank' ? 'noopener' : undefined}
     >

--- a/components/atom/button/src/index.scss
+++ b/components/atom/button/src/index.scss
@@ -269,8 +269,9 @@ $tt-atom-button: none !default;
 
   // Modifiers
   &--disabled {
-    cursor: not-allowed;
+    cursor: default;
     opacity: 0.3;
+    pointer-events: none;
   }
 
   &--small {


### PR DESCRIPTION
## Fix Issue and fix redirect when it is `link` and` disabled`

- Fix Issue error in React warning console
https://github.com/SUI-Components/sui-components/issues/874

- Solve link redirection when a `<Button />` is a link and is disabled.

The solution I propose is to use the href like the other props `href = {href}` and disable the event click when it is `disabled` using the css rule `pointer-events: none` and `cursor: default`.

I add here an example of the css rule https://codesandbox.io/s/billowing-microservice-0jd78