### PR TITLE
feat(atom/panel): fixed overlay color-alpha feature

### DIFF
--- a/components/atom/panel/src/ImagePanel.js
+++ b/components/atom/panel/src/ImagePanel.js
@@ -16,6 +16,7 @@ const VERTICAL_ALIGNMENTS = {
 }
 
 const DEFAULT_ALPHA = 'CONTRAST'
+const DEFAULT_COLOR = 'ACCENT'
 
 const getClassNames = function({
   verticalAlign,
@@ -28,12 +29,13 @@ const getClassNames = function({
   const BASE_CLASS = 'sui-atom-panel'
   const IMAGE_PANEL_CLASS = `${BASE_CLASS}-image`
   const overlayAlphaValue = ALPHA[overlayAlpha] || DEFAULT_ALPHA
+  const overlayColorValue = COLORS[overlayColor] || DEFAULT_COLOR
 
   return cx(
     `${IMAGE_PANEL_CLASS}--vertical-${verticalAlign}`,
     `${IMAGE_PANEL_CLASS}--horizontal-${horizontalAlign}`,
     overlayColor &&
-      `${BASE_CLASS}--${overlayColor}-overlay-${overlayAlphaValue}`,
+      `${BASE_CLASS}--${overlayColorValue}-overlay-${overlayAlphaValue}`,
     `${BASE_CLASS}-color--${color}`,
     resized && `${IMAGE_PANEL_CLASS}--resized`
   )

--- a/demo/atom/panel/playground
+++ b/demo/atom/panel/playground
@@ -167,7 +167,7 @@ return (
           {
             Object.keys(atomPanelAlpha).map((alpha) =>
               <div style={Object.assign({}, flexItem, {width: '250px'})}>
-                <AtomPanel src={'https://picsum.photos/250/200'} overlayColor={color.toLowerCase()} overlayAlpha={alpha}>
+                <AtomPanel src={'https://picsum.photos/250/200'} overlayColor={color} overlayAlpha={alpha}>
                   <div style={{height: '150px'}} />
                 </AtomPanel>
                 <span>{color} {alpha}</span>


### PR DESCRIPTION
# In this Pull Request

**Fixed the Atom Panel Overlay.**

## Before

<img width="950" alt="before" src="https://user-images.githubusercontent.com/1307927/78693218-3cc6b000-78fb-11ea-9bb4-97987266a756.png">

## After

<img width="951" alt="after" src="https://user-images.githubusercontent.com/1307927/78693241-43edbe00-78fb-11ea-98dc-454451f83c4e.png">
