### PR TITLE
fix(molecule/autosuggest): avoid rendering a span when there is no icon provided

### DIFF
--- a/components/molecule/autosuggest/src/hoc/withClearUI.js
+++ b/components/molecule/autosuggest/src/hoc/withClearUI.js
@@ -15,7 +15,7 @@ export default BaseComponent => {
       return (
         <div className={CLASS_CONTAINER}>
           <BaseComponent {...props} />
-          {!!isVisibleClear && (
+          {!!isVisibleClear && iconClear && (
             <span className={CLASS_ICON_CLEAR} onClick={onClickClear}>
               {iconClear}
             </span>

--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -215,7 +215,7 @@ MoleculeAutosuggest.propTypes = {
   /** Icon for closing (removing) tags */
   iconCloseTag: PropTypes.node,
 
-  /** Icon for closing (removing) tags */
+  /** Icon for clearing values */
   iconClear: PropTypes.node,
 
   /** size (height) of the list */

--- a/demo/molecule/autosuggest/demo/index.js
+++ b/demo/molecule/autosuggest/demo/index.js
@@ -93,6 +93,14 @@ const Demo = () => (
       />
     </div>
 
+    <div className={CLASS_DEMO_SECTION}>
+      <h3>With no clear icon</h3>
+      <MoleculeAutosuggestWithState
+        value="Luxembourg"
+        onChange={(_, {value}) => console.log(value)}
+      />
+    </div>
+
     <h2>Multiple Selection</h2>
     <p>
       Este componente permite añadir nuevas opciones (como tags) aunque no esten


### PR DESCRIPTION
If no icon is provided the component will no longer render an empty <span>