### PR TITLE
perf(molecule/notification): remove not needed repeated css properties

### DIFF
--- a/components/molecule/notification/src/index.scss
+++ b/components/molecule/notification/src/index.scss
@@ -27,6 +27,7 @@ $base-class: '.sui-MoleculeNotification';
 
   &-icon {
     svg {
+      fill: currentColor !important;
       height: $sz-notification-icon;
       width: $sz-notification-icon;
     }
@@ -55,10 +56,6 @@ $base-class: '.sui-MoleculeNotification';
     &--#{$key} {
       background-color: #{$value};
       color: $color;
-
-      svg {
-        fill: $color !important;
-      }
     }
   }
 
@@ -73,17 +70,10 @@ $base-class: '.sui-MoleculeNotification';
       }
     }
 
-    // Type text in positive variations
-    @each $key, $value in $notification-type-positive-icon-colors {
-      &#{$base-class}--#{$key} #{$base-class}-icon svg {
-        fill: $value !important;
-      }
-    }
-
     // Type variations
     @each $key, $value in $notification-type-colors {
       &#{$base-class}--#{$key} {
-        background-color: color-variation($value, $c-light-step * 2);
+        background: color-variation($value, $c-light-step * 2);
       }
     }
   }


### PR DESCRIPTION
Avoid unnecesary css as icons are always same color as text by using `currentColor` we achieve the same effect.