### PR TITLE
feat(atom/card): add flex grow to atomCard info

### DIFF
--- a/components/atom/card/src/index.scss
+++ b/components/atom/card/src/index.scss
@@ -39,6 +39,7 @@ $class-media: '#{$base-class}-media';
 
   &-info {
     padding: $p-atom-card-info;
+    flex-grow: 1;
   }
 
   &-link {


### PR DESCRIPTION
Add flex grow to make take up 100% of remaining space