### PR TITLE
fix(molecule/autosuggest): call onBlur only when the user clicks outs…

### DIFF
--- a/components/molecule/autosuggest/src/components/MultipleSelection.js
+++ b/components/molecule/autosuggest/src/components/MultipleSelection.js
@@ -22,7 +22,6 @@ const MoleculeAutosuggestFieldMultiSelection = ({
   onInputKeyDown,
   onChange,
   onChangeTags,
-  onBlur,
   onSelect,
   disabled,
   required,
@@ -78,7 +77,6 @@ const MoleculeAutosuggestFieldMultiSelection = ({
         tagsCloseIcon={iconCloseTag}
         onChangeTags={handleChangeTags}
         onChange={handleChange}
-        onBlur={onBlur}
         isOpen={isOpen}
         isVisibleClear={tags.length}
         iconClear={iconClear}

--- a/components/molecule/autosuggest/src/components/SingleSelection.js
+++ b/components/molecule/autosuggest/src/components/SingleSelection.js
@@ -15,7 +15,6 @@ const MoleculeAutosuggestSingleSelection = ({
   isOpen,
   onToggle,
   onChange,
-  onBlur,
   onClickRightIcon,
   onInputKeyDown,
   onSelect,
@@ -59,7 +58,6 @@ const MoleculeAutosuggestSingleSelection = ({
         isVisibleClear={value}
         onClickClear={handleClear}
         onChange={handleChange}
-        onBlur={onBlur}
         iconClear={!disabled && iconClear}
         rightIcon={rightIcon}
         onClickRightIcon={handleRightClick}

--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -39,6 +39,7 @@ const MoleculeAutosuggest = ({multiselection, ...props}) => {
     children,
     onToggle,
     onChange,
+    onBlur,
     onEnter,
     isOpen,
     keysCloseList,
@@ -129,13 +130,19 @@ const MoleculeAutosuggest = ({multiselection, ...props}) => {
     const {current: domInnerInput} = refMoleculeAutosuggestInput
     const {current: optionsFromRef} = refsMoleculeAutosuggestOptions
     const options = optionsFromRef.map(getTarget)
+
     setTimeout(() => {
       const currentElementFocused = getCurrentElementFocused()
       const focusOutFromOutside = ![domInnerInput, ...options].includes(
         currentElementFocused
       )
       if (focusOutFromOutside) {
-        isOpen ? closeList(ev) : setFocus(false)
+        if (isOpen) {
+          closeList(ev)
+        } else {
+          setFocus(false)
+          onBlur()
+        }
       }
     }, 1)
     setFocus(true)


### PR DESCRIPTION
- Now focus out (or onBlur) is called when only input losses focus. But we need to take into account that the component is more than only an input, there is the dropdown.
- So this PR solves the previous issue. The component will call the focus out (or onBlur) method when the component losses focus (not only the input, also the when the dropdown is closed).