### PR TITLE
feat(molecule/dropdownList): add key stroke item selection feature

### DIFF
--- a/components/molecule/dropdownList/src/index.js
+++ b/components/molecule/dropdownList/src/index.js
@@ -54,16 +54,28 @@ const MoleculeDropdownList = ({
       current: {children: options}
     } = refDropdownList
     const numOptions = options.length
+    const index = getFocusedOptionIndex(options)
     if (key === 'ArrowDown' || key === 'ArrowUp') {
-      const index = getFocusedOptionIndex(options)
       if (index >= 0 || index <= numOptions) {
         if (key === 'ArrowDown' && index < numOptions - 1)
           options[index + 1].focus()
         if (key === 'ArrowUp' && index > 0) options[index - 1].focus()
       }
-      ev.preventDefault()
-      ev.stopPropagation()
+    } else {
+      const optionToFocusOn =
+        Array.from(options).find(
+          (option, i) =>
+            i > index &&
+            option.innerText.charAt(0).toLowerCase() === key.toLowerCase()
+        ) ||
+        Array.from(options).find(
+          (option, i) =>
+            option.innerText.charAt(0).toLowerCase() === key.toLowerCase()
+        )
+      optionToFocusOn && optionToFocusOn.focus()
     }
+    ev.preventDefault()
+    ev.stopPropagation()
   }
 
   return (


### PR DESCRIPTION
Items on a dropdown list can only be navigated either by arrow up / down or through mouse / trackpad / gesture interaction.

This PR suggests a way to allow navigation through key strokes other than arrow up / down, based on the first character of the `innerText` property of the dropdown list items.

![moleculedropdown](https://user-images.githubusercontent.com/18154356/73893106-088e2f00-4879-11ea-9666-71944b17631c.gif)
