### PR TITLE
Feature/add node label to radio

### DIFF
--- a/components/molecule/field/src/index.js
+++ b/components/molecule/field/src/index.js
@@ -23,20 +23,33 @@ const MoleculeLabel = ({
   name,
   onClickLabel
 }) => {
-  let response = null
-  if (label) {
-    response = (
-      <AtomLabel
-        type={typeValidationLabel}
-        name={name}
-        text={label}
-        onClick={onClickLabel}
-      />
-    )
-  } else if (nodeLabel) {
-    response = <div className={CLASS_NODE_LABEL_CONTAINER}>{nodeLabel}</div>
+  const innerLabel = () => {
+    if (label) {
+      return (
+        <AtomLabel
+          type={typeValidationLabel}
+          name={name}
+          text={label}
+          onClick={onClickLabel}
+        />
+      )
+    } else if (nodeLabel) {
+      return React.cloneElement(nodeLabel, {
+        type: typeValidationLabel,
+        name,
+        onClickLabel
+      })
+    }
   }
-  return response
+  return <div className={CLASS_NODE_LABEL_CONTAINER}>{innerLabel()}</div>
+}
+
+MoleculeLabel.propTypes = {
+  label: PropTypes.string,
+  nodeLabel: PropTypes.node,
+  type: PropTypes.oneOf(Object.values(AtomLabelTypes)),
+  name: PropTypes.string,
+  onClickLabel: PropTypes.func
 }
 
 const MoleculeField = ({

--- a/components/molecule/field/src/index.scss
+++ b/components/molecule/field/src/index.scss
@@ -24,7 +24,6 @@ $atomHelpText-class: '.sui-AtomHelpText';
 
       #{$atomLabel-class} {
         align-items: center;
-        margin-left: $ml-molecule-field-label;
       }
     }
   }

--- a/components/molecule/radioButtonField/src/index.js
+++ b/components/molecule/radioButtonField/src/index.js
@@ -14,6 +14,7 @@ const getErrorState = ({successText, errorText}) => {
 const MoleculeRadioButtonField = ({
   id,
   label,
+  nodeLabel,
   successText,
   errorText,
   alertText,
@@ -28,6 +29,7 @@ const MoleculeRadioButtonField = ({
       <MoleculeField
         name={id}
         label={label}
+        nodeLabel={nodeLabel}
         successText={successText}
         errorText={errorText}
         alertText={alertText}
@@ -46,7 +48,10 @@ MoleculeRadioButtonField.displayName = 'MoleculeRadioButtonField'
 
 MoleculeRadioButtonField.propTypes = {
   /** Text to be displayed as label */
-  label: PropTypes.string.isRequired,
+  label: PropTypes.string,
+
+  /** React node to be displayed as label if there is not a label */
+  nodeLabel: PropTypes.node,
 
   /** used as label for attribute and input element id */
   id: PropTypes.string.isRequired,

--- a/components/molecule/radioButtonField/src/index.js
+++ b/components/molecule/radioButtonField/src/index.js
@@ -6,11 +6,6 @@ import AtomRadioButton from '@s-ui/react-atom-radio-button'
 
 const BASE_CLASS = 'sui-MoleculeRadioButtonField'
 
-const getErrorState = ({successText, errorText}) => {
-  if (successText) return false
-  if (errorText) return true
-}
-
 const MoleculeRadioButtonField = ({
   id,
   label,
@@ -22,8 +17,6 @@ const MoleculeRadioButtonField = ({
   onChange,
   ...props
 }) => {
-  const errorState = getErrorState({successText, errorText})
-
   return (
     <div className={BASE_CLASS}>
       <MoleculeField
@@ -38,7 +31,7 @@ const MoleculeRadioButtonField = ({
         inline
         reverse
       >
-        <AtomRadioButton id={id} errorState={errorState} {...props} />
+        <AtomRadioButton id={id} {...props} />
       </MoleculeField>
     </div>
   )

--- a/components/molecule/radioButtonField/src/index.scss
+++ b/components/molecule/radioButtonField/src/index.scss
@@ -11,7 +11,7 @@ $m-molecule-radio-button-field-container: 0 !default;
   input[type='radio'] {
     margin: $m-molecule-radio-button-field;
     &:disabled {
-      + .sui-AtomLabel {
+      + .sui-MoleculeField-nodeLabelContainer .sui-AtomLabel {
         color: $c-molecule-radio-button-field-label--disabled;
       }
     }

--- a/demo/molecule/radioButtonField/playground
+++ b/demo/molecule/radioButtonField/playground
@@ -86,6 +86,19 @@ return (
           value="In some place of La Mancha which name..."
         />
       </li>
+      <li style={styleListItem}>
+        <h2>With nodeLabel</h2>
+        <MoleculeRadioButtonField
+          id="with-node-label"
+          nodeLabel={
+            <>
+              <label for="with-node-label">Description</label>{' '}
+              <span>I am out of the label</span>
+            </>
+          }
+          helpText="Tu descripción en Latin"
+        />
+      </li>
     </ul>
   </div>
 )

--- a/demo/molecule/radioButtonField/playground
+++ b/demo/molecule/radioButtonField/playground
@@ -92,7 +92,7 @@ return (
           id="with-node-label"
           nodeLabel={
             <>
-              <label for="with-node-label">Description</label>{' '}
+              <label htmlFor="with-node-label">Description</label>{' '}
               <span>I am out of the label</span>
             </>
           }

--- a/demo/molecule/radioButtonGroup/demo/index.js
+++ b/demo/molecule/radioButtonGroup/demo/index.js
@@ -3,6 +3,7 @@ import React, {useState} from 'react'
 
 import AtomRadioButton from '@s-ui/react-atom-radio-button'
 import MoleculeRadioButtonField from '@s-ui/react-molecule-radio-button-field'
+import AtomLabel from '@s-ui/react-atom-label'
 import MoleculeRadioButtonGroup from '../../../../components/molecule/radioButtonGroup/src'
 
 import RadioButtonGroupIcons from './components/radioButtonGroupIcons'
@@ -10,6 +11,20 @@ import './index.scss'
 
 const BASE_CLASS_DEMO = `DemoMoleculeRadioButtonGroup`
 const CLASS_SECTION = `${BASE_CLASS_DEMO}-section`
+
+// eslint-disable-next-line react/prop-types
+const CustomLabel = ({text, type, name, onClickLabel}) => (
+  <>
+    <AtomLabel
+      name={name}
+      text={text}
+      inline="left"
+      onClick={onClickLabel}
+      type={type}
+    />
+    <span>I am out of the label</span>
+  </>
+)
 
 const RadioButtonGroupStateWrapper = () => {
   const [value, setValue] = useState('john')
@@ -95,7 +110,7 @@ const Demo = () => {
           <MoleculeRadioButtonField
             id="john"
             value="john"
-            label="John"
+            nodeLabel={<CustomLabel text="John" />}
             helpText="John Lennon"
           />
           <MoleculeRadioButtonField

--- a/demo/molecule/radioButtonGroup/demo/package.json
+++ b/demo/molecule/radioButtonGroup/demo/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@s-ui/hoc": "1",
+    "@s-ui/react-atom-label": "1",
     "@s-ui/react-atom-radio-button": "1",
     "@s-ui/react-molecule-radio-button-field": "1"
   }

--- a/test/molecule/checkboxField/index.js
+++ b/test/molecule/checkboxField/index.js
@@ -54,7 +54,7 @@ describe('molecule/checkboxField', () => {
         // Given
         const text = 'nodeLabel'
         const props = {
-          nodeLabel: <div>{text}</div>
+          nodeLabel: <div className="testNodeLabel">{text}</div>
         }
         // When
         const {container, getByText} = setup(props)
@@ -64,18 +64,14 @@ describe('molecule/checkboxField', () => {
         expect(container).to.be.not.undefined
         expect(labelElement).to.be.not.undefined
         expect(labelElement.innerText).to.equal(text)
-        expect(
-          labelElement.parentNode.classList.contains(
-            'sui-MoleculeField-nodeLabelContainer'
-          )
-        ).to.be.true
+        expect(labelElement.classList.contains('testNodeLabel')).to.be.true
       })
       it('should render the component with label value if there is label and nodeLabel props', async () => {
         // Given
         const text = 'label'
         const props = {
           label: text,
-          nodeLabel: <div>{text}</div>
+          nodeLabel: <div className="testNodeLabel">{text}</div>
         }
         // When
         const {container, getByText} = setup(props)
@@ -86,11 +82,7 @@ describe('molecule/checkboxField', () => {
         expect(labelElement).to.be.not.undefined
         expect(labelElement.innerText).to.equal(props.label)
         expect(labelElement.classList.contains('sui-AtomLabel')).to.be.true
-        expect(
-          labelElement.parentNode.classList.contains(
-            'sui-MoleculeField-nodeLabelContainer'
-          )
-        ).to.be.false
+        expect(labelElement.classList.contains('testNodeLabel')).to.be.false
       })
     })
   })

--- a/test/molecule/radioButtonField/index.js
+++ b/test/molecule/radioButtonField/index.js
@@ -1,22 +1,87 @@
-/*
- * Remember: YOUR COMPONENT IS DEFINED GLOBALLY
- * */
+/* global MoleculeRadioButtonField */
 
 /* eslint react/jsx-no-undef:0 */
 
-// import React from 'react'
-// import {render} from '@testing-library/react'
+import React from 'react'
+import {render} from '@testing-library/react'
 
 import chai, {expect} from 'chai'
 import chaiDOM from 'chai-dom'
 
 chai.use(chaiDOM)
 
+const setupBuilder = Component => props => {
+  const container = document.createElement('div')
+  container.setAttribute('id', 'test-container')
+  const utils = render(<Component {...props} />, {
+    container: document.body.appendChild(container)
+  })
+  return utils
+}
+
+const setup = setupBuilder(MoleculeRadioButtonField)
+
+chai.use(chaiDOM)
+
 describe('molecule/radioButtonField', () => {
-  it('Render', () => {
-    // Example TO BE DELETED!!!!
-    // const {getByRole} = render(<AtomButton>HOLA</AtomButton>)
-    // expect(getByRole('button')).to.have.text('HOLA')
-    expect(true).to.be.eql(false)
+  describe('props', () => {
+    describe('label & nodeLabel', () => {
+      it('should render the empty component if there is not label or nodeLabel props', async () => {
+        // Given
+        // When
+        const {container} = setup()
+        // Then
+        expect(container).to.be.not.undefined
+      })
+
+      it('should render the component if there is label', async () => {
+        // Given
+        const props = {
+          label: 'label'
+        }
+        // When
+        const {container, getByText} = setup(props)
+        // Then
+        const labelElement = getByText(props.label)
+        expect(container).to.be.not.undefined
+        expect(labelElement).to.be.not.undefined
+        expect(labelElement.innerText).to.equal(props.label)
+        expect(labelElement.classList.contains('sui-AtomLabel')).to.be.true
+      })
+      it('should render the component if there is nodeLabel', async () => {
+        // Given
+        const text = 'nodeLabel'
+        const props = {
+          nodeLabel: <div className="testNodeLabel">{text}</div>
+        }
+        // When
+        const {container, getByText} = setup(props)
+
+        // Then
+        const labelElement = getByText(text)
+        expect(container).to.be.not.undefined
+        expect(labelElement).to.be.not.undefined
+        expect(labelElement.innerText).to.equal(text)
+        expect(labelElement.classList.contains('testNodeLabel')).to.be.true
+      })
+      it('should render the component with label value if there is label and nodeLabel props', async () => {
+        // Given
+        const text = 'label'
+        const props = {
+          label: text,
+          nodeLabel: <div className="testNodeLabel">{text}</div>
+        }
+        // When
+        const {container, getByText} = setup(props)
+
+        // Then
+        const labelElement = getByText(text)
+        expect(container).to.be.not.undefined
+        expect(labelElement).to.be.not.undefined
+        expect(labelElement.innerText).to.equal(props.label)
+        expect(labelElement.classList.contains('sui-AtomLabel')).to.be.true
+        expect(labelElement.classList.contains('testNodeLabel')).to.be.false
+      })
+    })
   })
 })


### PR DESCRIPTION
We need to be able to use custom Labels for our RadioButtonField. In some cases, we would like to add extra components that are not part of the interactive label of the radioButton itself like in this i.e 
![image](https://user-images.githubusercontent.com/21960669/78017070-06fa5800-734c-11ea-837a-ef07fb2d98b3.png)

where the "+ info" part should not trigger the onchange of the radiobutton. This PR tries to solves that by inverting the dependency of the AtomLabel to the client of the RadioButtonField.
