### PR TITLE
perf(atom/badge): write less css for atom-badge

### DIFF
--- a/components/atom/badge/src/index.scss
+++ b/components/atom/badge/src/index.scss
@@ -36,6 +36,7 @@ $badges: (
 
 .sui-AtomBadge {
   align-items: center;
+  background: transparent;
   border-radius: $bdrs-atom-badge;
   box-sizing: border-box;
   color: $c-atom-badge;
@@ -50,32 +51,23 @@ $badges: (
 
   &-small {
     font-size: $fz-atom-badge-s;
+    line-height: $h-atom-badge-s;
     height: $h-atom-badge-s;
     padding: $p-atom-badge;
-
-    .sui-AtomBadge-text {
-      line-height: $h-atom-badge-s;
-    }
   }
 
   &-medium {
     font-size: $fz-atom-badge-m;
+    line-height: $h-atom-badge-s;
     height: $h-atom-badge-s;
     padding: $p-atom-badge;
-
-    .sui-AtomBadge-text {
-      line-height: $h-atom-badge-s;
-    }
   }
 
   &-large {
     font-size: $fz-atom-badge-l;
+    line-height: $h-atom-badge-l;
     height: $h-atom-badge-l;
     padding: $p-atom-badge;
-
-    .sui-AtomBadge-text {
-      line-height: $h-atom-badge-l;
-    }
   }
 
   &-icon {
@@ -86,6 +78,10 @@ $badges: (
     &--iconRight {
       margin-left: $m-atom-badge-s;
     }
+  }
+
+  &[class$='--transparent'] {
+    padding: 0;
   }
 
   @each $type, $element in $badges {
@@ -100,9 +96,7 @@ $badges: (
     }
 
     &-#{$type}--transparent {
-      background: transparent;
       color: $bgc;
-      padding: 0;
     }
   }
 }

--- a/components/atom/badge/src/index.scss
+++ b/components/atom/badge/src/index.scss
@@ -1,6 +1,7 @@
 @import '~@schibstedspain/sui-theme/lib/index';
 
 $bdrs-atom-badge: $bdrs-m !default;
+$c-atom-badge: $c-white !default;
 $fz-atom-badge-l: $fz-m !default;
 $fz-atom-badge-m: $fz-s !default;
 $fz-atom-badge-s: $fz-xs !default;
@@ -37,6 +38,8 @@ $badges: (
   align-items: center;
   border-radius: $bdrs-atom-badge;
   box-sizing: border-box;
+  color: $c-atom-badge;
+  fill: currentColor;
   display: inline-flex;
   justify-content: center;
   white-space: nowrap;
@@ -90,15 +93,15 @@ $badges: (
     $c: map-get($element, c);
 
     &-#{$type} {
-      background-color: $bgc;
-      color: $c;
-      fill: $c;
+      background: $bgc;
+      @if ($c != $c-atom-badge) {
+        color: $c;
+      }
     }
 
     &-#{$type}--transparent {
-      background-color: transparent;
+      background: transparent;
       color: $bgc;
-      fill: $bgc;
       padding: 0;
     }
   }

--- a/components/atom/badge/src/index.scss
+++ b/components/atom/badge/src/index.scss
@@ -72,6 +72,7 @@ $badges: (
 
   &-icon {
     @include sui-icon--small;
+    line-height: initial;
     margin-right: $m-atom-badge-s;
     vertical-align: middle;
 


### PR DESCRIPTION
Produce less CSS for atom/badge by:

- Using fill as currentColor instead filling over each color.
- Use a default color for badge (usually is white) and don't overwrite the color if not needed for each color.
- Use background shorthand and `transparent` as default to avoid putting on loop.
- Use line-height to be inherit on text and rewrite only on icon.
- Avoid using padding: 0 for each type of color and put it only once.

![image](https://user-images.githubusercontent.com/1561955/75296351-37227880-582d-11ea-9414-6487120399c1.png)