### PR TITLE
Add atom input props

### DIFF
--- a/components/atom/input/src/Input/Component/index.js
+++ b/components/atom/input/src/Input/Component/index.js
@@ -177,8 +177,7 @@ Input.defaultProps = {
   tabIndex: -1,
   onKeyDown: () => {},
   onEnter: () => {},
-  onChange: () => {},
-  required: false
+  onChange: () => {}
 }
 
 export default Input

--- a/components/atom/input/src/Input/Component/index.js
+++ b/components/atom/input/src/Input/Component/index.js
@@ -173,7 +173,8 @@ Input.defaultProps = {
   tabIndex: -1,
   onKeyDown: () => {},
   onEnter: () => {},
-  onChange: () => {}
+  onChange: () => {},
+  required: false
 }
 
 export default Input

--- a/components/atom/input/src/Input/Component/index.js
+++ b/components/atom/input/src/Input/Component/index.js
@@ -63,7 +63,8 @@ const Input = ({
   onChange,
   onEnter,
   onEnterKey,
-  onKeyDown
+  onKeyDown,
+  required
 }) => {
   const changeHandler = ev => {
     const {
@@ -110,6 +111,7 @@ const Input = ({
       maxLength={maxLength}
       minLength={minLength}
       autoComplete={autoComplete}
+      required={required}
     />
   )
 }
@@ -160,7 +162,9 @@ Input.propTypes = {
   /** Wether to hide the input border or not */
   noBorder: PropTypes.bool,
   /** tabindex value */
-  tabIndex: PropTypes.number
+  tabIndex: PropTypes.number,
+  /** native required attribtue  */
+  required: PropTypes.bool
 }
 
 Input.defaultProps = {

--- a/components/atom/input/src/Input/Component/index.js
+++ b/components/atom/input/src/Input/Component/index.js
@@ -64,7 +64,8 @@ const Input = ({
   onEnter,
   onEnterKey,
   onKeyDown,
-  required
+  required,
+  pattern
 }) => {
   const changeHandler = ev => {
     const {
@@ -112,6 +113,7 @@ const Input = ({
       minLength={minLength}
       autoComplete={autoComplete}
       required={required}
+      pattern={pattern}
     />
   )
 }
@@ -164,7 +166,9 @@ Input.propTypes = {
   /** tabindex value */
   tabIndex: PropTypes.number,
   /** native required attribtue  */
-  required: PropTypes.bool
+  required: PropTypes.bool,
+  /** native pattern attribute */
+  pattern: PropTypes.string
 }
 
 Input.defaultProps = {

--- a/components/atom/input/src/Input/Component/index.js
+++ b/components/atom/input/src/Input/Component/index.js
@@ -58,6 +58,7 @@ const Input = ({
   charsSize,
   tabIndex,
   maxLength,
+  minLength,
   autoComplete,
   onChange,
   onEnter,
@@ -107,6 +108,7 @@ const Input = ({
       value={value}
       size={charsSize}
       maxLength={maxLength}
+      minLength={minLength}
       autoComplete={autoComplete}
     />
   )
@@ -141,6 +143,8 @@ Input.propTypes = {
   charsSize: PropTypes.number,
   /* specifies the maximum number of characters (native "maxlength" attribute) */
   maxLength: PropTypes.number,
+  /* specifies the minimum number of characters (native "minlength" attribute) */
+  minLength: PropTypes.number,
   /** specifies whether or not an input field should have autocomplete enabled (on|off) */
   autoComplete: PropTypes.string,
   /* text, password, date or number */

--- a/components/atom/input/src/index.js
+++ b/components/atom/input/src/index.js
@@ -82,6 +82,9 @@ AtomInput.propTypes = {
   /** specifies the maximum number of characters (native "maxlength" attribute) */
   maxLength: PropTypes.number,
 
+  /** specifies the minimum number of characters (native "minlength" attribute) */
+  minLength: PropTypes.number,
+
   /** specifies whether or not an input field should have autocomplete enabled (on|off) */
   autoComplete: PropTypes.string,
 

--- a/components/molecule/autosuggest/src/components/MultipleSelection.js
+++ b/components/molecule/autosuggest/src/components/MultipleSelection.js
@@ -105,8 +105,7 @@ MoleculeAutosuggestFieldMultiSelection.defaultProps = {
   disabled: false,
   value: '',
   tags: [],
-  iconCloseTag: <span />,
-  required: false
+  iconCloseTag: <span />
 }
 
 export default MoleculeAutosuggestFieldMultiSelection

--- a/components/molecule/autosuggest/src/components/MultipleSelection.js
+++ b/components/molecule/autosuggest/src/components/MultipleSelection.js
@@ -22,7 +22,8 @@ const MoleculeAutosuggestFieldMultiSelection = ({
   onChange,
   onChangeTags,
   onSelect,
-  disabled
+  disabled,
+  required
 }) => {
   const MoleculeInputTagsRef = useRef()
 
@@ -80,6 +81,7 @@ const MoleculeAutosuggestFieldMultiSelection = ({
         placeholder={!tags.length ? placeholder : ''}
         noBorder
         disabled={disabled}
+        required={required}
       />
       <MoleculeDropdownList
         checkbox
@@ -101,7 +103,8 @@ MoleculeAutosuggestFieldMultiSelection.defaultProps = {
   disabled: false,
   value: '',
   tags: [],
-  iconCloseTag: <span />
+  iconCloseTag: <span />,
+  required: false
 }
 
 export default MoleculeAutosuggestFieldMultiSelection

--- a/components/molecule/autosuggest/src/components/MultipleSelection.js
+++ b/components/molecule/autosuggest/src/components/MultipleSelection.js
@@ -8,6 +8,7 @@ import withClearUI from '../hoc/withClearUI'
 const MoleculeInputTagsWithClearUI = withClearUI(MoleculeInputTags)
 
 const MoleculeAutosuggestFieldMultiSelection = ({
+  id,
   refMoleculeAutosuggest,
   tags,
   value,
@@ -65,6 +66,7 @@ const MoleculeAutosuggestFieldMultiSelection = ({
   return (
     <>
       <MoleculeInputTagsWithClearUI
+        id={id}
         onKeyDown={onInputKeyDown}
         ref={MoleculeInputTagsRef}
         tags={tags}

--- a/components/molecule/autosuggest/src/components/SingleSelection.js
+++ b/components/molecule/autosuggest/src/components/SingleSelection.js
@@ -83,8 +83,7 @@ MoleculeAutosuggestSingleSelection.displayName =
   'MoleculeAutosuggestSingleSelection'
 
 MoleculeAutosuggestSingleSelection.defaultProps = {
-  value: '',
-  required: false
+  value: ''
 }
 
 export default MoleculeAutosuggestSingleSelection

--- a/components/molecule/autosuggest/src/components/SingleSelection.js
+++ b/components/molecule/autosuggest/src/components/SingleSelection.js
@@ -9,6 +9,7 @@ import withClearUI from '../hoc/withClearUI'
 const AtomInputWithClearUI = withClearUI(AtomInput)
 
 const MoleculeAutosuggestSingleSelection = ({
+  id,
   value = '',
   children,
   isOpen,
@@ -49,6 +50,7 @@ const MoleculeAutosuggestSingleSelection = ({
   return (
     <>
       <AtomInputWithClearUI
+        id={id}
         value={value}
         isVisibleClear={value}
         onClickClear={handleClear}

--- a/components/molecule/autosuggest/src/components/SingleSelection.js
+++ b/components/molecule/autosuggest/src/components/SingleSelection.js
@@ -23,7 +23,8 @@ const MoleculeAutosuggestSingleSelection = ({
   rightIcon,
   iconClear,
   placeholder,
-  disabled
+  disabled,
+  required
 }) => {
   const handleSelection = (ev, {value}) => {
     onChange(ev, {value})
@@ -59,6 +60,7 @@ const MoleculeAutosuggestSingleSelection = ({
         placeholder={placeholder}
         onKeyDown={onInputKeyDown}
         disabled={disabled}
+        required={required}
       />
       {value && (
         <MoleculeDropdownList
@@ -79,7 +81,8 @@ MoleculeAutosuggestSingleSelection.displayName =
   'MoleculeAutosuggestSingleSelection'
 
 MoleculeAutosuggestSingleSelection.defaultProps = {
-  value: ''
+  value: '',
+  required: false
 }
 
 export default MoleculeAutosuggestSingleSelection

--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -241,8 +241,7 @@ MoleculeAutosuggest.defaultProps = {
   onEnter: () => {},
   onSelect: () => {},
   keysSelection: [' ', 'Enter'],
-  keysCloseList: ['Escape'],
-  required: false
+  keysCloseList: ['Escape']
 }
 
 export default withOpenToggle(MoleculeAutosuggest)

--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -226,7 +226,10 @@ MoleculeAutosuggest.propTypes = {
   keysCloseList: PropTypes.array,
 
   /* object generated w/ Reacte.createRef method to get a DOM reference of internal input */
-  refMoleculeAutosuggest: PropTypes.object
+  refMoleculeAutosuggest: PropTypes.object,
+
+  /* native required html attribute */
+  required: PropTypes.bool
 }
 
 MoleculeAutosuggest.defaultProps = {
@@ -235,7 +238,8 @@ MoleculeAutosuggest.defaultProps = {
   onEnter: () => {},
   onSelect: () => {},
   keysSelection: [' ', 'Enter'],
-  keysCloseList: ['Escape']
+  keysCloseList: ['Escape'],
+  required: false
 }
 
 export default withOpenToggle(MoleculeAutosuggest)

--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -168,6 +168,9 @@ const MoleculeAutosuggest = ({multiselection, ...props}) => {
 }
 
 MoleculeAutosuggest.propTypes = {
+  /** The DOM id global attribute. */
+  id: PropTypes.string,
+
   /** if select accept single value or multiple values */
   multiselection: PropTypes.bool,
 

--- a/components/molecule/autosuggestField/src/index.js
+++ b/components/molecule/autosuggestField/src/index.js
@@ -45,6 +45,7 @@ class MoleculeAutosuggestField extends Component {
         useContrastLabel={useContrastLabel}
       >
         <MoleculeAutosuggest
+          id={id}
           refMoleculeAutosuggest={refAutosuggest}
           errorState={errorState}
           {...props}

--- a/components/molecule/select/src/components/MultipleSelection.js
+++ b/components/molecule/select/src/components/MultipleSelection.js
@@ -77,8 +77,7 @@ MoleculeSelectFieldMultiSelection.displayName =
   'MoleculeSelectFieldMultiSelection'
 
 MoleculeSelectFieldMultiSelection.defaultProps = {
-  value: [],
-  required: false
+  value: []
 }
 
 export default MoleculeSelectFieldMultiSelection

--- a/components/molecule/select/src/components/MultipleSelection.js
+++ b/components/molecule/select/src/components/MultipleSelection.js
@@ -22,6 +22,7 @@ const MoleculeSelectFieldMultiSelection = props => {
     keysSelection,
     id,
     size,
+    required,
     optionsData = {}
   } = props
 
@@ -57,6 +58,7 @@ const MoleculeSelectFieldMultiSelection = props => {
         autoComplete="off"
         readOnly
         noBorder
+        required={required}
       />
       <MoleculeDropdownList
         checkbox
@@ -75,7 +77,8 @@ MoleculeSelectFieldMultiSelection.displayName =
   'MoleculeSelectFieldMultiSelection'
 
 MoleculeSelectFieldMultiSelection.defaultProps = {
-  value: []
+  value: [],
+  required: false
 }
 
 export default MoleculeSelectFieldMultiSelection

--- a/components/molecule/select/src/components/SingleSelection.js
+++ b/components/molecule/select/src/components/SingleSelection.js
@@ -60,8 +60,7 @@ const MoleculeSelectSingleSelection = props => {
 MoleculeSelectSingleSelection.displayName = 'MoleculeSelectSingleSelection'
 
 MoleculeSelectSingleSelection.defaultProps = {
-  value: '',
-  required: false
+  value: ''
 }
 
 export default MoleculeSelectSingleSelection

--- a/components/molecule/select/src/components/SingleSelection.js
+++ b/components/molecule/select/src/components/SingleSelection.js
@@ -21,7 +21,8 @@ const MoleculeSelectSingleSelection = props => {
     placeholder,
     id,
     disabled,
-    optionsData = {}
+    optionsData = {},
+    required
   } = props
 
   const handleSelection = (ev, {value}) => {
@@ -42,6 +43,7 @@ const MoleculeSelectSingleSelection = props => {
         placeholder={placeholder}
         autoComplete="off"
         readOnly
+        required={required}
       />
       <MoleculeDropdownList
         size={size}
@@ -58,7 +60,8 @@ const MoleculeSelectSingleSelection = props => {
 MoleculeSelectSingleSelection.displayName = 'MoleculeSelectSingleSelection'
 
 MoleculeSelectSingleSelection.defaultProps = {
-  value: ''
+  value: '',
+  required: false
 }
 
 export default MoleculeSelectSingleSelection


### PR DESCRIPTION
- Add `minLength`, `required` and `pattern` props in `atom/input` component.
- Add `required` prop to `molecule/select`
- Add `id` and `required` prop to `molecule/autosuggest`
- Pass down `id` prop from `molecule/autosuggestField` to `molecule/autosuggest`