### PR TITLE
feat(molecule/textareaField): add alert state

### DIFF
--- a/components/molecule/textareaField/README.md
+++ b/components/molecule/textareaField/README.md
@@ -68,6 +68,16 @@ import MoleculeTextareaField from '@s-ui/react-molecule-textarea-field'
   />
 ```
 
+### With Alert Message 
+```
+  <MoleculeTextareaField
+    id="description"
+    label="Description"
+    value="In some place of La Mancha which name..."
+    alertText="Ok, but's something needs your attention..."
+  />
+```
+
 ### With Help Text
 
 ```

--- a/components/molecule/textareaField/package.json
+++ b/components/molecule/textareaField/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@s-ui/component-dependencies": "1",
     "@s-ui/react-molecule-field": "1",
-    "@s-ui/react-atom-textarea": "1"
+    "@s-ui/react-atom-textarea": "2"
   },
   "keywords": [],
   "author": "",

--- a/components/molecule/textareaField/src/index.js
+++ b/components/molecule/textareaField/src/index.js
@@ -3,13 +3,20 @@ import PropTypes from 'prop-types'
 
 import MoleculeField from '@s-ui/react-molecule-field'
 import AtomTextarea, {
-  AtomTextareaSizes as SIZES
+  AtomTextareaSizes as SIZES,
+  AtomTextareaStates
 } from '@s-ui/react-atom-textarea'
 import WithCharacterCount from './hoc/WithCharacterCount'
 
-const hasErrors = (success, error) => {
-  if (error) return true
-  if (success) return false
+const hasErrors = ({successText, errorText}) => {
+  if (errorText) return true
+  if (successText) return false
+}
+
+const getState = ({successText, errorState, alertText}) => {
+  if (successText) return AtomTextareaStates.SUCCESS
+  if (errorState) return AtomTextareaStates.ERROR
+  if (alertText) return AtomTextareaStates.ALERT
 }
 
 const MoleculeTextareaField = WithCharacterCount(
@@ -20,11 +27,14 @@ const MoleculeTextareaField = WithCharacterCount(
     textCharacters,
     successText,
     errorText,
+    alertText,
     helpText,
     onChange,
     ...props
   }) => {
-    const errorState = hasErrors(successText, errorText)
+    const errorState = hasErrors({successText, errorText})
+    const textAreaState = getState({successText, errorState, alertText})
+
     return (
       <MoleculeField
         name={id}
@@ -32,11 +42,17 @@ const MoleculeTextareaField = WithCharacterCount(
         textCharacters={textCharacters}
         successText={successText}
         errorText={errorText}
+        alertText={alertText}
         helpText={helpText}
         maxChars={maxChars}
         onChange={onChange}
       >
-        <AtomTextarea id={id} errorState={errorState} {...props} />
+        <AtomTextarea
+          id={id}
+          errorState={errorState}
+          state={textAreaState}
+          {...props}
+        />
       </MoleculeField>
     )
   }
@@ -78,6 +94,9 @@ MoleculeTextareaField.propTypes = {
 
   /** Error message to display when error state  */
   errorText: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+
+  /** Alert message to display when error state  */
+  alertText: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
 
   /** Help Text to display */
   helpText: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),

--- a/demo/molecule/textareaField/playground
+++ b/demo/molecule/textareaField/playground
@@ -68,6 +68,18 @@ return (
           maxChars={60}
         />
       </li>
+      <li>
+        <h2>
+          With Alert validation HelpText and custom <code>maxChars</code>
+        </h2>
+        <MoleculeTextareaField
+          id="notes"
+          label="Notes"
+          alertText="Ok, but's something needs your attention..."
+          value="In some place of La Mancha which name..."
+          maxChars={60}
+        />
+      </li>
     </ul>
   </div>
 )


### PR DESCRIPTION
Add the possibility to receive an alert text (`alertText`)  in the same way `errorText` or `successText` works now.
<img width="838" alt="Captura de pantalla 2020-01-30 a las 17 18 46" src="https://user-images.githubusercontent.com/37936498/73469166-34e01200-4386-11ea-8387-4acfc4ac25cd.png">
