### PR TITLE
fix(atom/badge): changed margin left for margin right

### DIFF
--- a/components/atom/badge/src/index.scss
+++ b/components/atom/badge/src/index.scss
@@ -43,10 +43,11 @@ $badges: (
   fill: currentColor;
   display: inline-flex;
   justify-content: center;
+  margin-right: $m-atom-badge-l;
   white-space: nowrap;
 
-  & + & {
-    margin-left: $m-atom-badge-l;
+  &:last-child {
+    margin-right: 0;
   }
 
   &-small {


### PR DESCRIPTION
I've changed `margin-left`, for `margin-right` (except the last element) to avoid unnecessary margin-left on the first element of the second line

Current: 

<img width="296" alt="Screenshot 2020-04-14 at 17 08 21" src="https://user-images.githubusercontent.com/74129/79240909-a2beb480-7e72-11ea-8cde-7080c0570f72.png">

Expected: 
<img width="301" alt="Screenshot 2020-04-14 at 17 08 39" src="https://user-images.githubusercontent.com/74129/79240924-a81bff00-7e72-11ea-9e20-7455a23c835b.png">
