### PR TITLE
feat(atom/spinner): add position fixed for spinner full page

### DIFF
--- a/components/atom/spinner/src/index.scss
+++ b/components/atom/spinner/src/index.scss
@@ -34,6 +34,7 @@ $z-atom-spinner: 1 !default;
 
     .sui-AtomSpinner-loader {
       display: block;
+      position: fixed;
     }
   }
 


### PR DESCRIPTION
Spinner must be centered on the screen when we use it as a full-page