### PR TITLE
feat(Root): fixed Atom Panel Overlay demo

### DIFF
--- a/demo/atom/panel/playground
+++ b/demo/atom/panel/playground
@@ -18,7 +18,7 @@ return (
     <h2>As Color Panel</h2>
     <div>
       <h3>Structure - Alpha</h3>
-      <div style={Object.assign({}, flexWrapper, {background: 'white url(https://picsum.photos/1000/800?blur)'})}>
+      <div style={Object.assign({}, flexWrapper, {background: 'white url(https://picsum.photos/1000/800)'})}>
       {
         Object.values(atomPanelAlpha).map((alpha, idx) =>
           <div key={idx} style={{flex: '0 0 auto', textAlign: 'center', margin: '15px'}}>

--- a/demo/atom/panel/playground
+++ b/demo/atom/panel/playground
@@ -167,7 +167,7 @@ return (
           {
             Object.keys(atomPanelAlpha).map((alpha) =>
               <div style={Object.assign({}, flexItem, {width: '250px'})}>
-                <AtomPanel src={'https://picsum.photos/250/200'} overlayColor={color} overlayAlpha={alpha}>
+                <AtomPanel src={'https://picsum.photos/250/200'} overlayColor={color.toLowerCase()} overlayAlpha={alpha}>
                   <div style={{height: '150px'}} />
                 </AtomPanel>
                 <span>{color} {alpha}</span>


### PR DESCRIPTION
# In this Pull Request

**Fixed the Atom Panel Overlay demo.**

The problem is that the demo code uses the keys (they are in capital letters) and the CSS use the value in lowercase 🤷🏽‍♂️

## Before

<img width="950" alt="before" src="https://user-images.githubusercontent.com/1307927/78693218-3cc6b000-78fb-11ea-9bb4-97987266a756.png">

## After

<img width="951" alt="after" src="https://user-images.githubusercontent.com/1307927/78693241-43edbe00-78fb-11ea-98dc-454451f83c4e.png">
