### PR TITLE
feat(molecule/select): add state prop

### DIFF
--- a/components/molecule/select/README.md
+++ b/components/molecule/select/README.md
@@ -73,6 +73,24 @@ const options = ['John','Paul','George','Ringo']
 </MoleculeSelect>
 ```
 
+#### With state highlight
+Can be `success`, `error` or `alert`.
+
+```js
+<MoleculeSelect
+      placeholder="Select a Country..."
+      onChange={(_, {value}) => console.log(value)}
+      iconArrowDown={<IconArrowDown />}
+      state="success"
+    >
+  {options.map((option, i) => (
+    <MoleculeSelectOption key={i} value={option}>
+      {option}
+    </MoleculeSelectOption>
+  ))}
+</MoleculeSelect>
+```
+
 ### Multiple Selection
 
 #### Basic usage

--- a/components/molecule/select/src/index.js
+++ b/components/molecule/select/src/index.js
@@ -16,9 +16,10 @@ const BASE_CLASS = `sui-MoleculeSelect`
 const CLASS_FOCUS = `${BASE_CLASS}--focus`
 const CLASS_DISABLED = `is-disabled`
 
-const ERROR_STATES = {
+const SELECT_STATES = {
   ERROR: 'error',
-  SUCCESS: 'success'
+  SUCCESS: 'success',
+  ALERT: 'alert'
 }
 
 const ENABLED_KEYS = ['Enter', 'ArrowDown', 'ArrowUp']
@@ -38,6 +39,7 @@ const MoleculeSelect = props => {
     onToggle,
     children,
     errorState,
+    state,
     disabled,
     keysSelection,
     refMoleculeSelect: refMoleculeSelectFromProps
@@ -60,8 +62,9 @@ const MoleculeSelect = props => {
 
   const className = cx(
     BASE_CLASS,
-    errorState && `${BASE_CLASS}--${ERROR_STATES.ERROR}`,
-    errorState === false && `${BASE_CLASS}--${ERROR_STATES.SUCCESS}`,
+    errorState && `${BASE_CLASS}--${SELECT_STATES.ERROR}`,
+    errorState === false && `${BASE_CLASS}--${SELECT_STATES.SUCCESS}`,
+    state && `${BASE_CLASS}--${state}`,
     {
       [CLASS_FOCUS]: focus,
       [CLASS_DISABLED]: disabled
@@ -205,6 +208,9 @@ MoleculeSelect.propTypes = {
   /** true = error, false = success, null = neutral */
   errorState: PropTypes.bool,
 
+  /* Will set a red/green/orange border if set to 'error' / 'success' / 'alert' */
+  state: PropTypes.oneOf(Object.values(SELECT_STATES)),
+
   /** This Boolean attribute prevents the user from interacting with the select */
   disabled: PropTypes.bool,
 
@@ -230,3 +236,4 @@ MoleculeSelect.defaultProps = {
 export default withOpenToggle(MoleculeSelect)
 export {SIZES as moleculeSelectDropdownListSizes}
 export {SELECT_SIZES as moleculeSelectSizes}
+export {SELECT_STATES as moleculeSelectStates}

--- a/demo/molecule/select/demo/index.js
+++ b/demo/molecule/select/demo/index.js
@@ -124,6 +124,26 @@ const Demo = () => (
       </MoleculeSelect>
     </div>
 
+    <div className={CLASS_DEMO_SECTION}>
+      <h3>With state</h3>
+      <p>
+        State to highlight that can be <code>success</code>, <code>error</code>{' '}
+        or <code>alert</code>
+      </p>
+      <MoleculeSelect
+        placeholder="Select a Country..."
+        onChange={(_, {value}) => console.log(value)}
+        iconArrowDown={<IconArrowDown />}
+        state="alert"
+      >
+        {countriesData.map(({name, code}, i) => (
+          <MoleculeSelectOption key={i} value={code}>
+            {name}
+          </MoleculeSelectOption>
+        ))}
+      </MoleculeSelect>
+    </div>
+
     <h2>Multiple Selection</h2>
     <div className={CLASS_DEMO_SECTION}>
       <h3>With Placeholder</h3>

--- a/demo/molecule/select/demo/index.js
+++ b/demo/molecule/select/demo/index.js
@@ -4,7 +4,8 @@ import React from 'react'
 import {withStateValue} from '@s-ui/hoc'
 
 import MoleculeSelect, {
-  moleculeSelectSizes
+  moleculeSelectSizes,
+  moleculeSelectStates
 } from '../../../../components/molecule/select/src'
 
 import MoleculeSelectOption from '@s-ui/react-molecule-dropdown-option'
@@ -134,7 +135,7 @@ const Demo = () => (
         placeholder="Select a Country..."
         onChange={(_, {value}) => console.log(value)}
         iconArrowDown={<IconArrowDown />}
-        state="alert"
+        state={moleculeSelectStates.ALERT}
       >
         {countriesData.map(({name, code}, i) => (
           <MoleculeSelectOption key={i} value={code}>


### PR DESCRIPTION
Add new states passed by props.

Before:
We only could highlight the input with success or error, green or red. That's because we had a boolean prop (errorState), we couldn't have more than two values.

After:
We can highlight the **select** in different ways. Now, we need an alert orange border. So we add a string prop (state), which can receive 'success', 'error' or 'alert'. In the future, more states can be added easily. Also, we exported from that component **moleculeSelectStates**.

It's backward compatible, so it doesn't need a major.

<img width="241" alt="Captura de pantalla 2020-01-31 a las 11 29 01" src="https://user-images.githubusercontent.com/37936498/73532579-3d375c00-441d-11ea-9760-7b61a868162e.png">
