### PR TITLE
docs(examples): add themes to complex demos as well

### DIFF
--- a/demo/molecule/buttonGroup/demo/index.js
+++ b/demo/molecule/buttonGroup/demo/index.js
@@ -7,6 +7,7 @@ import AtomButtom, {atomButtonGroupPositions} from '@s-ui/react-atom-button'
 
 import SimpleOptionsRadioForm from './inputRadio'
 import SimpleOptionsCheckboxForm from './inputCheckbox'
+import './index.scss'
 
 const ButtonDesignByState = () => {
   const [selected, setSelected] = useState()

--- a/demo/molecule/buttonGroup/demo/index.js
+++ b/demo/molecule/buttonGroup/demo/index.js
@@ -3,13 +3,10 @@
 import React, {useState} from 'react'
 
 import MoleculeButtonGroup from '../../../../components/molecule/buttonGroup/src'
-import AtomButtom, {
-  atomButtonGroupPositions
-} from '@s-ui/react-atom-button'
+import AtomButtom, {atomButtonGroupPositions} from '@s-ui/react-atom-button'
 
 import SimpleOptionsRadioForm from './inputRadio'
 import SimpleOptionsCheckboxForm from './inputCheckbox'
-import './index.scss'
 
 const ButtonDesignByState = () => {
   const [selected, setSelected] = useState()

--- a/package-lock.json
+++ b/package-lock.json
@@ -8288,7 +8288,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8309,12 +8310,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8329,17 +8332,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8456,7 +8462,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8468,6 +8475,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8482,6 +8490,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8489,12 +8498,14 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8513,6 +8524,7 @@
           "version": "0.5.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -8574,7 +8586,8 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -8602,7 +8615,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8614,6 +8628,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8691,7 +8706,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8727,6 +8743,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8746,6 +8763,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8789,12 +8807,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/scripts/build-themes.js
+++ b/scripts/build-themes.js
@@ -34,6 +34,8 @@ const writeFile = (path, body) => {
     })
 }
 
+const checkFileExists = path => fse.pathExists(path)
+
 const createDir = path => {
   return fse
     .mkdirp(path)
@@ -87,12 +89,14 @@ const writeThemesInDemoFolders = async themes => {
       try {
         const [, component] = demo.split('/demo/')
         await createDir(`${demo}/themes`)
+        const hasDemoStyles = await checkFileExists(`${demo}/demo/index.scss`)
         await Promise.all(
           themes.map(theme =>
             writeFile(
               `${demo}/themes/${theme}.scss`,
               `
 @import '../../../../themes/${theme}';
+${hasDemoStyles ? `@import '../demo/index.scss';` : ''}
 @import '../../../../components/${component}/src/index.scss';
         `.trim()
             )


### PR DESCRIPTION
This PR allows demos styles to be imported by every theme.

Before:
![image](https://user-images.githubusercontent.com/1561955/77640031-ffa50a00-6f59-11ea-8153-51433f06369b.png)

Now:
![image](https://user-images.githubusercontent.com/1561955/77639931-d2585c00-6f59-11ea-82ff-4f711b5b64f9.png)
