### PR TITLE
feat(molecule/photoUploader): fix rejected files callback

### DIFF
--- a/components/molecule/photoUploader/src/config.js
+++ b/components/molecule/photoUploader/src/config.js
@@ -33,3 +33,10 @@ export const ROTATION_DIRECTION = {
   clockwise: 'clockwise',
   counterclockwise: 'counterclockwise'
 }
+
+export const REJECT_FILES_REASONS = {
+  repeated: 'File already loaded.',
+  fileType: 'Not accepted file type.',
+  maxSize: 'Exceding max size of : ',
+  loadFailed: 'Load failed, corrupt file.'
+}

--- a/components/molecule/photoUploader/src/fileTools.js
+++ b/components/molecule/photoUploader/src/fileTools.js
@@ -10,7 +10,7 @@ export const filterValidFiles = ({
   files,
   filesToBeFiltered,
   acceptedFileMaxSize,
-  callbackPhotosRejected,
+  handlePhotosRejected,
   setMaxSizeError,
   setMaxPhotosError,
   allowUploadDuplicatedPhotos,
@@ -63,7 +63,7 @@ export const filterValidFiles = ({
 
   if (excedingMaxSizeFiles.length) {
     setMaxSizeError()
-    callbackPhotosRejected(excedingMaxSizeFiles)
+    handlePhotosRejected(excedingMaxSizeFiles)
   }
 
   if (allowUploadDuplicatedPhotos) {
@@ -73,7 +73,7 @@ export const filterValidFiles = ({
   }
 
   if (repeatedFiles.length) {
-    callbackPhotosRejected(repeatedFiles)
+    handlePhotosRejected(repeatedFiles)
   }
 
   if (!notRepeatedFiles.length) return notRepeatedFiles
@@ -90,7 +90,7 @@ export const filterValidFiles = ({
 }
 
 export const prepareFiles = ({
-  callbackPhotosRejected,
+  handlePhotosRejected,
   currentFiles,
   newFiles,
   defaultFormatToBase64Options,
@@ -122,7 +122,7 @@ export const prepareFiles = ({
               '%{filepath}',
               nextFile.path
             )
-            callbackPhotosRejected([
+            handlePhotosRejected([
               {
                 rejectedFile: nextFile,
                 reason: REJECT_FILES_REASONS.loadFailed

--- a/components/molecule/photoUploader/src/fileTools.js
+++ b/components/molecule/photoUploader/src/fileTools.js
@@ -2,35 +2,46 @@ import {formatToBase64} from './photoTools'
 
 import {
   DEFAULT_HAS_ERRORS_STATUS,
-  DEFAULT_IMAGE_ROTATION_DEGREES
+  DEFAULT_IMAGE_ROTATION_DEGREES,
+  REJECT_FILES_REASONS
 } from './config'
 
 export const filterValidFiles = ({
   files,
   filesToBeFiltered,
   acceptedFileMaxSize,
+  callbackPhotosRejected,
   setMaxSizeError,
   setMaxPhotosError,
   allowUploadDuplicatedPhotos,
   maxPhotos
 }) => {
+  const notExcedingMaxSizeFiles = []
+  const excedingMaxSizeFiles = []
+
   const notExcedingMaxSizeFilesFilter = filesToFilter =>
-    filesToFilter.filter(fileToFilter => {
+    filesToFilter.map(fileToFilter => {
       if (fileToFilter.size >= acceptedFileMaxSize) {
-        setMaxSizeError()
-        return false
+        excedingMaxSizeFiles.push({
+          rejectedFile: fileToFilter,
+          reason: `${REJECT_FILES_REASONS.maxSize}${acceptedFileMaxSize}`
+        })
+      } else {
+        notExcedingMaxSizeFiles.push(fileToFilter)
       }
-      return true
     })
 
+  const notRepeatedFiles = []
+  const repeatedFiles = []
+
   const notRepeatedFilesFilter = filesToFilter =>
-    filesToFilter.filter(fileToFilter => {
+    filesToFilter.map(fileToFilter => {
       const {
         path: newFilePath,
         size: newFileSize,
         lastModified: newFileLastModified
       } = fileToFilter
-      return !files.some(file => {
+      const isFileAlready = files.some(file => {
         const {path, size, lastModified} = file.properties
         return (
           path === newFilePath &&
@@ -38,17 +49,31 @@ export const filterValidFiles = ({
           lastModified === newFileLastModified
         )
       })
+      if (isFileAlready) {
+        repeatedFiles.push({
+          rejectedFile: fileToFilter,
+          reason: REJECT_FILES_REASONS.repeated
+        })
+      } else {
+        notRepeatedFiles.push(fileToFilter)
+      }
     })
 
-  const notExcedingMaxSizeFiles = notExcedingMaxSizeFilesFilter(
-    filesToBeFiltered
-  )
+  notExcedingMaxSizeFilesFilter(filesToBeFiltered)
 
-  let notRepeatedFiles
+  if (excedingMaxSizeFiles.length) {
+    setMaxSizeError()
+    callbackPhotosRejected(excedingMaxSizeFiles)
+  }
+
   if (allowUploadDuplicatedPhotos) {
-    notRepeatedFiles = notExcedingMaxSizeFiles
+    notRepeatedFiles.push(...notExcedingMaxSizeFiles)
   } else {
-    notRepeatedFiles = notRepeatedFilesFilter(notExcedingMaxSizeFiles)
+    notRepeatedFilesFilter(notExcedingMaxSizeFiles)
+  }
+
+  if (repeatedFiles.length) {
+    callbackPhotosRejected(repeatedFiles)
   }
 
   if (!notRepeatedFiles.length) return notRepeatedFiles
@@ -65,6 +90,7 @@ export const filterValidFiles = ({
 }
 
 export const prepareFiles = ({
+  callbackPhotosRejected,
   currentFiles,
   newFiles,
   defaultFormatToBase64Options,
@@ -96,6 +122,12 @@ export const prepareFiles = ({
               '%{filepath}',
               nextFile.path
             )
+            callbackPhotosRejected([
+              {
+                rejectedFile: nextFile,
+                reason: REJECT_FILES_REASONS.loadFailed
+              }
+            ])
             setCorruptedFileError(errorText)
           } else {
             currentFiles.push({

--- a/components/molecule/photoUploader/src/index.js
+++ b/components/molecule/photoUploader/src/index.js
@@ -146,7 +146,7 @@ const MoleculePhotoUploader = ({
       files,
       filesToBeFiltered: acceptedFiles,
       acceptedFileMaxSize,
-      callbackPhotosRejected,
+      handlePhotosRejected: callbackPhotosRejected,
       setMaxSizeError: () => {
         setNotificationError({
           isError: true,
@@ -170,7 +170,7 @@ const MoleculePhotoUploader = ({
     }
 
     prepareFiles({
-      callbackPhotosRejected,
+      handlePhotosRejected: callbackPhotosRejected,
       currentFiles: [...files],
       newFiles: validFiles,
       defaultFormatToBase64Options: DEFAULT_FORMAT_TO_BASE_64_OPTIONS,

--- a/components/molecule/photoUploader/src/index.js
+++ b/components/molecule/photoUploader/src/index.js
@@ -28,7 +28,8 @@ import {
   DEFAULT_MAX_FILE_SIZE_ACCEPTED,
   DEFAULT_NOTIFICATION_ERROR,
   DRAG_STATE_STATUS_REJECTED,
-  ROTATION_DIRECTION
+  ROTATION_DIRECTION,
+  REJECT_FILES_REASONS
 } from './config'
 
 const MoleculePhotoUploader = ({
@@ -119,7 +120,11 @@ const MoleculePhotoUploader = ({
       text: notificationErrorFormatPhotoUploaded
     })
     _scrollToBottom()
-    callbackPhotosRejected(rejectedFiles)
+    const rejectedFilesWithReason = rejectedFiles.map(rejectedFile => ({
+      rejectedFile,
+      reason: REJECT_FILES_REASONS.fileType
+    }))
+    callbackPhotosRejected(rejectedFilesWithReason)
   }
 
   const _onDropAccepted = acceptedFiles => {
@@ -141,6 +146,7 @@ const MoleculePhotoUploader = ({
       files,
       filesToBeFiltered: acceptedFiles,
       acceptedFileMaxSize,
+      callbackPhotosRejected,
       setMaxSizeError: () => {
         setNotificationError({
           isError: true,
@@ -164,6 +170,7 @@ const MoleculePhotoUploader = ({
     }
 
     prepareFiles({
+      callbackPhotosRejected,
       currentFiles: [...files],
       newFiles: validFiles,
       defaultFormatToBase64Options: DEFAULT_FORMAT_TO_BASE_64_OPTIONS,


### PR DESCRIPTION
Improve rejected file callback

Before: only executing when a not accepted file is dropped.

Now: executed in four cases
- when a not accepted file is dropped.
- dropped file exceeds the maximum size.
- dropped file is repeated.
- added file fails when loading.
Also, a reason string will be sent in the callback with the file.

This callback will be useful to track user's behavior.

