### PR TITLE
Feature/atom checkbox add native style option

### DIFF
--- a/components/atom/checkbox/src/index.js
+++ b/components/atom/checkbox/src/index.js
@@ -79,7 +79,7 @@ AtomCheckbox.propTypes = {
   checked: PropTypes.bool,
 
   /* AtomIcon when checkbox is checked */
-  checkedIcon: PropTypes.elementType.isRequired,
+  checkedIcon: PropTypes.elementType,
 
   /* Mark the input as intermediate */
   intermediate: PropTypes.bool,

--- a/components/atom/checkbox/src/index.js
+++ b/components/atom/checkbox/src/index.js
@@ -1,41 +1,61 @@
-import React from 'react'
+import React, {useRef} from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
 const BASE_CLASS = 'sui-AtomCheckbox'
 
 const AtomCheckbox = ({
-  id,
-  name,
-  disabled,
   checked = false,
-  intermediate = false,
   checkedIcon: CheckedIcon,
+  disabled,
+  id,
+  intermediate = false,
   intermediateIcon: IntermediateIcon,
+  isNative: isNativeProp = false,
+  name,
   onChange: onChangeFromProps = () => {},
   ...props
 }) => {
+  const inputRef = useRef()
+  const hasNotCustomIcons = !CheckedIcon && !IntermediateIcon
+  const isNative = isNativeProp || hasNotCustomIcons
+  const isIntermediate = intermediate && !checked
+
+  const updateNativeIndeterminate = () => {
+    inputRef.current && (inputRef.current.indeterminate = isIntermediate)
+  }
+
   const handleChange = ev => {
+    // Handler doesn't necessarily trigger render, but browser could still set
+    // native indeterminate property which may end up in a mismatch between it
+    // and the component's prop, so native value should be kept updated here.
+    updateNativeIndeterminate()
+
     const {checked, name} = ev.target
     if (!disabled) onChangeFromProps(ev, {name, value: checked})
   }
 
   const className = cx(BASE_CLASS, {
     'is-checked': checked,
-    'is-disabled': disabled
+    'is-disabled': disabled,
+    [`${BASE_CLASS}--native`]: isNative
   })
+
+  // Keep native indeterminate property updated every render
+  updateNativeIndeterminate()
 
   return (
     <label className={className}>
-      {checked && <CheckedIcon />}
-      {intermediate && !checked && <IntermediateIcon />}
+      {!isNative && checked && <CheckedIcon />}
+      {!isNative && isIntermediate && <IntermediateIcon />}
       <input
+        ref={inputRef}
         type="checkbox"
         id={id}
         name={name || id}
         disabled={disabled}
         checked={checked}
-        intermediate={intermediate ? 'intermediate' : ''}
+        intermediate={isIntermediate ? 'intermediate' : ''}
         onChange={handleChange}
         {...props}
       />
@@ -49,7 +69,7 @@ AtomCheckbox.propTypes = {
   /* The DOM id global attribute. */
   id: PropTypes.string.isRequired,
 
-  /* name attribute for the input */
+  /* Name attribute for the input */
   name: PropTypes.string,
 
   /* This Boolean attribute prevents the user from interacting with the input */
@@ -66,6 +86,9 @@ AtomCheckbox.propTypes = {
 
   /* AtomIcon when checkbox is intermediate */
   intermediateIcon: PropTypes.elementType,
+
+  /* Uses browser's native look and feel instead of custom icons */
+  isNative: PropTypes.bool,
 
   /* onChange callback */
   onChange: PropTypes.func.isRequired

--- a/components/atom/checkbox/src/index.scss
+++ b/components/atom/checkbox/src/index.scss
@@ -22,28 +22,37 @@ $h-atom-checkbox: 24px !default;
 $w-atom-checkbox: 24px !default;
 
 .sui-AtomCheckbox {
-  $base: &;
-
-  align-items: center;
-  background-color: $bgc-atom-checkbox;
-  border-radius: $bdrs-atom-checkbox;
-  border: $bd-atom-checkbox;
-  cursor: pointer;
-  display: inline-flex;
-  height: $h-atom-checkbox;
-  justify-content: center;
-  text-align: center;
-  vertical-align: top;
-  width: $w-atom-checkbox;
-
-  span {
+  &:not(&--native) {
     align-items: center;
-    display: flex;
+    background-color: $bgc-atom-checkbox;
+    border-radius: $bdrs-atom-checkbox;
+    border: $bd-atom-checkbox;
+    cursor: pointer;
+    display: inline-flex;
+    height: $h-atom-checkbox;
     justify-content: center;
+    text-align: center;
+    vertical-align: top;
+    width: $w-atom-checkbox;
+
+    span {
+      /* Center custom icons */
+      align-items: center;
+      display: flex;
+      justify-content: center;
+    }
+
+    &.is-checked {
+      background-color: $bgc-checked-atom-checkbox;
+    }
+
+    &.is-disabled {
+      background-color: $bgc-checked-atom-checkbox-is-disabled;
+      border-color: $bdc-atom-checkbox-is-disabled;
+    }
   }
 
   &.is-checked {
-    background-color: $bgc-checked-atom-checkbox;
     color: $c-atom-checkbox;
   }
 
@@ -51,9 +60,13 @@ $w-atom-checkbox: 24px !default;
     display: none;
   }
 
+  &--native {
+    input[type='checkbox'] {
+      display: inline;
+    }
+  }
+
   &.is-disabled {
-    background-color: $bgc-checked-atom-checkbox-is-disabled;
-    border-color: $bdc-atom-checkbox-is-disabled;
     color: $c-atom-checkbox-is-disabled;
   }
 }

--- a/demo/atom/checkbox/demo/index.js
+++ b/demo/atom/checkbox/demo/index.js
@@ -2,11 +2,14 @@
 import React, {useState} from 'react'
 import AtomIcon from '../../../../components/atom/icon/src'
 import AtomCheckbox from '../../../../components/atom/checkbox/src'
+import AtomSwitch from '../../../../components/atom/switch/src'
 
 import './index.scss'
 
 const BASE_CLASS_DEMO = `DemoAtomCheckbox`
 const CLASS_SECTION = `${BASE_CLASS_DEMO}-section`
+
+const noop = () => {}
 
 const IconCheck = props => (
   <AtomIcon {...props}>
@@ -29,14 +32,22 @@ const IconHalfCheck = props => (
 
 const Demo = () => {
   const [checkboxValue, setCheckboxValue] = useState(true)
+  const [isNative, setIsNative] = useState(false)
 
   return (
     <div className={BASE_CLASS_DEMO}>
+      <AtomSwitch
+        label="Choose Design"
+        labelLeft="Custom"
+        labelRight="Native"
+        onToggle={setIsNative}
+      />
       <h1>AtomCheckbox</h1>
       <h2>Use Cases</h2>
       <div className={CLASS_SECTION}>
         <h3>Checked with onChange method</h3>
         <AtomCheckbox
+          isNative={isNative}
           id="checkbox1"
           checked={checkboxValue}
           checkedIcon={IconCheck}
@@ -46,30 +57,52 @@ const Demo = () => {
       <div className={CLASS_SECTION}>
         <h3>Intermediate</h3>
         <AtomCheckbox
+          isNative={isNative}
           id="checkbox2"
           checkedIcon={IconCheck}
           intermediate
           intermediateIcon={IconHalfCheck}
+          onChange={noop}
         />
       </div>
       <div className={CLASS_SECTION}>
         <h3>Unchecked</h3>
-        <AtomCheckbox id="checkbox3" checkedIcon={IconCheck} />
+        <AtomCheckbox
+          isNative={isNative}
+          id="checkbox3"
+          checkedIcon={IconCheck}
+          onChange={noop}
+        />
       </div>
 
       <h2>Disabled</h2>
       <h3>Checked</h3>
-      <AtomCheckbox id="checkbox4" disabled checked checkedIcon={IconCheck} />
+      <AtomCheckbox
+        isNative={isNative}
+        id="checkbox4"
+        disabled
+        checked
+        checkedIcon={IconCheck}
+        onChange={noop}
+      />
       <h3>Intermediate</h3>
       <AtomCheckbox
+        isNative={isNative}
         id="checkbox5"
         disabled
         intermediate
         checkedIcon={IconCheck}
         intermediateIcon={IconHalfCheck}
+        onChange={noop}
       />
       <h3>Unchecked</h3>
-      <AtomCheckbox id="checkbox5" disabled checkedIcon={IconCheck} />
+      <AtomCheckbox
+        isNative={isNative}
+        id="checkbox5"
+        disabled
+        checkedIcon={IconCheck}
+        onChange={noop}
+      />
     </div>
   )
 }

--- a/demo/atom/checkbox/demo/index.scss
+++ b/demo/atom/checkbox/demo/index.scss
@@ -1,4 +1,5 @@
 @import '../../../../components/atom/icon/src/index.scss';
+@import '../../../../components/atom/switch/src/index.scss';
 
 .DemoAtomCheckbox {
   padding: 20px;


### PR DESCRIPTION
## Add native style option

Adds the ability to go with the browser's native checkbox which was lost when we got to v2 major. This way we can update major version of this dependency on other components while still keeping the original behaviour/style. Also, it's a reasonable feature IMHO.

There are two ways of getting the native checkbox:
- Setting the new `isNative` prop to `true`
- Not setting any of the custom icon props (required for custom checkbox)

![Screen-Recording-2020-02-21-at-1](https://user-images.githubusercontent.com/4168389/75037461-80cd3500-54b4-11ea-89de-24beed55a2af.gif)
