### PR TITLE
feat(molecule/inputField): add useContrastLabel prop

### DIFF
--- a/components/molecule/inputField/src/index.js
+++ b/components/molecule/inputField/src/index.js
@@ -25,6 +25,7 @@ const MoleculeInputField = ({
   autoHideHelpText = false,
   inline,
   onChange,
+  useContrastLabel,
   ...props
 }) => {
   const errorState = getErrorState({successText, errorText})
@@ -41,6 +42,7 @@ const MoleculeInputField = ({
       autoHideHelpText={autoHideHelpText}
       inline={inline}
       onChange={onChange}
+      useContrastLabel={useContrastLabel}
     >
       <AtomInput
         id={id}
@@ -80,7 +82,10 @@ MoleculeInputField.propTypes = {
   inline: PropTypes.bool,
 
   /** Boolean to decide if helptext should be auto hide */
-  autoHideHelpText: PropTypes.bool
+  autoHideHelpText: PropTypes.bool,
+
+  /** label prop to use contrast type */
+  useContrastLabel: PropTypes.bool
 }
 
 export default MoleculeInputField

--- a/demo/molecule/inputField/playground
+++ b/demo/molecule/inputField/playground
@@ -26,6 +26,10 @@ const styleListItem = {
   marginTop: '50px'
 }
 
+const darkBackground = {
+  backgroundColor: '#2b91c1'
+}
+
 const MoleculeInputFieldWithState = withState(MoleculeInputField)
 
 return (
@@ -115,6 +119,19 @@ return (
           id="notes"
           value="In some place of La Mancha which name..."
         />
+      </li>
+      <li style={styleListItem}>
+        <h2>
+          With contrast label
+        </h2>
+        <div style={darkBackground}>
+          <MoleculeInputFieldWithState
+            id="notes"
+            value="In some place of La Mancha which name..."
+            label="Label"
+            useContrastLabel
+          />
+        </div>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
adds useContrastLabel prop that is already used by the autosuggest field https://github.com/SUI-Components/sui-components/blob/master/components/molecule/autosuggestField/src/index.js#L101 in order to use the contrast label 

won't work until https://github.com/SUI-Components/sui-components/pull/1040 is merged