### PR TITLE
feat(molecule/autosuggest): move the autoComplete value to a prop

### DIFF
--- a/components/molecule/autosuggest/src/components/MultipleSelection.js
+++ b/components/molecule/autosuggest/src/components/MultipleSelection.js
@@ -25,7 +25,8 @@ const MoleculeAutosuggestFieldMultiSelection = ({
   onSelect,
   disabled,
   required,
-  tabIndex
+  tabIndex,
+  autoComplete
 }) => {
   const MoleculeInputTagsRef = useRef()
 
@@ -86,7 +87,7 @@ const MoleculeAutosuggestFieldMultiSelection = ({
         disabled={disabled}
         required={required}
         tabIndex={tabIndex}
-        autoComplete="nope"
+        autoComplete={autoComplete}
       />
       <MoleculeDropdownList
         checkbox
@@ -108,7 +109,8 @@ MoleculeAutosuggestFieldMultiSelection.defaultProps = {
   disabled: false,
   value: '',
   tags: [],
-  iconCloseTag: <span />
+  iconCloseTag: <span />,
+  autoComplete: 'nope'
 }
 
 export default MoleculeAutosuggestFieldMultiSelection

--- a/components/molecule/autosuggest/src/components/SingleSelection.js
+++ b/components/molecule/autosuggest/src/components/SingleSelection.js
@@ -26,7 +26,8 @@ const MoleculeAutosuggestSingleSelection = ({
   placeholder,
   disabled,
   required,
-  tabIndex
+  tabIndex,
+  autoComplete
 }) => {
   const handleSelection = (ev, {value}) => {
     onChange(ev, {value})
@@ -65,7 +66,7 @@ const MoleculeAutosuggestSingleSelection = ({
         disabled={disabled}
         required={required}
         tabIndex={tabIndex}
-        autoComplete="nope"
+        autoComplete={autoComplete}
       />
       {value && (
         <MoleculeDropdownList
@@ -86,7 +87,8 @@ MoleculeAutosuggestSingleSelection.displayName =
   'MoleculeAutosuggestSingleSelection'
 
 MoleculeAutosuggestSingleSelection.defaultProps = {
-  value: ''
+  value: '',
+  autoComplete: 'nope'
 }
 
 export default MoleculeAutosuggestSingleSelection

--- a/demo/molecule/autosuggest/demo/index.js
+++ b/demo/molecule/autosuggest/demo/index.js
@@ -83,6 +83,16 @@ const Demo = () => (
       />
     </div>
 
+    <div className={CLASS_DEMO_SECTION}>
+      <h3>Whit autocomplete "off"</h3>
+      <MoleculeAutosuggestWithState
+        value="Luxembourg"
+        onChange={(_, {value}) => console.log(value)}
+        iconClear={<IconClose />}
+        autoComplete="off"
+      />
+    </div>
+
     <h2>Multiple Selection</h2>
     <p>
       Este componente permite añadir nuevas opciones (como tags) aunque no esten


### PR DESCRIPTION
Change the autocomplete value from a hardcoded one to a prop. This allow us to send different values for the autocomplete attribute.
Since "nope"/"off" are needed based on the type of input this change will allow us to set the attribute as needed. 

Additional info:
"As of recent Chrome (definitely version 70) autocomplete="off" is now respected, as long as your inputs do not look like user profile, address or credit card data.

On the other hand, values such as disabled, nope or random strings appear to be ignored."