### PR TITLE
fix(molecule/autosuggest): do not focus if inner ref is undefined

### DIFF
--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -78,7 +78,7 @@ const MoleculeAutosuggest = ({multiselection, ...props}) => {
     const {current: domMoleculeAutosuggest} = refMoleculeAutosuggest
     onToggle(ev, {isOpen: false})
     if (multiselection) onChange(ev, {value: ''})
-    domMoleculeAutosuggest.focus()
+    domMoleculeAutosuggest && domMoleculeAutosuggest.focus()
     setFocus(false)
     ev.preventDefault()
     ev.stopPropagation()


### PR DESCRIPTION
Looks like it could happen that this inner ref is undefined so this line breaks