### PR TITLE
fix(molecule/quickAction): fix overflow when children has css ellipsis

### DIFF
--- a/components/molecule/quickAction/src/index.scss
+++ b/components/molecule/quickAction/src/index.scss
@@ -41,6 +41,7 @@ $p-molecule-quick-action-large: $p-l !default;
   }
 
   &-text {
+    overflow: hidden;
     width: 100%;
   }
 


### PR DESCRIPTION
Add overflow hidden in order to avoid element position issues

Problem:
![image](https://user-images.githubusercontent.com/5390428/71981133-060ccb00-3222-11ea-85ec-b142f6567c34.png)

With this fix:
![image](https://user-images.githubusercontent.com/5390428/71981152-0f963300-3222-11ea-8c4a-43408d6f3d7f.png)

We have this issue in motor because we are passing as children an span with css ellipsis
