### PR TITLE
feat(molecule/select): Add selectSize prop to set input size

### DIFF
--- a/components/molecule/select/src/components/MultipleSelection.js
+++ b/components/molecule/select/src/components/MultipleSelection.js
@@ -23,7 +23,8 @@ const MoleculeSelectFieldMultiSelection = props => {
     id,
     size,
     required,
-    optionsData = {}
+    optionsData = {},
+    selectSize
   } = props
 
   const handleMultiSelection = (ev, {value: valueOptionSelected}) => {
@@ -59,6 +60,7 @@ const MoleculeSelectFieldMultiSelection = props => {
         readOnly
         noBorder
         required={required}
+        size={selectSize}
       />
       <MoleculeDropdownList
         checkbox

--- a/components/molecule/select/src/components/SingleSelection.js
+++ b/components/molecule/select/src/components/SingleSelection.js
@@ -22,7 +22,8 @@ const MoleculeSelectSingleSelection = props => {
     id,
     disabled,
     optionsData = {},
-    required
+    required,
+    selectSize
   } = props
 
   const handleSelection = (ev, {value}) => {
@@ -44,6 +45,7 @@ const MoleculeSelectSingleSelection = props => {
         autoComplete="off"
         readOnly
         required={required}
+        size={selectSize}
       />
       <MoleculeDropdownList
         size={size}

--- a/components/molecule/select/src/index.js
+++ b/components/molecule/select/src/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import cx from 'classnames'
 
 import {moleculeDropdownListSizes as SIZES} from '@s-ui/react-molecule-dropdown-list'
+import {inputSizes as SELECT_SIZES} from '@s-ui/react-atom-input'
 
 import MoleculeSelectSingleSelection from './components/SingleSelection'
 import MoleculeSelectMultipleSelection from './components/MultipleSelection'
@@ -213,7 +214,10 @@ MoleculeSelect.propTypes = {
   disabled: PropTypes.bool,
 
   /** This Boolean attribute prevents the user from interacting with the input but without disabled styles  */
-  readOnly: PropTypes.bool
+  readOnly: PropTypes.bool,
+
+  /** Size of the select(input) */
+  selectSize: PropTypes.oneOf(Object.values(SELECT_SIZES))
 }
 
 MoleculeSelect.defaultProps = {
@@ -221,8 +225,10 @@ MoleculeSelect.defaultProps = {
   keysSelection: [' ', 'Enter'],
   onChange: () => {},
   onToggle: () => {},
-  readOnly: false
+  readOnly: false,
+  selectSize: SELECT_SIZES.MEDIUM
 }
 
 export default withOpenToggle(MoleculeSelect)
 export {SIZES as moleculeSelectDropdownListSizes}
+export {SELECT_SIZES as moleculeSelectSizes}

--- a/demo/molecule/select/demo/index.js
+++ b/demo/molecule/select/demo/index.js
@@ -3,7 +3,9 @@ import React from 'react'
 
 import {withStateValue} from '@s-ui/hoc'
 
-import MoleculeSelect from '../../../../components/molecule/select/src'
+import MoleculeSelect, {
+  moleculeSelectSizes
+} from '../../../../components/molecule/select/src'
 
 import MoleculeSelectOption from '@s-ui/react-molecule-dropdown-option'
 
@@ -37,6 +39,7 @@ const Demo = () => (
       <code>DropdownOption</code>. Recuerda que en dichos componentes existen
       más posibilidades si son necesarias
     </p>
+
     <h2>Single Selection</h2>
     <div className={CLASS_DEMO_SECTION}>
       <h3>With Placeholder</h3>
@@ -105,6 +108,22 @@ const Demo = () => (
       </MoleculeSelectWithState>
     </div>
 
+    <div className={CLASS_DEMO_SECTION}>
+      <h3>Small size</h3>
+      <MoleculeSelect
+        placeholder="Select a Country..."
+        onChange={(_, {value}) => console.log(value)}
+        iconArrowDown={<IconArrowDown />}
+        selectSize={moleculeSelectSizes.SMALL}
+      >
+        {countriesData.map(({name, code}, i) => (
+          <MoleculeSelectOption key={i} value={code}>
+            {name}
+          </MoleculeSelectOption>
+        ))}
+      </MoleculeSelect>
+    </div>
+
     <h2>Multiple Selection</h2>
     <div className={CLASS_DEMO_SECTION}>
       <h3>With Placeholder</h3>
@@ -162,6 +181,24 @@ const Demo = () => (
     <div className={CLASS_DEMO_SECTION}>
       <h3>With Placeholder</h3>
       <ComboCountries />
+    </div>
+
+    <div className={CLASS_DEMO_SECTION}>
+      <h3>Small size</h3>
+      <MoleculeSelectWithState
+        placeholder="Select some countries..."
+        onChange={(_, {value}) => console.log(value)}
+        iconCloseTag={<IconCloseTag />}
+        iconArrowDown={<IconArrowDown />}
+        multiselection
+        selectSize={moleculeSelectSizes.SMALL}
+      >
+        {countriesData.map(({name, code}, i) => (
+          <MoleculeSelectOption key={i} value={code}>
+            {name}
+          </MoleculeSelectOption>
+        ))}
+      </MoleculeSelectWithState>
     </div>
   </div>
 )


### PR DESCRIPTION
This PR adds a `selectSize` prop to moleculeSelect so it can be passed to the select, which is using the atomInput. 

Right now the `size` prop only sets the size for the dropdownList, and not the main select.