### PR TITLE
feat(molecule/autosuggest): add alert state

### DIFF
--- a/components/molecule/autosuggest/README.md
+++ b/components/molecule/autosuggest/README.md
@@ -29,6 +29,7 @@ const suggestions = ['John','Johnny']
   value={'Jo'}
   placeholder="Select an option..."
   iconClear={<IconClose />}
+  state="success"
 >
   {suggestions.map((suggestion, i) => (
     <MoleculeAutosuggestOption key={i} value={suggestion}>

--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -15,9 +15,10 @@ const BASE_CLASS = `sui-MoleculeAutosuggest`
 const CLASS_FOCUS = `${BASE_CLASS}--focus`
 const CLASS_DISABLED = `${BASE_CLASS}--disabled`
 
-const ERROR_STATES = {
+const AUTOSUGGEST_STATES = {
   ERROR: 'error',
-  SUCCESS: 'success'
+  SUCCESS: 'success',
+  ALERT: 'alert'
 }
 
 const getIsTypeableKey = key => {
@@ -43,7 +44,8 @@ const MoleculeAutosuggest = ({multiselection, ...props}) => {
     keysCloseList,
     keysSelection,
     disabled,
-    errorState
+    errorState,
+    state
   } = props
 
   const refMoleculeAutosuggest = useRef(
@@ -66,8 +68,9 @@ const MoleculeAutosuggest = ({multiselection, ...props}) => {
 
   const className = cx(
     BASE_CLASS,
-    errorState && `${BASE_CLASS}--${ERROR_STATES.ERROR}`,
-    errorState === false && `${BASE_CLASS}--${ERROR_STATES.SUCCESS}`,
+    errorState && `${BASE_CLASS}--${AUTOSUGGEST_STATES.ERROR}`,
+    errorState === false && `${BASE_CLASS}--${AUTOSUGGEST_STATES.SUCCESS}`,
+    state && `${BASE_CLASS}--${state}`,
     {
       [CLASS_FOCUS]: focus,
       [CLASS_DISABLED]: disabled
@@ -249,7 +252,10 @@ MoleculeAutosuggest.propTypes = {
   tabIndex: PropTypes.number,
 
   /** true = error, false = success, null = neutral */
-  errorState: PropTypes.bool
+  errorState: PropTypes.bool,
+
+  /* Will set a red/green/orange border if set to 'error' / 'success' / 'alert' */
+  state: PropTypes.oneOf(Object.values(AUTOSUGGEST_STATES))
 }
 
 MoleculeAutosuggest.defaultProps = {
@@ -263,3 +269,4 @@ MoleculeAutosuggest.defaultProps = {
 
 export default withOpenToggle(MoleculeAutosuggest)
 export {SIZES as MoleculeAutosuggestDropdownListSizes}
+export {AUTOSUGGEST_STATES as MoleculeAutosuggestStates}

--- a/demo/molecule/autosuggest/demo/index.js
+++ b/demo/molecule/autosuggest/demo/index.js
@@ -4,7 +4,8 @@ import React from 'react'
 import {withStateValue, withStateValueTags} from '@s-ui/hoc'
 
 import MoleculeAutosuggest, {
-  MoleculeAutosuggestDropdownListSizes
+  MoleculeAutosuggestDropdownListSizes,
+  MoleculeAutosuggestStates
 } from '../../../../components/molecule/autosuggest/src'
 import MoleculeAutosuggestOption from '@s-ui/react-molecule-dropdown-option'
 
@@ -98,6 +99,39 @@ const Demo = () => (
       <MoleculeAutosuggestWithState
         value="Luxembourg"
         onChange={(_, {value}) => console.log(value)}
+      />
+    </div>
+
+    <div className={CLASS_DEMO_SECTION}>
+      <h3>with Success State</h3>
+      <MoleculeAutosuggestWithState
+        placeholder="Type a Country name..."
+        onChange={(_, {value}) => console.log(value)}
+        onEnter={() => console.log('Enter pressed')}
+        state={MoleculeAutosuggestStates.SUCCESS}
+        iconClear={<IconClose />}
+      />
+    </div>
+
+    <div className={CLASS_DEMO_SECTION}>
+      <h3>with Error State</h3>
+      <MoleculeAutosuggestWithState
+        placeholder="Type a Country name..."
+        onChange={(_, {value}) => console.log(value)}
+        onEnter={() => console.log('Enter pressed')}
+        state={MoleculeAutosuggestStates.ERROR}
+        iconClear={<IconClose />}
+      />
+    </div>
+
+    <div className={CLASS_DEMO_SECTION}>
+      <h3>with Alert State</h3>
+      <MoleculeAutosuggestWithState
+        placeholder="Type a Country name..."
+        onChange={(_, {value}) => console.log(value)}
+        onEnter={() => console.log('Enter pressed')}
+        state={MoleculeAutosuggestStates.ALERT}
+        iconClear={<IconClose />}
       />
     </div>
 


### PR DESCRIPTION
Add new states passed by props.

Before:
We only could highlight the input with success or error, green or red. That's because we had a boolean prop (errorState), we couldn't have more than two values.

After:
We can highlight the **autosuggest** in different ways. Now, we need an alert orange border. So we add a string prop (state), which can receive 'success', 'error' or 'alert'. In the future, more states can be added easily. Also, we exported from that component **moleculeAutosuggestState**.

It's backward compatible, so it doesn't need a major.

<img width="846" alt="Captura de pantalla 2020-02-03 a las 12 56 35" src="https://user-images.githubusercontent.com/37936498/73651518-e2a03900-4684-11ea-940c-4e91987a9842.png">
