### PR TITLE
feat(molecule/pagination): allow molecule/pagination to take a linkFactory prop and render links

### DIFF
--- a/components/molecule/pagination/src/index.js
+++ b/components/molecule/pagination/src/index.js
@@ -14,13 +14,19 @@ const BASE_CLASS = 'sui-MoleculePagination'
 const CLASS_PREV_BUTTON_ICON = 'sui-MoleculePagination-prevButtonIcon'
 const CLASS_NEXT_BUTTON_ICON = 'sui-MoleculePagination-nextButtonIcon'
 
-const PageButton = ({onSelectPage, page, design, ...props}) => {
+const PageButton = ({onSelectPage, page, design, linkFactory, ...props}) => {
   const _onSelectPage = e => {
     onSelectPage(e, {page})
   }
   return (
     <li className={`${BASE_CLASS}-item`}>
-      <AtomButton onClick={_onSelectPage} design={design} {...props} />
+      <AtomButton
+        onClick={_onSelectPage}
+        design={design}
+        {...props}
+        link
+        linkFactory={linkFactory(page)}
+      />
     </li>
   )
 }
@@ -31,7 +37,9 @@ PageButton.propTypes = {
   /** Current page selected */
   page: isValidPage,
   /** Design to be used for the page button. Design types 'solid', 'outline' or 'flat' */
-  design: PropTypes.string
+  design: PropTypes.string,
+  /** Factory used to create navigation links */
+  linkFactory: PropTypes.func
 }
 
 const MoleculePagination = ({
@@ -51,9 +59,7 @@ const MoleculePagination = ({
   nonSelectedPageButtonDesign,
   prevButtonDesign,
   nextButtonDesign,
-  link,
-  linkFactory,
-  href
+  linkFactory
 }) => {
   const paramsPagination = {
     page,
@@ -86,6 +92,8 @@ const MoleculePagination = ({
             onClick={handleClickPrev}
             design={prevButtonDesign}
             disabled={!prevPage}
+            link
+            linkFactory={linkFactory(page)}
           >
             {PrevButtonIcon && (
               <span className={CLASS_PREV_BUTTON_ICON}>
@@ -101,6 +109,7 @@ const MoleculePagination = ({
           page={page}
           design={selectedPageButtonDesign}
           onSelectPage={onSelectPage}
+          linkFactory={linkFactory}
         >
           {page}
         </PageButton>
@@ -115,6 +124,7 @@ const MoleculePagination = ({
                 : nonSelectedPageButtonDesign
             }
             onSelectPage={onSelectPage}
+            linkFactory={linkFactory}
           >
             {pageRange}
           </PageButton>
@@ -126,6 +136,8 @@ const MoleculePagination = ({
             onClick={handleClickNext}
             design={nextButtonDesign}
             disabled={!nextPage}
+            link
+            linkFactory={linkFactory}
           >
             {nextButtonText}
             {NextButtonIcon && (
@@ -191,14 +203,8 @@ MoleculePagination.propTypes = {
   /** Design to be used for the next button if its visible. Design types 'solid', 'outline' or 'flat */
   nextButtonDesign: PropTypes.string,
 
-  /** Prop to be passed down to AtomButton so that it renders anchor tags instead of button tags */
-  link: PropTypes.bool,
-
   /** Factory used to create navigation links */
-  linkFactory: PropTypes.func,
-
-  /** URL to be added on the HTML link, page number would be concatenated by the pagination component itself */
-  href: PropTypes.string
+  linkFactory: PropTypes.func
 }
 
 MoleculePagination.defaultProps = {
@@ -212,8 +218,7 @@ MoleculePagination.defaultProps = {
   selectedPageButtonDesign: 'solid',
   nonSelectedPageButtonDesign: 'flat',
   prevButtonDesign: 'flat',
-  nextButtonDesign: 'flat',
-  link: false
+  nextButtonDesign: 'flat'
 }
 
 export default MoleculePagination

--- a/components/molecule/pagination/src/index.js
+++ b/components/molecule/pagination/src/index.js
@@ -14,6 +14,8 @@ const BASE_CLASS = 'sui-MoleculePagination'
 const CLASS_PREV_BUTTON_ICON = 'sui-MoleculePagination-prevButtonIcon'
 const CLASS_NEXT_BUTTON_ICON = 'sui-MoleculePagination-nextButtonIcon'
 
+const PAGE_NUMBER_HOLDER = '%{pageNumber}'
+
 const PageButton = ({onSelectPage, page, design, ...props}) => {
   const _onSelectPage = e => {
     onSelectPage(e, {page})
@@ -53,7 +55,10 @@ const MoleculePagination = ({
   nonSelectedPageButtonDesign,
   prevButtonDesign,
   nextButtonDesign,
-  linkFactory
+  linkFactory,
+  createUrl,
+  urlPattern,
+  links
 }) => {
   const paramsPagination = {
     page,
@@ -79,9 +84,9 @@ const MoleculePagination = ({
   const isHideNext = hideDisabled && !nextPage
 
   const linkProps = pageNumber =>
-    typeof linkFactory === 'function' && {
+    links && {
       link: true,
-      linkFactory: linkFactory(pageNumber)
+      linkFactory: linkFactory({href: createUrl({pageNumber, urlPattern})})
     }
 
   return (
@@ -202,7 +207,16 @@ MoleculePagination.propTypes = {
   nextButtonDesign: PropTypes.string,
 
   /** Factory used to create navigation links */
-  linkFactory: PropTypes.func
+  linkFactory: PropTypes.func,
+
+  /** Factory used to create the urls */
+  createUrl: PropTypes.func,
+
+  /** URL patterns */
+  urlPattern: PropTypes.string,
+
+  /** tells wether to render links as anchor tags or as buttons */
+  links: PropTypes.bool
 }
 
 MoleculePagination.defaultProps = {
@@ -216,7 +230,20 @@ MoleculePagination.defaultProps = {
   selectedPageButtonDesign: 'solid',
   nonSelectedPageButtonDesign: 'flat',
   prevButtonDesign: 'flat',
-  nextButtonDesign: 'flat'
+  nextButtonDesign: 'flat',
+  createUrl: ({pageNumber, urlPattern}) => {
+    return urlPattern.replace(PAGE_NUMBER_HOLDER, pageNumber)
+  },
+  // eslint-disable-next-line
+  linkFactory: ({href, children, props}) => {
+    return (
+      <a {...props} href={href}>
+        {children}
+      </a>
+    )
+  },
+  urlPattern: '#',
+  links: false
 }
 
 export default MoleculePagination

--- a/components/molecule/pagination/src/index.js
+++ b/components/molecule/pagination/src/index.js
@@ -50,7 +50,10 @@ const MoleculePagination = ({
   selectedPageButtonDesign,
   nonSelectedPageButtonDesign,
   prevButtonDesign,
-  nextButtonDesign
+  nextButtonDesign,
+  link,
+  linkFactory,
+  href
 }) => {
   const paramsPagination = {
     page,
@@ -186,7 +189,16 @@ MoleculePagination.propTypes = {
   prevButtonDesign: PropTypes.string,
 
   /** Design to be used for the next button if its visible. Design types 'solid', 'outline' or 'flat */
-  nextButtonDesign: PropTypes.string
+  nextButtonDesign: PropTypes.string,
+
+  /** Prop to be passed down to AtomButton so that it renders anchor tags instead of button tags */
+  link: PropTypes.bool,
+
+  /** Factory used to create navigation links */
+  linkFactory: PropTypes.func,
+
+  /** URL to be added on the HTML link, page number would be concatenated by the pagination component itself */
+  href: PropTypes.string
 }
 
 MoleculePagination.defaultProps = {
@@ -200,7 +212,8 @@ MoleculePagination.defaultProps = {
   selectedPageButtonDesign: 'solid',
   nonSelectedPageButtonDesign: 'flat',
   prevButtonDesign: 'flat',
-  nextButtonDesign: 'flat'
+  nextButtonDesign: 'flat',
+  link: false
 }
 
 export default MoleculePagination

--- a/components/molecule/pagination/src/index.js
+++ b/components/molecule/pagination/src/index.js
@@ -14,19 +14,13 @@ const BASE_CLASS = 'sui-MoleculePagination'
 const CLASS_PREV_BUTTON_ICON = 'sui-MoleculePagination-prevButtonIcon'
 const CLASS_NEXT_BUTTON_ICON = 'sui-MoleculePagination-nextButtonIcon'
 
-const PageButton = ({onSelectPage, page, design, linkFactory, ...props}) => {
+const PageButton = ({onSelectPage, page, design, ...props}) => {
   const _onSelectPage = e => {
     onSelectPage(e, {page})
   }
   return (
     <li className={`${BASE_CLASS}-item`}>
-      <AtomButton
-        onClick={_onSelectPage}
-        design={design}
-        {...props}
-        link
-        linkFactory={linkFactory(page)}
-      />
+      <AtomButton onClick={_onSelectPage} design={design} {...props} />
     </li>
   )
 }
@@ -84,6 +78,12 @@ const MoleculePagination = ({
   const isHidePrev = hideDisabled && !prevPage
   const isHideNext = hideDisabled && !nextPage
 
+  const linkProps = pageNumber =>
+    typeof linkFactory === 'function' && {
+      link: true,
+      linkFactory: linkFactory(pageNumber)
+    }
+
   return (
     <ul className={BASE_CLASS}>
       {!isHidePrev && (
@@ -92,8 +92,7 @@ const MoleculePagination = ({
             onClick={handleClickPrev}
             design={prevButtonDesign}
             disabled={!prevPage}
-            link
-            linkFactory={linkFactory(page)}
+            {...linkProps(prevPage)}
           >
             {PrevButtonIcon && (
               <span className={CLASS_PREV_BUTTON_ICON}>
@@ -109,7 +108,7 @@ const MoleculePagination = ({
           page={page}
           design={selectedPageButtonDesign}
           onSelectPage={onSelectPage}
-          linkFactory={linkFactory}
+          {...linkProps(page)}
         >
           {page}
         </PageButton>
@@ -124,7 +123,7 @@ const MoleculePagination = ({
                 : nonSelectedPageButtonDesign
             }
             onSelectPage={onSelectPage}
-            linkFactory={linkFactory}
+            {...linkProps(pageRange)}
           >
             {pageRange}
           </PageButton>
@@ -136,8 +135,7 @@ const MoleculePagination = ({
             onClick={handleClickNext}
             design={nextButtonDesign}
             disabled={!nextPage}
-            link
-            linkFactory={linkFactory}
+            {...linkProps(nextPage)}
           >
             {nextButtonText}
             {NextButtonIcon && (

--- a/components/molecule/pagination/src/index.js
+++ b/components/molecule/pagination/src/index.js
@@ -38,27 +38,39 @@ PageButton.propTypes = {
   linkFactory: PropTypes.func
 }
 
+// eslint-disable-next-line
+const defaultLinkFactory = ({href}) => ({children, props}) => {
+  return (
+    <a {...props} href={href}>
+      {children}
+    </a>
+  )
+}
+
+const defaultCreateUrl = ({pageNumber, urlPattern}) =>
+  urlPattern.replace(PAGE_NUMBER_HOLDER, pageNumber)
+
 const MoleculePagination = ({
-  onSelectNext,
-  onSelectPrev,
+  onSelectNext = () => {},
+  onSelectPage = () => {},
+  onSelectPrev = () => {},
   page,
   totalPages,
-  showPages,
-  prevButtonText,
+  showPages = 10,
+  prevButtonText = 'Previous',
   prevButtonIcon: PrevButtonIcon,
-  nextButtonText,
+  nextButtonText = 'Next',
   nextButtonIcon: NextButtonIcon,
-  onSelectPage,
-  compressed,
+  compressed = false,
   hideDisabled,
-  selectedPageButtonDesign,
-  nonSelectedPageButtonDesign,
-  prevButtonDesign,
-  nextButtonDesign,
-  linkFactory,
-  createUrl,
-  urlPattern,
-  links
+  selectedPageButtonDesign = 'solid',
+  nonSelectedPageButtonDesign = 'flat',
+  prevButtonDesign = 'flat',
+  nextButtonDesign = 'flat',
+  linkFactory = defaultLinkFactory,
+  createUrl = defaultCreateUrl,
+  urlPattern = '#',
+  renderLinks = false
 }) => {
   const paramsPagination = {
     page,
@@ -84,7 +96,7 @@ const MoleculePagination = ({
   const isHideNext = hideDisabled && !nextPage
 
   const linkProps = pageNumber =>
-    links && {
+    renderLinks && {
       link: true,
       linkFactory: linkFactory({href: createUrl({pageNumber, urlPattern})})
     }
@@ -216,34 +228,7 @@ MoleculePagination.propTypes = {
   urlPattern: PropTypes.string,
 
   /** tells wether to render links as anchor tags or as buttons */
-  links: PropTypes.bool
-}
-
-MoleculePagination.defaultProps = {
-  showPages: 10,
-  compressed: false,
-  prevButtonText: 'Previous',
-  nextButtonText: 'Next',
-  onSelectPrev: () => {},
-  onSelectNext: () => {},
-  onSelectPage: () => {},
-  selectedPageButtonDesign: 'solid',
-  nonSelectedPageButtonDesign: 'flat',
-  prevButtonDesign: 'flat',
-  nextButtonDesign: 'flat',
-  createUrl: ({pageNumber, urlPattern}) => {
-    return urlPattern.replace(PAGE_NUMBER_HOLDER, pageNumber)
-  },
-  // eslint-disable-next-line
-  linkFactory: ({href, children, props}) => {
-    return (
-      <a {...props} href={href}>
-        {children}
-      </a>
-    )
-  },
-  urlPattern: '#',
-  links: false
+  renderLinks: PropTypes.bool
 }
 
 export default MoleculePagination

--- a/demo/molecule/pagination/demo/index.js
+++ b/demo/molecule/pagination/demo/index.js
@@ -162,7 +162,7 @@ const Demo = () => {
         />
       </div>
       {/* ------------------------------------------------------------------------------------------------------------- */}
-      <h3>Compresed Version</h3>
+      <h3>Compressed Version</h3>
       <div className={CLASS_DEMO_SECTION}>
         <h4>First Page (only next)</h4>
         <p>

--- a/demo/molecule/pagination/demo/index.js
+++ b/demo/molecule/pagination/demo/index.js
@@ -30,6 +30,16 @@ const BASE_CLASS_DEMO = 'DemoMoleculePagination'
 const CLASS_DEMO_SECTION = `${BASE_CLASS_DEMO}-section`
 const CLASS_DEMO_SECTION_RESPONSIVE = `${CLASS_DEMO_SECTION}-responsive`
 
+const PAGINATION_URL = '/?page='
+
+const linkFactory = page => ({children, ...props}) => {
+  return (
+    <a {...props} href={PAGINATION_URL + page}>
+      {children}
+    </a>
+  )
+}
+
 const Demo = () => {
   return (
     <div className={BASE_CLASS_DEMO}>
@@ -82,6 +92,17 @@ const Demo = () => {
           <code>totalPages=25 page=7</code>
         </p>
         <MoleculePagination totalPages={25} page={7} />
+      </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h4>Basic with links and linkFactory</h4>
+        <p>
+          <code>totalPages=25 page=7 linkFactory=linkFactory</code>
+        </p>
+        <MoleculePagination
+          totalPages={25}
+          page={7}
+          linkFactory={linkFactory}
+        />
       </div>
       <div className={CLASS_DEMO_SECTION}>
         <h4>w/ Next</h4>

--- a/demo/molecule/pagination/demo/index.js
+++ b/demo/molecule/pagination/demo/index.js
@@ -98,7 +98,7 @@ const Demo = () => {
         <p>
           <code>
             totalPages=25 page=7 linkFactory urlPattern="
-            {`/?page=%{pageNumber}`}" links
+            {`/?page=%{pageNumber}`}" renderLinks
           </code>
         </p>
         <MoleculePagination
@@ -106,7 +106,7 @@ const Demo = () => {
           page={7}
           linkFactory={linkFactory}
           urlPattern={PAGINATION_URL}
-          links
+          renderLinks
         />
       </div>
       <div className={CLASS_DEMO_SECTION}>

--- a/demo/molecule/pagination/demo/index.js
+++ b/demo/molecule/pagination/demo/index.js
@@ -96,7 +96,10 @@ const Demo = () => {
       <div className={CLASS_DEMO_SECTION}>
         <h4>Basic with links and linkFactory</h4>
         <p>
-          <code>totalPages=25 page=7 linkFactory urlPattern links</code>
+          <code>
+            totalPages=25 page=7 linkFactory urlPattern="
+            {`/?page=%{pageNumber}`}" links
+          </code>
         </p>
         <MoleculePagination
           totalPages={25}

--- a/demo/molecule/pagination/demo/index.js
+++ b/demo/molecule/pagination/demo/index.js
@@ -30,11 +30,11 @@ const BASE_CLASS_DEMO = 'DemoMoleculePagination'
 const CLASS_DEMO_SECTION = `${BASE_CLASS_DEMO}-section`
 const CLASS_DEMO_SECTION_RESPONSIVE = `${CLASS_DEMO_SECTION}-responsive`
 
-const PAGINATION_URL = '/?page='
+const PAGINATION_URL = '/?page=%{pageNumber}'
 
-const linkFactory = page => ({children, ...props}) => {
+const linkFactory = ({href}) => ({children, ...props}) => {
   return (
-    <a {...props} href={PAGINATION_URL + page}>
+    <a {...props} href={href}>
       {children}
     </a>
   )
@@ -96,12 +96,14 @@ const Demo = () => {
       <div className={CLASS_DEMO_SECTION}>
         <h4>Basic with links and linkFactory</h4>
         <p>
-          <code>totalPages=25 page=7 linkFactory=linkFactory</code>
+          <code>totalPages=25 page=7 linkFactory urlPattern links</code>
         </p>
         <MoleculePagination
           totalPages={25}
           page={7}
           linkFactory={linkFactory}
+          urlPattern={PAGINATION_URL}
+          links
         />
       </div>
       <div className={CLASS_DEMO_SECTION}>


### PR DESCRIPTION
`molecule/pagination` uses `atom/button` which by default renders `button` tags for every pagination element.

The idea behind this PR is to allow `molecule/pagination` to tell `atom/button` to render an anchor tag if a `renderLinks` prop and a linkFactory are passed.