### PR TITLE
feat(atom/button): remove unnecesary paddings for empty buttons

### DIFF
--- a/components/atom/button/src/index.scss
+++ b/components/atom/button/src/index.scss
@@ -335,6 +335,7 @@ $icon-stroke-color: currentColor !default;
   }
 
   &--empty {
+    padding: 0;
     #{$base-class}-leftIcon,
     #{$base-class}-rightIcon {
       margin: 0;


### PR DESCRIPTION
**TASK**: [https://jira.scmspain.com/browse/SUIC-454](https://jira.scmspain.com/browse/SUIC-454)
**BUILD**: [https://sui-components-git-feature-suic-454.schibstedspain.now.sh/workbench/atom/button/demo](https://sui-components-git-feature-suic-454.schibstedspain.now.sh/workbench/atom/button/demo)
![image](https://user-images.githubusercontent.com/1674036/77422073-2da91380-6dcd-11ea-8990-c207618d2894.png)
