### PR TITLE
feat(molecule/autosuggest): send event up onEnter event handler

### DIFF
--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -118,7 +118,7 @@ const MoleculeAutosuggest = ({multiselection, ...props}) => {
       else if (isSomeOptionFocused) handleFocusIn(ev)
     } else {
       if (key === 'Enter') {
-        onEnter()
+        onEnter(ev)
       }
     }
   }
@@ -152,7 +152,7 @@ const MoleculeAutosuggest = ({multiselection, ...props}) => {
     const {key} = ev
     if (key !== 'ArrowDown') ev.stopPropagation()
     if (key === 'Enter') {
-      onEnter()
+      onEnter(ev)
     }
   }
 


### PR DESCRIPTION
This would help us do `ev.preventDefault` on a parent component without any extra changes but I'm not 100% certain about its ramifications.