### PR TITLE
feat(atom/card): add new highlight bgc hover variable

### DIFF
--- a/components/atom/card/src/index.scss
+++ b/components/atom/card/src/index.scss
@@ -7,6 +7,7 @@ $p-atom-card-small: 0 !default;
 $bgc-atom-card-hover: transparent !default;
 $bxsh-atom-card-hover: none !default;
 $c-atom-card-highlight: $c-highlight !default;
+$bgc-atom-card-highlight-hover: $bgc-atom-card-hover !default;
 $w-atom-card-media: 33% !default;
 $mr-atom-card-media: 0 !default;
 $mq-responsive-breakpoint-name: 'm' !default;
@@ -50,6 +51,11 @@ $class-media: '#{$base-class}-media';
 
   &--highlight {
     background: $c-atom-card-highlight;
+    @media (hover: hover) {
+      &:hover {
+        background: $bgc-atom-card-highlight-hover;
+      }
+    }
   }
 
   &--vertical {

--- a/components/atom/card/src/index.scss
+++ b/components/atom/card/src/index.scss
@@ -7,7 +7,7 @@ $p-atom-card-small: 0 !default;
 $bgc-atom-card-hover: transparent !default;
 $bxsh-atom-card-hover: none !default;
 $c-atom-card-highlight: $c-highlight !default;
-$bgc-atom-card-highlight-hover: $bgc-atom-card-hover !default;
+$bgc-atom-card-highlight-hover: $bgc-atom-card-hover !default; // using $bgc-atom-card-hover to keep styles backwards compatible
 $w-atom-card-media: 33% !default;
 $mr-atom-card-media: 0 !default;
 $mq-responsive-breakpoint-name: 'm' !default;


### PR DESCRIPTION
This will allow us to overwrite the background colour on hover of a card that's highlighted.

![Kapture 2020-03-23 at 12 54 38](https://user-images.githubusercontent.com/18154356/77314209-7e553980-6d05-11ea-9819-cc745390e0df.gif)
