### PR TITLE
Feature/molecule select popover add open events

### DIFF
--- a/components/molecule/selectPopover/src/index.js
+++ b/components/molecule/selectPopover/src/index.js
@@ -11,6 +11,14 @@ const SIZES = {
   XSMALL: 'xs'
 }
 
+function usePrevious(value) {
+  const ref = useRef()
+  useEffect(() => {
+    ref.current = value
+  }, [value])
+  return ref.current
+}
+
 function MoleculeSelectPopover({
   acceptButtonText,
   cancelButtonText,
@@ -19,11 +27,22 @@ function MoleculeSelectPopover({
   isSelected = false,
   onAccept = () => {},
   onCancel = () => {},
+  onClose = () => {},
+  onOpen = () => {},
   selectText,
   size = 'm',
   title
 }) {
   const [isOpen, setIsOpen] = useState(false)
+  const previousIsOpen = usePrevious(isOpen)
+
+  useEffect(() => {
+    // only run open events when isOpen actually changes (not event methods)
+    if (isOpen === previousIsOpen) return
+
+    const openEvent = isOpen ? onOpen : onClose
+    openEvent()
+  }, [isOpen, onClose, onOpen, previousIsOpen])
 
   const selectRef = useRef()
   const popoverRef = useRef()
@@ -100,6 +119,8 @@ MoleculeSelectPopover.propTypes = {
   isSelected: PropTypes.bool,
   onAccept: PropTypes.func,
   onCancel: PropTypes.func,
+  onClose: PropTypes.func,
+  onOpen: PropTypes.func,
   selectText: PropTypes.string.isRequired,
   size: PropTypes.string,
   title: PropTypes.string

--- a/components/molecule/selectPopover/src/index.js
+++ b/components/molecule/selectPopover/src/index.js
@@ -37,9 +37,14 @@ function MoleculeSelectPopover({
   const previousIsOpen = usePrevious(isOpen)
 
   useEffect(() => {
-    // only run open events when isOpen actually changes (not event methods)
-    if (isOpen === previousIsOpen) return
-
+    /**
+     * Only run open events:
+     *  - After first render
+     *  - When isOpen actually changes
+     **/
+    if (typeof previousIsOpen === 'undefined' || isOpen === previousIsOpen) {
+      return
+    }
     const openEvent = isOpen ? onOpen : onClose
     openEvent()
   }, [isOpen, onClose, onOpen, previousIsOpen])

--- a/demo/molecule/selectPopover/demo/index.js
+++ b/demo/molecule/selectPopover/demo/index.js
@@ -95,6 +95,23 @@ const Demo = () => {
 
       <h3>Size XS</h3>
       {renderSelectPopover(selectPopoverSizes.XSMALL)}
+
+      <h2>Extra events</h2>
+      <h3>onOpen / onClose</h3>
+      <MoleculeSelectPopover
+        acceptButtonText="Accept"
+        cancelButtonText="Cancel"
+        iconArrowDown={IconArrowDown}
+        onClose={() => window.alert('Popover closed!')}
+        onOpen={() => window.alert('Popover open!')}
+        selectText="Click me!"
+        size={selectPopoverSizes.SMALL}
+      >
+        <div className="demo-content">
+          <h3>Demo title</h3>
+          <p>Check the alert!</p>
+        </div>
+      </MoleculeSelectPopover>
     </div>
   )
 }


### PR DESCRIPTION
## 🎯 Why?

We need some events to be aware of popover opening or closing, which is a different concept than 
 onAccept/onCancel events.

## 🤔 How?

I think this is a good chance to make `useEffect` shine a bit, instead of manually tracking down all `isOpen` updates 😄

## ↪️ About usePrevious
📌 https://usehooks.com/usePrevious/