### PR TITLE
feat(atom/input): add max and min prop to atom inpu

### DIFF
--- a/components/atom/input/src/Input/Component/index.js
+++ b/components/atom/input/src/Input/Component/index.js
@@ -69,6 +69,7 @@ const Input = ({
   minLength,
   min,
   max,
+  step,
   autoComplete,
   onChange = DEFAULT_PROPS.ON_CHANGE,
   onEnter = DEFAULT_PROPS.ON_ENTER,
@@ -125,6 +126,7 @@ const Input = ({
       minLength={minLength}
       max={max}
       min={min}
+      step={step}
       autoComplete={autoComplete}
       required={required}
       pattern={pattern}
@@ -168,6 +170,8 @@ Input.propTypes = {
   max: PropTypes.number,
   /* specifies the minimum number allowed (native "min" attribute) */
   min: PropTypes.number,
+  /** stepping interval to use when using up and down arrows to adjust the value, as well as for validation (native "step" attribute) */
+  step: PropTypes.number,
   /** specifies whether or not an input field should have autocomplete enabled (on|off) */
   autoComplete: PropTypes.string,
   /* text, password, date or number */

--- a/components/atom/input/src/Input/Component/index.js
+++ b/components/atom/input/src/Input/Component/index.js
@@ -67,6 +67,8 @@ const Input = ({
   tabIndex = DEFAULT_PROPS.TAB_INDEX,
   maxLength,
   minLength,
+  min,
+  max,
   autoComplete,
   onChange = DEFAULT_PROPS.ON_CHANGE,
   onEnter = DEFAULT_PROPS.ON_ENTER,
@@ -121,6 +123,8 @@ const Input = ({
       size={charsSize}
       maxLength={maxLength}
       minLength={minLength}
+      max={max}
+      min={min}
       autoComplete={autoComplete}
       required={required}
       pattern={pattern}
@@ -160,6 +164,10 @@ Input.propTypes = {
   maxLength: PropTypes.number,
   /* specifies the minimum number of characters (native "minlength" attribute) */
   minLength: PropTypes.number,
+  /* specifies the maximum number allowed (native "max" attribute) */
+  max: PropTypes.number,
+  /* specifies the minimum number allowed (native "min" attribute) */
+  min: PropTypes.number,
   /** specifies whether or not an input field should have autocomplete enabled (on|off) */
   autoComplete: PropTypes.string,
   /* text, password, date or number */

--- a/components/atom/input/src/index.js
+++ b/components/atom/input/src/index.js
@@ -103,6 +103,9 @@ AtomInput.propTypes = {
   /** specifies the minimum number allowed (native "min" attribute) */
   min: PropTypes.number,
 
+  /** stepping interval to use when using up and down arrows to adjust the value, as well as for validation (native "step" attribute) */
+  step: PropTypes.number,
+
   /** specifies whether or not an input field should have autocomplete enabled (on|off) */
   autoComplete: PropTypes.string,
 

--- a/components/atom/input/src/index.js
+++ b/components/atom/input/src/index.js
@@ -97,6 +97,12 @@ AtomInput.propTypes = {
   /** specifies the minimum number of characters (native "minlength" attribute) */
   minLength: PropTypes.number,
 
+  /** specifies the maximum number allowed (native "max" attribute) */
+  max: PropTypes.number,
+
+  /** specifies the minimum number allowed (native "min" attribute) */
+  min: PropTypes.number,
+
   /** specifies whether or not an input field should have autocomplete enabled (on|off) */
   autoComplete: PropTypes.string,
 


### PR DESCRIPTION
- Add max, min and step prop to atom/input component.

Note: When input `type` attribute is `number` there are two properties `max` and `min` that are different than the already defined props `maxLength` and `minLength`.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number#max
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number#min