### PR TITLE
feat(atom/button): fill color of any value within svg

### DIFF
--- a/components/atom/button/src/index.scss
+++ b/components/atom/button/src/index.scss
@@ -196,7 +196,7 @@ $icon-stroke-color: currentColor !default;
       display: inline-flex;
     }
 
-    svg path {
+    svg {
       fill: $icon-fill-color;
       stroke: $icon-stroke-color;
     }


### PR DESCRIPTION
### Current behaviour
![Captura de pantalla 2020-01-13 a las 12 43 44](https://user-images.githubusercontent.com/31726966/72253822-b4d65000-3602-11ea-86bf-4120926161ae.png)
![Captura de pantalla 2020-01-13 a las 12 32 40](https://user-images.githubusercontent.com/31726966/72253829-b9026d80-3602-11ea-8fa3-5ebff24dc782.png)

### Expected behaviour
![Captura de pantalla 2020-01-13 a las 12 31 38](https://user-images.githubusercontent.com/31726966/72253833-bbfd5e00-3602-11ea-82d2-bab8e7c80e1c.png)

> By currently defining the style of the icons, only the color is applied to the `SVG` path. In some cases, the `SVG` includes `**ellipses**`, and you need to apply the same color as the rest of the icon
