### PR TITLE
Fix/suic 258 border error and success in textareafield and autosuggestfield

### DIFF
--- a/components/atom/input/src/Input/Component/index.js
+++ b/components/atom/input/src/Input/Component/index.js
@@ -15,12 +15,6 @@ const ERROR_STATES = {
   SUCCESS: 'success'
 }
 
-const getErrorStateClass = errorState => {
-  if (errorState) return `${BASE_CLASS}--${ERROR_STATES.ERROR}`
-  if (errorState === false) return `${BASE_CLASS}--${ERROR_STATES.SUCCESS}`
-  return ''
-}
-
 const getClassNames = ({
   size,
   charsSize,
@@ -36,7 +30,8 @@ const getClassNames = ({
     hideInput && `${BASE_CLASS}--hidden`,
     noBorder && `${BASE_CLASS}--noBorder`,
     readOnly && `${BASE_CLASS}--readOnly`,
-    getErrorStateClass(errorState)
+    errorState && `${BASE_CLASS}--${ERROR_STATES.ERROR}`,
+    errorState === false && `${BASE_CLASS}--${ERROR_STATES.SUCCESS}`
   )
 }
 

--- a/components/atom/textarea/src/index.js
+++ b/components/atom/textarea/src/index.js
@@ -8,8 +8,23 @@ const SIZES = {
   LONG: 'long'
 }
 
-const AtomTextarea = ({onChange, size, value, ...props}) => {
-  const className = cx(BASE_CLASS, `${BASE_CLASS}--${size}`)
+const ERROR_STATES = {
+  ERROR: 'error',
+  SUCCESS: 'success'
+}
+
+const getErrorStateClass = errorState => {
+  if (errorState) return `${BASE_CLASS}--${ERROR_STATES.ERROR}`
+  if (errorState === false) return `${BASE_CLASS}--${ERROR_STATES.SUCCESS}`
+  return ''
+}
+
+const AtomTextarea = ({onChange, size, value, errorState, ...props}) => {
+  const className = cx(
+    BASE_CLASS,
+    `${BASE_CLASS}--${size}`,
+    getErrorStateClass(errorState)
+  )
 
   const handleChange = ev => {
     const {value, name} = ev.target
@@ -36,7 +51,10 @@ AtomTextarea.propTypes = {
   onChange: PropTypes.func,
 
   /** Value (content) of the textarea */
-  value: PropTypes.string
+  value: PropTypes.string,
+
+  /** true = error, false = success, null = neutral */
+  errorState: PropTypes.bool
 }
 
 AtomTextarea.defaultProps = {

--- a/components/atom/textarea/src/index.js
+++ b/components/atom/textarea/src/index.js
@@ -13,17 +13,12 @@ const ERROR_STATES = {
   SUCCESS: 'success'
 }
 
-const getErrorStateClass = errorState => {
-  if (errorState) return `${BASE_CLASS}--${ERROR_STATES.ERROR}`
-  if (errorState === false) return `${BASE_CLASS}--${ERROR_STATES.SUCCESS}`
-  return ''
-}
-
 const AtomTextarea = ({onChange, size, value, errorState, ...props}) => {
   const className = cx(
     BASE_CLASS,
     `${BASE_CLASS}--${size}`,
-    getErrorStateClass(errorState)
+    errorState && `${BASE_CLASS}--${ERROR_STATES.ERROR}`,
+    errorState === false && `${BASE_CLASS}--${ERROR_STATES.SUCCESS}`
   )
 
   const handleChange = ev => {

--- a/components/atom/textarea/src/index.scss
+++ b/components/atom/textarea/src/index.scss
@@ -8,7 +8,9 @@ $pm-atom-textarea: $p-m !default;
 $fz-atom-textarea: $fz-base !default;
 $lh-atom-textarea: $lh-l !default;
 
-.sui-AtomTextarea {
+$base-class: '.sui-AtomTextarea';
+
+#{$base-class} {
   border: 1px solid $c-gray-light;
   font-size: $fz-atom-textarea;
   line-height: $lh-atom-textarea;
@@ -30,5 +32,11 @@ $lh-atom-textarea: $lh-l !default;
     height: calc(
       (#{$lh-atom-textarea} * #{$long-num-lines}) + #{$pm-atom-textarea}
     );
+  }
+
+  @each $state, $color in $states-atom-input {
+    &#{$base-class}--#{$state} {
+      border-color: $color;
+    }
   }
 }

--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -64,19 +64,14 @@ const MoleculeAutosuggest = ({multiselection, ...props}) => {
       })
     })
 
-  const getErrorStateClass = errorState => {
-    if (errorState) return `${BASE_CLASS}--${ERROR_STATES.ERROR}`
-    if (errorState === false) return `${BASE_CLASS}--${ERROR_STATES.SUCCESS}`
-    return ''
-  }
-
   const className = cx(
     BASE_CLASS,
+    errorState && `${BASE_CLASS}--${ERROR_STATES.ERROR}`,
+    errorState === false && `${BASE_CLASS}--${ERROR_STATES.SUCCESS}`,
     {
       [CLASS_FOCUS]: focus,
       [CLASS_DISABLED]: disabled
-    },
-    getErrorStateClass(errorState)
+    }
   )
 
   const closeList = ev => {

--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -15,6 +15,11 @@ const BASE_CLASS = `sui-MoleculeAutosuggest`
 const CLASS_FOCUS = `${BASE_CLASS}--focus`
 const CLASS_DISABLED = `${BASE_CLASS}--disabled`
 
+const ERROR_STATES = {
+  ERROR: 'error',
+  SUCCESS: 'success'
+}
+
 const getIsTypeableKey = key => {
   const keysEdit = [
     'Backspace',
@@ -37,7 +42,8 @@ const MoleculeAutosuggest = ({multiselection, ...props}) => {
     isOpen,
     keysCloseList,
     keysSelection,
-    disabled
+    disabled,
+    errorState
   } = props
 
   const refMoleculeAutosuggest = useRef(
@@ -58,10 +64,20 @@ const MoleculeAutosuggest = ({multiselection, ...props}) => {
       })
     })
 
-  const className = cx(BASE_CLASS, {
-    [CLASS_FOCUS]: focus,
-    [CLASS_DISABLED]: disabled
-  })
+  const getErrorStateClass = errorState => {
+    if (errorState) return `${BASE_CLASS}--${ERROR_STATES.ERROR}`
+    if (errorState === false) return `${BASE_CLASS}--${ERROR_STATES.SUCCESS}`
+    return ''
+  }
+
+  const className = cx(
+    BASE_CLASS,
+    {
+      [CLASS_FOCUS]: focus,
+      [CLASS_DISABLED]: disabled
+    },
+    getErrorStateClass(errorState)
+  )
 
   const closeList = ev => {
     const {current: domMoleculeAutosuggest} = refMoleculeAutosuggest
@@ -235,7 +251,10 @@ MoleculeAutosuggest.propTypes = {
   required: PropTypes.bool,
 
   /* native tabIndex html attribute */
-  tabIndex: PropTypes.number
+  tabIndex: PropTypes.number,
+
+  /** true = error, false = success, null = neutral */
+  errorState: PropTypes.bool
 }
 
 MoleculeAutosuggest.defaultProps = {

--- a/components/molecule/autosuggest/src/index.scss
+++ b/components/molecule/autosuggest/src/index.scss
@@ -60,4 +60,10 @@ $bdw-autosuggest-container: $bdw-s !default;
       width: $w-autosuggest-icon-clear;
     }
   }
+
+  @each $state, $color in $states-atom-input {
+    &#{$base-class}--#{$state} #{$base-class}-input-container {
+      border-color: $color;
+    }
+  }
 }

--- a/components/molecule/select/src/index.js
+++ b/components/molecule/select/src/index.js
@@ -23,12 +23,6 @@ const ERROR_STATES = {
 
 const ENABLED_KEYS = ['Enter', 'ArrowDown', 'ArrowUp']
 
-const getErrorStateClass = errorState => {
-  if (errorState) return `${BASE_CLASS}--${ERROR_STATES.ERROR}`
-  if (errorState === false) return `${BASE_CLASS}--${ERROR_STATES.SUCCESS}`
-  return ''
-}
-
 const getOptionData = children => {
   const optionsData = {}
   React.Children.forEach(children, child => {
@@ -66,11 +60,12 @@ const MoleculeSelect = props => {
 
   const className = cx(
     BASE_CLASS,
+    errorState && `${BASE_CLASS}--${ERROR_STATES.ERROR}`,
+    errorState === false && `${BASE_CLASS}--${ERROR_STATES.SUCCESS}`,
     {
       [CLASS_FOCUS]: focus,
       [CLASS_DISABLED]: disabled
-    },
-    getErrorStateClass(errorState)
+    }
   )
 
   useEffect(() => {

--- a/components/molecule/textareaField/src/index.js
+++ b/components/molecule/textareaField/src/index.js
@@ -7,6 +7,11 @@ import AtomTextarea, {
 } from '@s-ui/react-atom-textarea'
 import WithCharacterCount from './hoc/WithCharacterCount'
 
+const hasErrors = (success, error) => {
+  if (error) return true
+  if (success) return false
+}
+
 const MoleculeTextareaField = WithCharacterCount(
   ({
     id,
@@ -19,10 +24,6 @@ const MoleculeTextareaField = WithCharacterCount(
     onChange,
     ...props
   }) => {
-    const hasErrors = (success, error) => {
-      if (error) return true
-      if (success) return false
-    }
     const errorState = hasErrors(successText, errorText)
     return (
       <MoleculeField

--- a/components/molecule/textareaField/src/index.js
+++ b/components/molecule/textareaField/src/index.js
@@ -19,6 +19,11 @@ const MoleculeTextareaField = WithCharacterCount(
     onChange,
     ...props
   }) => {
+    const hasErrors = (success, error) => {
+      if (error) return true
+      if (success) return false
+    }
+    const errorState = hasErrors(successText, errorText)
     return (
       <MoleculeField
         name={id}
@@ -30,7 +35,7 @@ const MoleculeTextareaField = WithCharacterCount(
         maxChars={maxChars}
         onChange={onChange}
       >
-        <AtomTextarea id={id} {...props} />
+        <AtomTextarea id={id} errorState={errorState} {...props} />
       </MoleculeField>
     )
   }


### PR DESCRIPTION
### What does this PR do?

- add error and success state (and border color) in `molecule/autosuggestField` and `molecule/textField`. This is the actual behavior of input, select, etc components. 

#### Before
![image](https://user-images.githubusercontent.com/32937662/72732568-465f3800-3b96-11ea-81c0-98daae02ef90.png)

#### After
![image](https://user-images.githubusercontent.com/32937662/72732608-5b3bcb80-3b96-11ea-9124-b71cd86db992.png)


### Implementation

Inspiration from `molecule/select` component: https://github.com/SUI-Components/sui-components/blob/master/components/molecule/select/src/index.js

### Ticket

https://jira.scmspain.com/browse/SUIC-258