### PR TITLE
fix(molecule/selectPopover): add missing cancel handler call on toggle

### DIFF
--- a/components/molecule/selectPopover/src/index.js
+++ b/components/molecule/selectPopover/src/index.js
@@ -64,12 +64,21 @@ function MoleculeSelectPopover({
     }
   }, [handleOnCancel, isOpen])
 
+  const handleOpenToggle = () => {
+    if (isOpen) {
+      setIsOpen(false)
+      handleOnCancel()
+      return
+    }
+    setIsOpen(true)
+  }
+
   return (
     <div className={BASE_CLASS} title={title}>
       <div
         ref={selectRef}
         className={selectClassName}
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={handleOpenToggle}
       >
         <span className={`${BASE_CLASS}-selectText`}>{selectText}</span>
         <div className={`${BASE_CLASS}-selectIcon`}>


### PR DESCRIPTION
## Issue

`handleOnCancel` is currently ran when:
- Closing Popover by clicking "Cancel" button
- Closing Popover by clicking outside of the Popover

`handleOnCancel` is NOT currently ran when:
- Closing Popover by clicking select again

This is causing an undesired behaviour in our project and I think that's not the expected one.