### PR TITLE
feat(molecule/tabs): fix molecule tabs scroller alignement when hight…

### DIFF
--- a/components/molecule/tabs/src/index.scss
+++ b/components/molecule/tabs/src/index.scss
@@ -98,6 +98,7 @@ $p-sui-molecule-tabs-item: $p-m $p-l !default;
     .sui-MoleculeTabs-item {
       border: 0 none transparent;
       border-bottom: $bdw-sui-molecule-tabs solid transparent;
+      text-align: center;
 
       &.is-active {
         border-bottom-color: $c-primary;


### PR DESCRIPTION
Fix MoleculeTabs component UI
 - When Molecule tabs receive both props: (HIGHLIGHTED, FULLWIDTH) the tab is displayed without centering its content.

**before**
![imagen](https://user-images.githubusercontent.com/17271365/75872233-17331c00-5e0e-11ea-97cf-1996414f093e.png)

**after**
![imagen](https://user-images.githubusercontent.com/17271365/75872287-2ade8280-5e0e-11ea-98cc-31079017b373.png)

