### PR TITLE
feat(molecule/dropdownOption): update dependency major atom checkbox

### DIFF
--- a/components/molecule/dropdownOption/package.json
+++ b/components/molecule/dropdownOption/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@s-ui/component-dependencies": "1",
-    "@s-ui/react-atom-checkbox": "1"
+    "@s-ui/react-atom-checkbox": "2"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
`molecule/dropdownOption` uses native checkboxes which were only available in `atom/checkbox` v1 major.

Thanks to #998 native checkboxes are finally available in v2 as well, so maintaining both `atom/checkbox` v1 and v2 major dependencies in different packages is no longer needed.