### PR TITLE
fix(atom/checkbox): align icon center

### DIFF
--- a/components/atom/checkbox/src/index.scss
+++ b/components/atom/checkbox/src/index.scss
@@ -24,18 +24,22 @@ $w-atom-checkbox: 24px !default;
 .sui-AtomCheckbox {
   $base: &;
 
+  align-items: center;
   background-color: $bgc-atom-checkbox;
   border-radius: $bdrs-atom-checkbox;
   border: $bd-atom-checkbox;
   cursor: pointer;
   display: inline-flex;
   height: $h-atom-checkbox;
+  justify-content: center;
   text-align: center;
   vertical-align: top;
   width: $w-atom-checkbox;
 
   span {
-    margin: auto;
+    align-items: center;
+    display: flex;
+    justify-content: center;
   }
 
   &.is-checked {


### PR DESCRIPTION
Align the icons of the checkbox to the center of it via flex because the current styles did not center them for Fotocasa.

Before

![image](https://user-images.githubusercontent.com/8220448/74722932-05604f00-523a-11ea-899a-c35ae7132ddf.png)


After

![image](https://user-images.githubusercontent.com/8220448/74722898-fbd6e700-5239-11ea-9dd3-0c5044891ca2.png)
