### PR TITLE
Feat/add min max to input

### DIFF
--- a/components/atom/input/src/Input/Component/index.js
+++ b/components/atom/input/src/Input/Component/index.js
@@ -67,6 +67,8 @@ const Input = ({
   tabIndex = DEFAULT_PROPS.TAB_INDEX,
   maxLength,
   minLength,
+  max,
+  min,
   autoComplete,
   onChange = DEFAULT_PROPS.ON_CHANGE,
   onEnter = DEFAULT_PROPS.ON_ENTER,
@@ -121,6 +123,8 @@ const Input = ({
       size={charsSize}
       maxLength={maxLength}
       minLength={minLength}
+      max={max}
+      min={min}
       autoComplete={autoComplete}
       required={required}
       pattern={pattern}
@@ -160,6 +164,10 @@ Input.propTypes = {
   maxLength: PropTypes.number,
   /* specifies the minimum number of characters (native "minlength" attribute) */
   minLength: PropTypes.number,
+  /** specifies the maximum number allowed (native "max" attribute) */
+  max: PropTypes.number,
+  /** specifies the minimum number allowed (native "min" attribute) */
+  min: PropTypes.number,
   /** specifies whether or not an input field should have autocomplete enabled (on|off) */
   autoComplete: PropTypes.string,
   /* text, password, date or number */

--- a/components/atom/input/src/index.js
+++ b/components/atom/input/src/index.js
@@ -97,6 +97,12 @@ AtomInput.propTypes = {
   /** specifies the minimum number of characters (native "minlength" attribute) */
   minLength: PropTypes.number,
 
+  /** specifies the maximum number allowed (native "max" attribute) */
+  max: PropTypes.number,
+
+  /** specifies the minimum number allowed (native "min" attribute) */
+  min: PropTypes.number,
+
   /** specifies whether or not an input field should have autocomplete enabled (on|off) */
   autoComplete: PropTypes.string,
 

--- a/components/molecule/dropdownList/package.json
+++ b/components/molecule/dropdownList/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "@s-ui/component-dependencies": "1",
-    "@s-ui/react-atom-input": "4"
+    "@s-ui/react-atom-input": "4",
+    "@s-ui/react-perf-dynamic-rendering": "^1.13.0"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
- Add max and min prop to atom/input component.

Note: When input `type` attribute is `number` there are two properties `max` and `min` that are different than the already defined props `maxLength` and `minLength`.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number#max
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number#min