### PR TITLE
feat(atom/input): add new option to highlight input

### DIFF
--- a/components/atom/input/README.md
+++ b/components/atom/input/README.md
@@ -135,6 +135,26 @@ There are 3 error states:
 />
 ```
 
+
+### Input states
+
+There are 3 error states:
+
+* input state = **'error'**, will show a **red** border around the input field
+* input state = **'success'**, will show a **green** border around the input field
+* input state = **'alert'**, will show a **orange** border around the input field
+* input state = **null**, will show the by **default** border around the input field
+
+```js
+<AtomInput 
+  name="second" 
+  placeholder="Success input" 
+  state="alert"
+/>
+```
+
+
+
 ### Form Usage
 
 Each field returns its value on every onChange event so you can save it inside your form state.

--- a/components/atom/input/src/Input/Component/index.js
+++ b/components/atom/input/src/Input/Component/index.js
@@ -10,9 +10,19 @@ const SIZES = {
   XSMALL: 'xs'
 }
 
-const ERROR_STATES = {
+const INPUT_STATES = {
   ERROR: 'error',
-  SUCCESS: 'success'
+  SUCCESS: 'success',
+  ALERT: 'alert'
+}
+
+const DEFAULT_PROPS = {
+  SIZE: SIZES.MEDIUM,
+  ON_ENTER_KEY: 'Enter',
+  TAB_INDEX: -1,
+  ON_KEY_DOWN: () => {},
+  ON_ENTER: () => {},
+  ON_CHANGE: () => {}
 }
 
 const getClassNames = ({
@@ -21,7 +31,8 @@ const getClassNames = ({
   hideInput,
   noBorder,
   readOnly,
-  errorState
+  errorState,
+  state
 }) => {
   return cx(
     BASE_CLASS,
@@ -30,8 +41,9 @@ const getClassNames = ({
     hideInput && `${BASE_CLASS}--hidden`,
     noBorder && `${BASE_CLASS}--noBorder`,
     readOnly && `${BASE_CLASS}--readOnly`,
-    errorState && `${BASE_CLASS}--${ERROR_STATES.ERROR}`,
-    errorState === false && `${BASE_CLASS}--${ERROR_STATES.SUCCESS}`
+    errorState && `${BASE_CLASS}--${INPUT_STATES.ERROR}`,
+    errorState === false && `${BASE_CLASS}--${INPUT_STATES.SUCCESS}`,
+    state && `${BASE_CLASS}--${state}`
   )
 }
 
@@ -46,19 +58,20 @@ const Input = ({
   onFocus,
   placeholder,
   reference,
-  size,
+  size = DEFAULT_PROPS.SIZE,
   errorState,
+  state,
   type,
   value,
   charsSize,
-  tabIndex,
+  tabIndex = DEFAULT_PROPS.TAB_INDEX,
   maxLength,
   minLength,
   autoComplete,
-  onChange,
-  onEnter,
-  onEnterKey,
-  onKeyDown,
+  onChange = DEFAULT_PROPS.ON_CHANGE,
+  onEnter = DEFAULT_PROPS.ON_ENTER,
+  onEnterKey = DEFAULT_PROPS.ON_ENTER_KEY,
+  onKeyDown = DEFAULT_PROPS.ON_KEY_DOWN,
   required,
   pattern
 }) => {
@@ -84,7 +97,8 @@ const Input = ({
     hideInput,
     noBorder,
     readOnly,
-    errorState
+    errorState,
+    state
   })
 
   return (
@@ -156,6 +170,8 @@ Input.propTypes = {
   hideInput: PropTypes.bool,
   /* Will set a red/green border if set to true/false */
   errorState: PropTypes.bool,
+  /* Will set a red/green/orange border if set to 'error' / 'success' / 'alert' */
+  state: PropTypes.oneOf(Object.values(INPUT_STATES)),
   /** Wether to hide the input border or not */
   noBorder: PropTypes.bool,
   /** tabindex value */
@@ -166,14 +182,5 @@ Input.propTypes = {
   pattern: PropTypes.string
 }
 
-Input.defaultProps = {
-  size: SIZES.MEDIUM,
-  onEnterKey: 'Enter',
-  tabIndex: -1,
-  onKeyDown: () => {},
-  onEnter: () => {},
-  onChange: () => {}
-}
-
 export default Input
-export {SIZES as inputSizes}
+export {SIZES as inputSizes, INPUT_STATES as inputStates}

--- a/components/atom/input/src/Input/Component/index.scss
+++ b/components/atom/input/src/Input/Component/index.scss
@@ -6,7 +6,6 @@ $bdrs-atom-input: $bdrs-none !default;
 
 $base-class: '.sui-AtomInput-input';
 $class-read-only: '#{$base-class}--readOnly';
-$c-atom-input-type: success $c-success, error $c-error, alert $c-alert;
 
 #{$base-class} {
   @extend %sui-atom-input-input;
@@ -53,7 +52,7 @@ $c-atom-input-type: success $c-success, error $c-error, alert $c-alert;
     }
   }
 
-  @each $state, $color in $c-atom-input-type {
+  @each $state, $color in $states-atom-input {
     &.sui-AtomInput-input--#{$state} {
       border-color: $color;
     }

--- a/components/atom/input/src/Input/Component/index.scss
+++ b/components/atom/input/src/Input/Component/index.scss
@@ -6,6 +6,7 @@ $bdrs-atom-input: $bdrs-none !default;
 
 $base-class: '.sui-AtomInput-input';
 $class-read-only: '#{$base-class}--readOnly';
+$c-atom-input-type: success $c-success, error $c-error, alert $c-alert;
 
 #{$base-class} {
   @extend %sui-atom-input-input;
@@ -52,7 +53,7 @@ $class-read-only: '#{$base-class}--readOnly';
     }
   }
 
-  @each $state, $color in $states-atom-input {
+  @each $state, $color in $c-atom-input-type {
     &.sui-AtomInput-input--#{$state} {
       border-color: $color;
     }

--- a/components/atom/input/src/index.js
+++ b/components/atom/input/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import Input, {inputSizes} from './Input'
+import Input, {inputSizes, inputStates} from './Input'
 import Password from './Password'
 import Mask from './Mask'
 
@@ -91,6 +91,9 @@ AtomInput.propTypes = {
   /** true = error, false = success, null = neutral */
   errorState: PropTypes.bool,
 
+  /** 'success', 'error' or 'alert' */
+  state: PropTypes.oneOf(Object.values(inputStates)),
+
   /** value of the control */
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
 
@@ -104,4 +107,4 @@ AtomInput.propTypes = {
 AtomInput.displayName = 'AtomInput'
 
 export default AtomInput
-export {inputSizes}
+export {inputSizes, inputStates}

--- a/demo/atom/input/demo/index.js
+++ b/demo/atom/input/demo/index.js
@@ -109,6 +109,18 @@ export default () => (
       <AtomInput name="second" placeholder="Error input" errorState />
     </div>
     <div style={field}>
+      <h4>With state="success"</h4>
+      <AtomInput name="second" placeholder="Success input" state="success" />
+    </div>
+    <div style={field}>
+      <h4>With state="error"</h4>
+      <AtomInput name="second" placeholder="Error input" state="error" />
+    </div>
+    <div style={field}>
+      <h4>With state="alert"</h4>
+      <AtomInput name="second" placeholder="Error input" state="alert" />
+    </div>
+    <div style={field}>
       <h4>Type: sui-password</h4>
       <AtomInput
         type="sui-password"


### PR DESCRIPTION
Add new states passed by props.

Before: 
We only could highlight the input with `success` or `error`, green or red. That's because we had a boolean prop (`errorState`), we couldn't have more than two values.

After:
We can highlight the input in different ways. Now, we need an `alert` orange border. So we add a string prop (`state`), which can receive `'success'`, `'error'` or `'alert'`.  In the future, more states can be added easily. Also, we exported from that component `inputStates`.

It's backward compatible, so it doesn't need a major.
 
<img width="343" alt="Captura de pantalla 2020-01-28 a las 16 14 46" src="https://user-images.githubusercontent.com/37936498/73276812-8ef7a080-41e9-11ea-9f06-7c439b5c4f63.png">

Related Jiras:
https://jira.scmspain.com/browse/SUIC-262
https://jira.scmspain.com/browse/SUIC-263