### PR TITLE
Fix/atom label default color

### DIFF
--- a/components/atom/label/src/index.scss
+++ b/components/atom/label/src/index.scss
@@ -6,7 +6,7 @@ $c-atom-label-optional: $c-gray-light !default;
 $c-atom-label-contrast: $c-white !default;
 $fw-atom-label: inherit !default;
 $c-atom-label-type: success $c-success, error $c-error, alert $c-alert,
-  contrast $c-atom-label-contrast;
+  contrast $c-atom-label-contrast !default;
 
 .sui-AtomLabel {
   display: block;

--- a/components/molecule/textareaField/CHANGELOG.md
+++ b/components/molecule/textareaField/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+# 3.0.0 (2020-04-06)
+
+
+### Features
+
+* added prop updateInternalValue in order to update the internal value o ([18307a3](https://github.com/SUI-Components/sui-components/commit/18307a3b83631b94260f250ceba3b0f9d25ae2bc))
+* modify value prop to update the internalValue ([314e91c](https://github.com/SUI-Components/sui-components/commit/314e91cb82b1ffc9e3f0bd0a41a126d0e8e571de))
+
+
+### BREAKING CHANGES
+
+* value prop
+
+
+
 # 2.8.0 (2020-03-11)
 
 

--- a/components/molecule/textareaField/package.json
+++ b/components/molecule/textareaField/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/react-molecule-textarea-field",
-  "version": "2.8.0",
+  "version": "3.0.0",
   "description": "",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
- Add `!default` to `$c-atom-label-type` so in vertical theme we can override if necessary.