### PR TITLE
fix(molecule/breadcrumb): make molecule/breadrumb latest change non-breaking

### DIFF
--- a/components/molecule/breadcrumb/src/index.js
+++ b/components/molecule/breadcrumb/src/index.js
@@ -36,7 +36,7 @@ export default function BreadcrumbBasic({
                 <IconAngle svgClass="sui-BreadcrumbBasic-icon" />
               )}
               {url ? (
-                <Link to={url} className="sui-BreadcrumbBasic-link">
+                <Link to={url} href={url} className="sui-BreadcrumbBasic-link">
                   {label}
                 </Link>
               ) : (
@@ -83,8 +83,8 @@ BreadcrumbBasic.propTypes = {
 }
 
 BreadcrumbBasic.defaultProps = {
-  linkFactory: ({to, className, children}) => (
-    <a href={to} className={className}>
+  linkFactory: ({to, href, className, children}) => (
+    <a href={to || href} className={className}>
       {children}
     </a>
   )


### PR DESCRIPTION
Replacing the `href` prop on the Link component with the `to` prop is a breaking change with custom `linkFactory` components we're currently using. We're re-introducing the `href` prop. Removing that prop should involve a major release of this component.  