### PR TITLE
feat(atom/popover): added showPopover value to control it from outside

### DIFF
--- a/components/atom/popover/src/index.js
+++ b/components/atom/popover/src/index.js
@@ -1,4 +1,4 @@
-import React, {useState, useRef, Suspense} from 'react'
+import React, {useEffect, useState, useRef, Suspense} from 'react'
 import PropTypes from 'prop-types'
 import {PLACEMENTS} from './config'
 
@@ -10,7 +10,6 @@ const DEFAULT_TRIGGER = 'legacy'
 const DEFAULT_DELAY = 0
 
 const Popover = React.lazy(() => import('reactstrap/lib/Popover'))
-let targetRef
 
 function AtomPopover({
   children,
@@ -19,15 +18,23 @@ function AtomPopover({
   id,
   onClose = () => {},
   onOpen = () => {},
-  placement = PLACEMENTS.BOTTOM
+  placement = PLACEMENTS.BOTTOM,
+  showPopover
 }) {
-  targetRef = useRef()
-  const [showPopover, setShowPopover] = useState(false)
+  const targetRef = useRef()
+  const [internalShowPopover, setInternalShowPopover] = useState(showPopover)
+
+  useEffect(
+    function() {
+      setInternalShowPopover(showPopover)
+    },
+    [showPopover]
+  )
 
   const extendChildren = () => {
-    const onClick = () => {
+    const onClick = e => {
       onOpen()
-      setShowPopover(true)
+      setInternalShowPopover(true)
     }
     const ref = targetRef
     const childrenOnly = React.Children.only(children)
@@ -45,42 +52,37 @@ function AtomPopover({
   }
 
   const handleToggle = () => {
-    setShowPopover(!showPopover)
+    setInternalShowPopover(!internalShowPopover)
     onClose()
   }
 
   return (
-    <>
-      <div>
-        {extendChildren()}
-        {showPopover && (
-          <Suspense fallback={<></>}>
-            <Popover
-              className={BASE_CLASS}
-              delay={DEFAULT_DELAY}
-              innerClassName={CLASS_INNER}
-              isOpen={showPopover}
-              offset={DEFAULT_OFFSET}
-              placement={placement}
-              placementPrefix={PREFIX_PLACEMENT}
-              target={id || targetRef.current}
-              toggle={handleToggle}
-              trigger={DEFAULT_TRIGGER}
-            >
-              {closeIcon && (
-                <div
-                  className={`${BASE_CLASS}-closeIcon`}
-                  onClick={handleToggle}
-                >
-                  {closeIcon}
-                </div>
-              )}
-              {content}
-            </Popover>
-          </Suspense>
-        )}
-      </div>
-    </>
+    <div>
+      {extendChildren()}
+      {internalShowPopover && (
+        <Suspense fallback={<></>}>
+          <Popover
+            className={BASE_CLASS}
+            delay={DEFAULT_DELAY}
+            innerClassName={CLASS_INNER}
+            isOpen={internalShowPopover}
+            offset={DEFAULT_OFFSET}
+            placement={placement}
+            placementPrefix={PREFIX_PLACEMENT}
+            target={id || targetRef.current}
+            toggle={handleToggle}
+            trigger={DEFAULT_TRIGGER}
+          >
+            {closeIcon && (
+              <div className={`${BASE_CLASS}-closeIcon`} onClick={handleToggle}>
+                {closeIcon}
+              </div>
+            )}
+            {content}
+          </Popover>
+        </Suspense>
+      )}
+    </div>
   )
 }
 
@@ -91,6 +93,8 @@ AtomPopover.propTypes = {
   content: PropTypes.element.isRequired,
   /** Popover children */
   children: PropTypes.node.isRequired,
+  /** Initial value for the show pop over */
+  showPopover: PropTypes.bool,
   /** Popover id: only is needed if use a children without ref */
   id: PropTypes.string,
   /** Custom close icon  */

--- a/components/atom/popover/src/index.js
+++ b/components/atom/popover/src/index.js
@@ -90,7 +90,7 @@ AtomPopover.propTypes = {
   content: PropTypes.element.isRequired,
   /** Popover children */
   children: PropTypes.node.isRequired,
-  /** Initial value for the show pop over */
+  /** Controlled value for the show pop over */
   showPopover: PropTypes.bool,
   /** Popover id: only is needed if use a children without ref */
   id: PropTypes.string,

--- a/components/atom/popover/src/index.js
+++ b/components/atom/popover/src/index.js
@@ -24,12 +24,9 @@ function AtomPopover({
   const targetRef = useRef()
   const [internalShowPopover, setInternalShowPopover] = useState(showPopover)
 
-  useEffect(
-    function() {
-      setInternalShowPopover(showPopover)
-    },
-    [showPopover]
-  )
+  useEffect(() => {
+    setInternalShowPopover(showPopover)
+  }, [showPopover])
 
   const extendChildren = () => {
     const onClick = e => {

--- a/components/atom/popover/src/index.js
+++ b/components/atom/popover/src/index.js
@@ -29,7 +29,7 @@ function AtomPopover({
   }, [showPopover])
 
   const extendChildren = () => {
-    const onClick = e => {
+    const onClick = () => {
       onOpen()
       setInternalShowPopover(true)
     }


### PR DESCRIPTION
_As commented to @midudev I tested the behavior with @quinwacca so this behavior is totally retro compatible._

## Goal
Make possible to control when the `Popover` is open or not from its parent.

## Implementation
- Add a `showPopover ` prop that makes possible this behavior.
- Removed unneeded `<>`
