### PR TITLE
feat(molecule/breadcrumb): breadcrumb collapsible

### DIFF
--- a/components/molecule/breadcrumb/src/index.js
+++ b/components/molecule/breadcrumb/src/index.js
@@ -73,7 +73,7 @@ BreadcrumbBasic.propTypes = {
    */
   icon: PropTypes.func,
   /**
-   * Function for creating links so it allow to customize it
+   * Function for creating links so it allows to customize it
    */
   linkFactory: PropTypes.func,
   /**

--- a/components/molecule/breadcrumb/src/index.js
+++ b/components/molecule/breadcrumb/src/index.js
@@ -5,12 +5,18 @@ import React, {useState} from 'react'
 import Chevronright from '@s-ui/react-icons/lib/Chevronright'
 import cx from 'classnames'
 
-const breadcrumbClassName = isExpanded =>
+const breadcrumbClassName = ({isExpanded, isScrollable}) =>
   cx('sui-BreadcrumbBasic', {
-    'is-expanded': isExpanded
+    'is-expanded': isExpanded,
+    'is-scrollable': isScrollable
   })
 
-export default function BreadcrumbBasic({items, icon, linkFactory: Link}) {
+export default function BreadcrumbBasic({
+  items,
+  icon,
+  linkFactory: Link,
+  isScrollable = false
+}) {
   const [isExpanded, setIsExpanded] = useState(false)
   const expandBreadcrumb = () => setIsExpanded(true)
 
@@ -19,7 +25,7 @@ export default function BreadcrumbBasic({items, icon, linkFactory: Link}) {
 
   return (
     <nav aria-label="breadcrumb" role="navigation">
-      <div className={breadcrumbClassName(isExpanded)}>
+      <div className={breadcrumbClassName({isExpanded, isScrollable})}>
         <button onClick={expandBreadcrumb} className="sui-BreadcrumbBasic-btn">
           ...
         </button>
@@ -69,7 +75,11 @@ BreadcrumbBasic.propTypes = {
   /**
    * Function for creating links so it allow to customize it
    */
-  linkFactory: PropTypes.func
+  linkFactory: PropTypes.func,
+  /**
+   * Boolean that allows us to show the items with a horizontal scroll
+   */
+  isScrollable: PropTypes.bool
 }
 
 BreadcrumbBasic.defaultProps = {

--- a/components/molecule/breadcrumb/src/index.scss
+++ b/components/molecule/breadcrumb/src/index.scss
@@ -20,7 +20,8 @@
     color: $c-breadcrumb-link;
     margin-right: $m-breadcrumb-items;
 
-    .is-expanded & {
+    .is-expanded &,
+    .is-scrollable & {
       display: none;
     }
   }
@@ -29,6 +30,12 @@
     @include reset-list;
     display: flex;
     flex-wrap: wrap;
+
+    .is-scrollable & {
+      flex-wrap: nowrap;
+      overflow-x: auto;
+      white-space: nowrap;
+    }
 
     &Item {
       align-items: center;
@@ -47,7 +54,8 @@
         }
       }
 
-      .is-expanded & {
+      .is-expanded &,
+      .is-scrollable & {
         display: inline-flex;
       }
     }

--- a/demo/molecule/breadcrumb/playground
+++ b/demo/molecule/breadcrumb/playground
@@ -26,4 +26,12 @@ const breadcrumbItems = [
   }
 ]
 
-return (<BreadcrumbBasic icon={ArrowRight} items={breadcrumbItems} />)
+return (
+  <div style={{padding: '20px'}}>
+    <h1>Breadcrumb</h1>
+    <h2>Breadcrumb basic</h2>
+    <BreadcrumbBasic icon={ArrowRight} items={breadcrumbItems} />
+    <h2>Breadcrum basic scrollable</h2>
+    <BreadcrumbBasic icon={ArrowRight} items={breadcrumbItems} isScrollable />
+  </div>
+)


### PR DESCRIPTION
### Context
Due to a need for SEO, we need to be able to keep the breadcrumbs always visible. Currently, it only shows the last of the items, and when we want to show all of them, the current behavior causes the breadcrumb to expand vertically, behavior not desired by UX.

### Goal
Add the isScrollable functionality, which gives us the ability to keep the breadcrumb items always visible (SEO) and avoid line jumping through a horizontal scroll (UX validated)

###  related to https://jira.scmspain.com/browse/SUIC-384

![Kapture 2020-02-24 at 18 48 30](https://user-images.githubusercontent.com/31726966/75178505-820e9400-5738-11ea-8d51-4007c5a7e935.gif)