### PR TITLE
fix(molecule/select): moleculeSelectSingleSelection refMoleculeSelectcurrent.focus() crash fix

### DIFF
--- a/components/molecule/select/src/components/SingleSelection.js
+++ b/components/molecule/select/src/components/SingleSelection.js
@@ -30,7 +30,9 @@ const MoleculeSelectSingleSelection = props => {
   const handleSelection = (ev, {value}) => {
     onChange(ev, {value})
     onToggle(ev, {isOpen: false})
-    refMoleculeSelect.current.focus()
+    refMoleculeSelect &&
+      refMoleculeSelect.current &&
+      refMoleculeSelect.current.focus()
   }
 
   return (


### PR DESCRIPTION
Handle `undefined` ref crash in `moleculeSelectSingleSelection`: If `refMoleculeSelect.current` exists execute `refMoleculeSelect.current.focus() `