### PR TITLE
fix(molecule/modal): add margin instead of padding to modal content

### DIFF
--- a/components/molecule/modal/src/_settings.scss
+++ b/components/molecule/modal/src/_settings.scss
@@ -40,3 +40,8 @@ $pt-molecule-modal-content: $p-l !default;
 $pb-molecule-modal-content: $pt-molecule-modal-content !default;
 $pr-molecule-modal-content: $p-xl !default;
 $pl-molecule-modal-content: $pr-molecule-modal-content !default;
+
+$mt-molecule-modal-content: $m-l !default;
+$mb-molecule-modal-content: $mt-molecule-modal-content !default;
+$mr-molecule-modal-content: $m-xl !default;
+$ml-molecule-modal-content: $mr-molecule-modal-content !default;

--- a/components/molecule/modal/src/_settings.scss
+++ b/components/molecule/modal/src/_settings.scss
@@ -41,7 +41,8 @@ $pb-molecule-modal-content: $pt-molecule-modal-content !default;
 $pr-molecule-modal-content: $p-xl !default;
 $pl-molecule-modal-content: $pr-molecule-modal-content !default;
 
-$mt-molecule-modal-content: $m-l !default;
-$mb-molecule-modal-content: $mt-molecule-modal-content !default;
-$mr-molecule-modal-content: $m-xl !default;
-$ml-molecule-modal-content: $mr-molecule-modal-content !default;
+// maintain backward compatibility in case someone uses any $pX-molecule-modal-content existing variables
+$mt-molecule-modal-content: $pt-molecule-modal-content !default;
+$mb-molecule-modal-content: $pb-molecule-modal-content !default;
+$mr-molecule-modal-content: $pr-molecule-modal-content !default;
+$ml-molecule-modal-content: $pl-molecule-modal-content !default;

--- a/components/molecule/modal/src/index.scss
+++ b/components/molecule/modal/src/index.scss
@@ -175,8 +175,8 @@ body.is-MoleculeModal-open {
     -webkit-overflow-scrolling: touch;
     flex: 1 1 auto;
     overflow-y: auto;
-    padding: $pt-molecule-modal-content $pr-molecule-modal-content 0
-      $pl-molecule-modal-content;
+    margin: $mt-molecule-modal-content $mr-molecule-modal-content 0
+      $ml-molecule-modal-content;
     position: relative;
 
     &:after {


### PR DESCRIPTION
Avoid sui molecule modal content overflow in mobile viewports adding `margin` instead of `padding`.

Before:
![Captura de pantalla 2020-03-12 a las 13 37 13](https://user-images.githubusercontent.com/1105226/76533232-0cb0fc00-6478-11ea-86a0-5700f4f17c41.png)

After:
![Captura de pantalla 2020-03-12 a las 13 38 59](https://user-images.githubusercontent.com/1105226/76533242-10dd1980-6478-11ea-8e37-39d9239a7c97.png)
