### PR TITLE
docs(atom/popover): fix readme

### DIFF
--- a/components/atom/popover/README.md
+++ b/components/atom/popover/README.md
@@ -18,13 +18,13 @@ import AtomPopover, { atomPopoverPositions } from '@s-ui/react-atom-popover'
 
 ```js
 <AtomPopover
-  placement={atomPopoverPositions.BOTTTOM}
+  placement={atomPopoverPositions.BOTTOM}
   onClose={() => console.log("CLOSE POPOVER!")}
-  content={ () => (
+  content={
     <>
       Hello <strong>world</strong>!
     </>
-  )}
+  }
 >
   <div>
     Show Popover


### PR DESCRIPTION
## Description

Update AtomPopover README fixing mistakes.

### `content` prop error:

![image](https://user-images.githubusercontent.com/13108014/72528844-4ac0e380-386c-11ea-8551-fce103ae2fe7.png)
