### PR TITLE
feat(atom/textarea): add state prop

### DIFF
--- a/components/atom/textarea/README.md
+++ b/components/atom/textarea/README.md
@@ -34,4 +34,12 @@ import AtomTextarea from '@s-ui/react-atom-textarea'
 <AtomTextarea placeholder="Write something cool here..." />
 ```
 
+### Textarea States
+
+The component can receive a `success`, `error` or `alert` state, to highlight his border with colors defined on sui-theme.
+
+```javascript
+<AtomTextarea state="success" />
+```
+
 > **Find full description and more examples in the [demo page](https://sui-components.now.sh/workbench/atom/textarea/demo).**

--- a/components/atom/textarea/src/index.js
+++ b/components/atom/textarea/src/index.js
@@ -8,17 +8,31 @@ const SIZES = {
   LONG: 'long'
 }
 
-const ERROR_STATES = {
+const TEXTAREA_STATES = {
   ERROR: 'error',
-  SUCCESS: 'success'
+  SUCCESS: 'success',
+  ALERT: 'alert'
 }
 
-const AtomTextarea = ({onChange, size, value, errorState, ...props}) => {
+const DEFAULT_PROPS = {
+  size: SIZES.SHORT,
+  onChange: () => {}
+}
+
+const AtomTextarea = ({
+  onChange = DEFAULT_PROPS.onChange,
+  size = DEFAULT_PROPS.size,
+  value,
+  errorState,
+  state,
+  ...props
+}) => {
   const className = cx(
     BASE_CLASS,
     `${BASE_CLASS}--${size}`,
-    errorState && `${BASE_CLASS}--${ERROR_STATES.ERROR}`,
-    errorState === false && `${BASE_CLASS}--${ERROR_STATES.SUCCESS}`
+    errorState && `${BASE_CLASS}--${TEXTAREA_STATES.ERROR}`,
+    errorState === false && `${BASE_CLASS}--${TEXTAREA_STATES.SUCCESS}`,
+    state && `${BASE_CLASS}--${state}`
   )
 
   const handleChange = ev => {
@@ -49,13 +63,11 @@ AtomTextarea.propTypes = {
   value: PropTypes.string,
 
   /** true = error, false = success, null = neutral */
-  errorState: PropTypes.bool
-}
+  errorState: PropTypes.bool,
 
-AtomTextarea.defaultProps = {
-  size: SIZES.SHORT,
-  onChange: () => {}
+  /* Will set a red/green/orange border if set to 'error' / 'success' / 'alert' */
+  state: PropTypes.oneOf(Object.values(TEXTAREA_STATES))
 }
 
 export default AtomTextarea
-export {SIZES as AtomTextareaSizes}
+export {SIZES as AtomTextareaSizes, TEXTAREA_STATES as AtomTextareaStates}

--- a/demo/atom/textarea/playground
+++ b/demo/atom/textarea/playground
@@ -68,5 +68,29 @@ return (
         onChange={console.log}
       />
     </div>
+    <h2>States</h2>
+    <div style={stylesSection}>
+    <h3>Success</h3>
+      <AtomTextareaWithState 
+        name="textarea-4"
+        placeholder="Write something cool here..."
+        onChange={console.log}
+        state="success"
+      />
+      <h3>Error</h3>
+      <AtomTextareaWithState 
+        name="textarea-4"
+        placeholder="Write something cool here..."
+        onChange={console.log}
+        state="error"
+      />
+      <h3>Alert</h3>
+      <AtomTextareaWithState 
+        name="textarea-4"
+        placeholder="Write something cool here..."
+        onChange={console.log}
+        state="alert"
+      />
+    </div>
   </div>
 )


### PR DESCRIPTION
As in `atom/input` component, we add new states passed by props.

Before:
We only could highlight the `text area` with success or error, green or red. That's because we had a boolean prop (errorState), we couldn't have more than two values.

After:
We can highlight the `text area` in different ways. Now, we need an alert orange border. So we add a string prop (state), which can receive 'success', 'error' or 'alert'. In the future, more states can be added easily. Also, we exported from that component atomTextareaStates (this time we really do😄 !)

It's backward compatible, so it doesn't need a major.

<img width="289" alt="Captura de pantalla 2020-01-30 a las 16 30 18" src="https://user-images.githubusercontent.com/37936498/73463962-6c4ac080-437e-11ea-811b-15b12476f0b8.png">
