### PR TITLE
feat(molecule/autosuggest): close list when Enter key is pressed

### DIFF
--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -79,8 +79,6 @@ const MoleculeAutosuggest = ({multiselection, ...props}) => {
   )
 
   const closeList = ev => {
-    const {key} = ev
-    if (key === 'Enter') onEnter(ev)
     const {current: domMoleculeAutosuggest} = refMoleculeAutosuggest
     onToggle(ev, {isOpen: false})
     if (multiselection) onChange(ev, {value: ''})
@@ -154,6 +152,7 @@ const MoleculeAutosuggest = ({multiselection, ...props}) => {
     const {key} = ev
     if (key !== 'ArrowDown') ev.stopPropagation()
     if (key === 'Enter') {
+      onEnter(ev)
       closeList(ev)
     }
   }

--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -79,6 +79,8 @@ const MoleculeAutosuggest = ({multiselection, ...props}) => {
   )
 
   const closeList = ev => {
+    const {key} = ev
+    if (key === 'Enter') onEnter(ev)
     const {current: domMoleculeAutosuggest} = refMoleculeAutosuggest
     onToggle(ev, {isOpen: false})
     if (multiselection) onChange(ev, {value: ''})
@@ -152,7 +154,7 @@ const MoleculeAutosuggest = ({multiselection, ...props}) => {
     const {key} = ev
     if (key !== 'ArrowDown') ev.stopPropagation()
     if (key === 'Enter') {
-      onEnter(ev)
+      closeList(ev)
     }
   }
 


### PR DESCRIPTION
### Before
- typing anything and hitting the `Enter` key wouldn't close the list

![moleculeautosuggest_before_iphone](https://user-images.githubusercontent.com/18154356/77835616-d7323100-714e-11ea-8952-96b608587aa7.gif)

### After
- typing anything and hitting the `Enter` key would close the list and trigger the `onEnter` event

![moleculeautosuggest_after_iphone](https://user-images.githubusercontent.com/18154356/77835633-f03ae200-714e-11ea-9277-f20bdc74a55a.gif)
