### PR TITLE
feat(molecule/dropdownOption): use highlighter from sui-js

### DIFF
--- a/components/molecule/dropdownOption/package.json
+++ b/components/molecule/dropdownOption/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@s-ui/component-dependencies": "1",
+    "@s-ui/js": "2",
     "@s-ui/react-atom-checkbox": "2"
   },
   "keywords": [],

--- a/components/molecule/dropdownOption/package.json
+++ b/components/molecule/dropdownOption/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/react-molecule-dropdown-option",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/components/molecule/dropdownOption/src/index.js
+++ b/components/molecule/dropdownOption/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
+import {highlightText} from '@s-ui/js/lib/string'
 import AtomCheckbox from '@s-ui/react-atom-checkbox'
 
 import handlersFactory from './handlersFactory'
@@ -54,11 +55,17 @@ const MoleculeDropdownOption = ({
         </span>
       )
     }
-    const regExpHighlight = new RegExp(highlightQuery, 'gi')
-    const mark = option.replace(
-      regExpHighlight,
-      `<mark class="${cx(CLASS_HIGHLIGHTED_MARK, CLASS_HIGHLIGHTED)}">$&</mark>`
-    )
+
+    const mark = highlightText({
+      value: option,
+      query: highlightQuery,
+      startTag: `<mark class="${cx(
+        CLASS_HIGHLIGHTED_MARK,
+        CLASS_HIGHLIGHTED
+      )}">`,
+      endTag: '</mark>'
+    })
+
     return (
       <span
         onFocus={handleInnerFocus}


### PR DESCRIPTION
Using highlighter from sui-js, `molecule/dropdownOption` has the hability to highlight elements in a case insensitive and accent insensitive way.

**Before**
![image](https://user-images.githubusercontent.com/32937662/76304335-85228c00-62c3-11ea-9281-ee41ecda7905.png)

**After**
![image](https://user-images.githubusercontent.com/32937662/76304397-a1262d80-62c3-11ea-8b71-f05b6f2a351e.png)

