### PR TITLE
Feat/suic 434 add tokens to atom/textarea, molecule/radioButtonField and molecule/select

### DIFF
--- a/components/atom/textarea/src/index.scss
+++ b/components/atom/textarea/src/index.scss
@@ -39,6 +39,10 @@ $base-class: '.sui-AtomTextarea';
     color: $c-atom-textarea-placeholder;
   }
 
+  &:focus {
+    @extend %sui-atom-input-input-focus;
+  }
+
   &--short {
     height: calc(
       (#{$lh-atom-textarea} * #{$short-num-lines}) + #{$pm-atom-textarea}

--- a/components/atom/textarea/src/index.scss
+++ b/components/atom/textarea/src/index.scss
@@ -10,7 +10,8 @@ $lh-atom-textarea: $lh-l !default;
 
 $bgc-atom-textarea: initial !default;
 $bgc-atom-textarea--disabled: $c-gray-lightest !default;
-$bd-atom-textarea: 1px solid $c-gray-light !default;
+$bd-atom-textarea: $bdw-s solid $c-gray-light !default;
+$bdrs-atom-textarea: 0 !default;
 $bd-atom-textarea--disabled: $bdw-s solid initial !default;
 $c-atom-textarea: initial !default;
 $c-atom-textarea--disabled: $c-gray-light !default;
@@ -22,6 +23,7 @@ $base-class: '.sui-AtomTextarea';
 #{$base-class} {
   background: $bgc-atom-textarea;
   border: $bd-atom-textarea;
+  border-radius: $bdrs-atom-textarea;
   color: $c-atom-textarea;
   font-size: $fz-atom-textarea;
   line-height: $lh-atom-textarea;

--- a/components/molecule/radioButtonField/src/index.scss
+++ b/components/molecule/radioButtonField/src/index.scss
@@ -2,7 +2,10 @@
 @import '~@s-ui/react-molecule-field/lib/index';
 @import '~@s-ui/react-atom-radio-button/lib/index';
 
+$m-molecule-radio-button-field: 0 !default;
+
 .sui-MoleculeRadioButtonField {
+  margin: $m-molecule-radio-button-field;
   input[type='radio'] {
     margin: 0;
   }

--- a/components/molecule/radioButtonField/src/index.scss
+++ b/components/molecule/radioButtonField/src/index.scss
@@ -3,11 +3,12 @@
 @import '~@s-ui/react-atom-radio-button/lib/index';
 
 $m-molecule-radio-button-field: 0 !default;
+$m-molecule-radio-button-field-container: 0 !default;
 
 .sui-MoleculeRadioButtonField {
-  margin: $m-molecule-radio-button-field;
+  margin: $m-molecule-radio-button-field-container;
   input[type='radio'] {
-    margin: 0;
+    margin: $m-molecule-radio-button-field;
   }
   .sui-AtomLabel {
     cursor: pointer;

--- a/components/molecule/select/src/index.scss
+++ b/components/molecule/select/src/index.scss
@@ -9,13 +9,14 @@ $class-select-atom-input: '.sui-AtomInput';
 $class-select-atom-input-input: '#{$class-select-atom-input}-input';
 $class-select-atom-input-tags: '#{$class-select-atom-input}--withTags';
 
+$bd-select: $bdw-s solid transparent !default;
+$bdrs-select: 0 !default;
 $z-select-list: $z-navigation !default;
 $mr-select-list-arrow: -$p-xxl !default;
 $pr-select-atom-input-tags: $p-xxl !default;
 $w-select-list-arrow: $sz-icon-m !default;
 $h-select-list-arrow: $sz-icon-m !default;
 $c-select-list-arrow-fill: initial !default;
-
 $bgc-atom-input-disabled: $c-gray-lightest !default;
 
 #{$base-class} {
@@ -30,7 +31,8 @@ $bgc-atom-input-disabled: $c-gray-lightest !default;
   &-inputSelect {
     &-container {
       align-items: center;
-      border: 1px solid transparent;
+      border: $bd-select;
+      border-radius: $bdrs-select;
       cursor: pointer;
       display: flex;
 
@@ -44,6 +46,7 @@ $bgc-atom-input-disabled: $c-gray-lightest !default;
       #{$class-select-atom-input-input}:disabled {
         opacity: 1;
         -webkit-appearance: none;
+        // color: $c-black;
       }
 
       #{$class-select-atom-input-input}:first-child,

--- a/components/molecule/select/src/index.scss
+++ b/components/molecule/select/src/index.scss
@@ -46,7 +46,6 @@ $bgc-atom-input-disabled: $c-gray-lightest !default;
       #{$class-select-atom-input-input}:disabled {
         opacity: 1;
         -webkit-appearance: none;
-        // color: $c-black;
       }
 
       #{$class-select-atom-input-input}:first-child,


### PR DESCRIPTION
- Add border-radius token to `atom/textarea` component.
- Extend focus behavior from input in  `atom/textarea` component.
- Add margin to `molecule/radioButtonField` component.
- Add border and border-radius token to `molecule/select`