### PR TITLE
feat(atom/card): add hover mediaquery

### DIFF
--- a/components/atom/card/src/index.scss
+++ b/components/atom/card/src/index.scss
@@ -25,9 +25,11 @@ $class-media: '#{$base-class}-media';
     padding: $p-atom-card;
   }
 
-  &:hover {
-    background: $bgc-atom-card-hover;
-    box-shadow: $bxsh-atom-card-hover;
+  @media (hover: hover) {
+    &:hover {
+      background: $bgc-atom-card-hover;
+      box-shadow: $bxsh-atom-card-hover;
+    }
   }
 
   &-media {


### PR DESCRIPTION
Only `hover` styles when device has `hover` available.