### PR TITLE
docs(atom/input): added atom-input props to improve the API doc

### DIFF
--- a/components/atom/input/src/index.js
+++ b/components/atom/input/src/index.js
@@ -55,11 +55,23 @@ AtomInput.propTypes = {
   /** Text to be shown in order to hide the password on click */
   pwHideLabel: PropTypes.string,
 
-  /** onBlur callback */
+  /** onBlur callback **/
   onBlur: PropTypes.func,
 
-  /** onChange callback */
+  /** onKeyDown callback **/
+  onKeyDown: PropTypes.func,
+
+  /** onChange callback **/
   onChange: PropTypes.func,
+
+  /** onFocus callback **/
+  onFocus: PropTypes.func,
+
+  /** onEnter callback **/
+  onEnter: PropTypes.func,
+
+  /** key to provoke the onEnter callback. Valid any value defined here → https://www.w3.org/TR/uievents-key/#named-key-attribute-values **/
+  onEnterKey: PropTypes.string,
 
   /** sets the name property of an element in the DOM */
   name: PropTypes.string,
@@ -101,7 +113,19 @@ AtomInput.propTypes = {
   mask: PropTypes.object,
 
   /** a button to be added on the right side of the input */
-  button: PropTypes.node
+  button: PropTypes.node,
+
+  /** tabindex value */
+  tabIndex: PropTypes.number,
+
+  /** native required attribtue  */
+  required: PropTypes.bool,
+
+  /** native pattern attribute */
+  pattern: PropTypes.string,
+
+  /** To select input keyboard mode on mobile. It can be 'numeric', 'decimal', 'email', etc */
+  inputMode: PropTypes.string
 }
 
 AtomInput.displayName = 'AtomInput'

--- a/components/atom/input/src/index.js
+++ b/components/atom/input/src/index.js
@@ -118,7 +118,7 @@ AtomInput.propTypes = {
   /** tabindex value */
   tabIndex: PropTypes.number,
 
-  /** native required attribtue  */
+  /** native required attribute  */
   required: PropTypes.bool,
 
   /** native pattern attribute */

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "phoenix": "sui-mono phoenix && npm run install:demos -- --no-audit",
     "precommit": "sui-precommit run",
     "release": "sui-studio release",
+    "start": "sui-studio start",
     "test": "true"
   },
   "repository": {},


### PR DESCRIPTION
### added atom-input props to improve the API documentation

<img width="526" alt="Screen Shot 2020-03-26 at 14 03 45" src="https://user-images.githubusercontent.com/1307927/77649766-a7c2cf00-6f6a-11ea-8e9e-f7f9060a6b9b.png">
