### PR TITLE
feat(molecule/textareaField): bump version

### DIFF
--- a/components/molecule/autosuggest/src/index.scss
+++ b/components/molecule/autosuggest/src/index.scss
@@ -6,6 +6,7 @@
 $base-class: '.sui-MoleculeAutosuggest';
 $base-class-atom-input: '.sui-AtomInput';
 $class-input: '#{$base-class}-input';
+$base-class-atom-input-input: '#{$base-class-atom-input}-input';
 
 $z-autosuggest-list: $z-navigation !default;
 $mr-autosuggest-icon-clear: -34px !default;
@@ -62,7 +63,7 @@ $bdw-autosuggest-container: $bdw-s !default;
   }
 
   @each $state, $color in $states-atom-input {
-    &#{$base-class}--#{$state} .sui-AtomInput-input {
+    &#{$base-class}--#{$state} #{$base-class-atom-input-input} {
       border-color: $color;
     }
   }

--- a/components/molecule/autosuggest/src/index.scss
+++ b/components/molecule/autosuggest/src/index.scss
@@ -62,7 +62,7 @@ $bdw-autosuggest-container: $bdw-s !default;
   }
 
   @each $state, $color in $states-atom-input {
-    &#{$base-class}--#{$state} #{$base-class}-input-container {
+    &#{$base-class}--#{$state} .sui-AtomInput-input {
       border-color: $color;
     }
   }

--- a/components/molecule/textareaField/package.json
+++ b/components/molecule/textareaField/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/react-molecule-textarea-field",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
- bump version of `molecule/textareaField` so it gets latest version of dependencies
- apply border color to input insted of container in `molecule/autosuggest` to solve visual bug. This bug is only visible if border-radius token is different than 0.

Before
![image](https://user-images.githubusercontent.com/32937662/72891660-007cae00-3d15-11ea-9629-2dfcbbcec251.png)

After
![image](https://user-images.githubusercontent.com/32937662/72891668-03779e80-3d15-11ea-8e25-a02c9f55e733.png)
