### PR TITLE
feat(atom/checkbox): fix styles when atom checkbox uses non native

### DIFF
--- a/components/atom/checkbox/src/index.scss
+++ b/components/atom/checkbox/src/index.scss
@@ -35,6 +35,7 @@ $w-atom-checkbox: 24px !default;
     text-align: center;
     vertical-align: top;
     width: $w-atom-checkbox;
+    min-width: $w-atom-checkbox;
 
     span {
       /* Center custom icons */
@@ -46,6 +47,12 @@ $w-atom-checkbox: 24px !default;
     &.is-checked {
       background-color: $bgc-checked-atom-checkbox;
       border: $bd-atom-checkbox--checked;
+      color: $c-atom-checkbox;
+      svg {
+        width: $w-atom-checkbox;
+        height: $h-atom-checkbox;
+        fill: $c-atom-checkbox;
+      }
     }
 
     &.is-disabled {

--- a/components/atom/checkbox/src/index.scss
+++ b/components/atom/checkbox/src/index.scss
@@ -44,13 +44,16 @@ $w-atom-checkbox: 24px !default;
       justify-content: center;
     }
 
+    svg {
+      width: $w-atom-checkbox;
+      height: $h-atom-checkbox;
+    }
+
     &.is-checked {
       background-color: $bgc-checked-atom-checkbox;
       border: $bd-atom-checkbox--checked;
       color: $c-atom-checkbox;
       svg {
-        width: $w-atom-checkbox;
-        height: $h-atom-checkbox;
         fill: $c-atom-checkbox;
       }
     }


### PR DESCRIPTION
- fix atom checkbox (non native version) in mobile devices.

Before:

![image](https://user-images.githubusercontent.com/32937662/77182083-7f4f5680-6acc-11ea-8d1d-a4bc74b268bf.png)
![image](https://user-images.githubusercontent.com/32937662/77182090-81b1b080-6acc-11ea-9906-bdf0551294a6.png)

After
![image](https://user-images.githubusercontent.com/32937662/77182099-85ddce00-6acc-11ea-92d1-e0f611039cfb.png)

![image](https://user-images.githubusercontent.com/32937662/77307437-87400e00-6cf9-11ea-98a9-b95524a45b3f.png)
