### PR TITLE
perf(atom/button): shave off 12KB of unnecesary CSS

### DIFF
--- a/components/atom/button/src/_deprecated.scss
+++ b/components/atom/button/src/_deprecated.scss
@@ -35,21 +35,23 @@ $bdc-atom-button-accent: $c-accent !default;
 
 // Types and colors
 #{$base-class}--primary {
-  @include button-foreground-color($c-atom-button-primary);
-  @include button-focused {
-    background-color: $bgc-atom-button-primary-focus;
-    border-color: $bdc-atom-button-primary-focus;
-  }
-  background-color: $bgc-atom-button-primary;
+  background: $bgc-atom-button-primary;
   border-color: $bdc-atom-button-primary;
   box-shadow: $bxsh-atom-button-primary;
+  color: $c-atom-button-primary;
+
+  @include button-focused {
+    background: $bgc-atom-button-primary-focus;
+    border-color: $bdc-atom-button-primary-focus;
+  }
 }
 
 #{$base-class}--secondary,
 #{$base-class}--tertiary {
-  @include button-foreground-color($bgc-atom-button-secondary);
+  color: $bgc-atom-button-secondary;
+
   @include button-focused {
-    background-color: $bgc-atom-button-secondary-focus;
+    background: $bgc-atom-button-secondary-focus;
   }
 }
 
@@ -59,31 +61,34 @@ $bdc-atom-button-accent: $c-accent !default;
 
 #{$base-class}--negative {
   &.sui-AtomButton--primary {
-    @include button-foreground-color($c-atom-button-negative-primary);
-    @include button-focused {
-      background-color: $bgc-atom-button-negative-primary-focus;
-      border-color: $bdc-atom-button-negative-primary-focus;
-    }
-    background-color: $bgc-atom-button-negative-primary;
+    background: $bgc-atom-button-negative-primary;
     border-color: $bdc-atom-button-negative-primary;
     box-shadow: $bxsh-atom-button-negative-primary;
+    color: $c-atom-button-negative-primary;
+
+    @include button-focused {
+      background: $bgc-atom-button-negative-primary-focus;
+      border-color: $bdc-atom-button-negative-primary-focus;
+    }
   }
 
   &.sui-AtomButton--secondary,
   &.sui-AtomButton--tertiary {
-    @include button-foreground-color($c-atom-button-negative-secondary);
+    color: $c-atom-button-negative-secondary;
+
     @include button-focused {
-      background-color: $bgc-atom-button-negative-secondary-focus;
+      background: $bgc-atom-button-negative-secondary-focus;
     }
   }
 }
 
 #{$base-class}--accent {
-  @include button-foreground-color($c-atom-button-accent);
+  background: $bgc-atom-button-accent;
+  border-color: $bdc-atom-button-accent;
+  color: $c-atom-button-accent;
+
   @include button-focused {
-    background-color: $bgc-atom-button-accent-focus;
+    background: $bgc-atom-button-accent-focus;
     border-color: $bdc-atom-button-accent-focus;
   }
-  background-color: $bgc-atom-button-accent;
-  border-color: $bdc-atom-button-accent;
 }

--- a/components/atom/button/src/index.scss
+++ b/components/atom/button/src/index.scss
@@ -254,7 +254,6 @@ $icon-stroke-color: currentColor !default;
         $c-atom-button-focused: $color !default;
         $c-atom-button-focused-invert: $color-invert !default;
 
-        background: none;
         border-color: $color;
         color: $color;
 
@@ -264,20 +263,30 @@ $icon-stroke-color: currentColor !default;
             nth($pair, 4),
             $bgc-atom-button-focused
           );
-          color: $c-atom-button-focused;
+
+          @if ($color != $c-atom-button-focused) {
+            color: $c-atom-button-focused;
+          }
         }
 
         &#{$base-class}--negative {
-          background: none;
           border-color: $color-invert;
           color: $color-invert;
+
           @include button-focused {
             background: $bgc-atom-button-focused-invert;
-            color: $c-atom-button-focused-invert;
+            @if ($color-invert != $c-atom-button-focused-invert) {
+              color: $c-atom-button-focused-invert;
+            }
           }
         }
       }
     }
+  }
+
+  &--outline,
+  &--negative {
+    background: none;
   }
 
   &--flat {

--- a/components/atom/button/src/index.scss
+++ b/components/atom/button/src/index.scss
@@ -102,10 +102,6 @@ $tt-atom-button: none !default;
 $icon-fill-color: currentColor !default;
 $icon-stroke-color: currentColor !default;
 
-// Set all color properties for text and icons
-@mixin button-foreground-color($color) {
-  color: $color;
-}
 // Sets active states when button is not disabled
 @mixin button-focused {
   &#{$base-class}--focused,
@@ -221,9 +217,12 @@ $icon-stroke-color: currentColor !default;
 
     &--#{$name}Color {
       &#{$base-class}--solid {
-        @include button-foreground-color($color-invert);
+        background: $color;
+        border-color: $color;
+        color: $color-invert;
+
         @include button-focused {
-          background-color: if(
+          background: if(
             length($pair) > 2,
             nth($pair, 3),
             color-variation($color, -1)
@@ -235,17 +234,16 @@ $icon-stroke-color: currentColor !default;
             color-variation($color, -1)
           );
         }
-        background-color: $color;
-        border-color: $color;
 
         &#{$base-class}--negative {
-          @include button-foreground-color($color);
+          background: $color-invert;
+          border-color: $color-invert;
+          color: $color;
+
           @include button-focused {
-            background-color: color-variation($color, 4);
+            background: color-variation($color, 4);
             border-color: color-variation($color, 4);
           }
-          background-color: $color-invert;
-          border-color: $color-invert;
         }
       }
 
@@ -256,26 +254,27 @@ $icon-stroke-color: currentColor !default;
         $c-atom-button-focused: $color !default;
         $c-atom-button-focused-invert: $color-invert !default;
 
-        @include button-foreground-color($color);
+        background: none;
+        border-color: $color;
+        color: $color;
+
         @include button-focused {
-          background-color: if(
+          background: if(
             length($pair) > 2,
             nth($pair, 4),
             $bgc-atom-button-focused
           );
           color: $c-atom-button-focused;
         }
-        background: none;
-        border-color: $color;
 
         &#{$base-class}--negative {
-          @include button-foreground-color($color-invert);
+          background: none;
+          border-color: $color-invert;
+          color: $color-invert;
           @include button-focused {
-            background-color: $bgc-atom-button-focused-invert;
+            background: $bgc-atom-button-focused-invert;
             color: $c-atom-button-focused-invert;
           }
-          background-color: none;
-          border-color: $color-invert;
         }
       }
     }

--- a/components/atom/button/src/index.scss
+++ b/components/atom/button/src/index.scss
@@ -223,7 +223,6 @@ $icon-stroke-color: currentColor !default;
       &#{$base-class}--solid {
         @include button-foreground-color($color-invert);
         @include button-focused {
-          background-color: color-variation($color, -1);
           background-color: if(
             length($pair) > 2,
             nth($pair, 3),
@@ -259,7 +258,6 @@ $icon-stroke-color: currentColor !default;
 
         @include button-foreground-color($color);
         @include button-focused {
-          background-color: $bgc-atom-button-focused;
           background-color: if(
             length($pair) > 2,
             nth($pair, 4),

--- a/components/atom/button/src/index.scss
+++ b/components/atom/button/src/index.scss
@@ -108,18 +108,17 @@ $icon-stroke-color: currentColor !default;
 }
 // Sets active states when button is not disabled
 @mixin button-focused {
-  &:not(#{$base-class}--disabled) {
-    &#{$base-class}--focused,
-    &:active {
+  &#{$base-class}--focused,
+  &:active {
+    @content;
+  }
+  @media (hover: hover) {
+    &:hover {
       @content;
-    }
-    @media (hover: hover) {
-      &:hover {
-        @content;
-      }
     }
   }
 }
+
 @mixin button-icon($size, $margin) {
   & #{$base-class}-leftIcon,
   & #{$base-class}-rightIcon {


### PR DESCRIPTION
When the button is disabled, pointer events are ignored anyway so no `hover` could be performed and can't be disabled anyway.

Before:
![image](https://user-images.githubusercontent.com/1561955/74943185-9c710680-53f4-11ea-8446-2094d8f945e0.png)

After removing `:not` clause:
![image](https://user-images.githubusercontent.com/1561955/74943366-a72b9b80-53f4-11ea-87d5-fd96374ab480.png)

Also we were adding `background-color` repeated without need so we can cut a few more bytes (2KB).

After removing repeated `background-color`:
![image](https://user-images.githubusercontent.com/1561955/74965784-1e255c00-5416-11ea-8e90-30edfe6174e1.png)

Also, as we don't expect to change the background other than the color, we could swap the `background-color` for `background`and cut almost 1KB more.
![image](https://user-images.githubusercontent.com/1561955/74966485-62fdc280-5417-11ea-809e-308f2ba2d734.png)

After extracting fix value for `background` as `transparent` on `outline` and `negative` buttons, 400 bytes less:
![image](https://user-images.githubusercontent.com/1561955/74967402-3054c980-5419-11ea-95c3-ad1eca38b5d3.png)

If we avoid writing same `color`property when value is not changing: 1.2KB less:
![image](https://user-images.githubusercontent.com/1561955/74967482-58dcc380-5419-11ea-98ce-1be1768ecee5.png)

Also removed `@include button-foreground-color` that was adding noise (only was used for adding the `color` property.

Demo: https://sui-components-git-perf-avoid-bloated-css.schibstedspain.now.sh/workbench/atom/button/demo
