### PR TITLE
fix(molecule/autosuggest): clicks on dropdown scrollbar won't focus out

### DIFF
--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -127,15 +127,16 @@ const MoleculeAutosuggest = ({multiselection, ...props}) => {
 
   const handleFocusOut = ev => {
     ev.persist()
+    const {current: domContainer} = refMoleculeAutosuggest
     const {current: domInnerInput} = refMoleculeAutosuggestInput
     const {current: optionsFromRef} = refsMoleculeAutosuggestOptions
     const options = optionsFromRef.map(getTarget)
 
     setTimeout(() => {
       const currentElementFocused = getCurrentElementFocused()
-      const focusOutFromOutside = ![domInnerInput, ...options].includes(
-        currentElementFocused
-      )
+      const focusOutFromOutside =
+        ![domInnerInput, ...options].includes(currentElementFocused) &&
+        !domContainer.contains(currentElementFocused)
       if (focusOutFromOutside) {
         if (isOpen) {
           closeList(ev)


### PR DESCRIPTION
NOTE: moved to https://github.com/SUI-Components/sui-components/pull/1095 to test new PR templates.

**BEFORE**, we got this behaviour:
![bugfix_autosuggest_scroll_0](https://user-images.githubusercontent.com/18154356/79558045-dd5b6380-80a3-11ea-97fa-fb8affd31ef4.gif)

**AFTER**, clicking on the scrollbar is no longer focusing out:
![bugfix_autosuggest_scroll_1](https://user-images.githubusercontent.com/18154356/79558059-e2201780-80a3-11ea-870f-d4b339b4f8f9.gif)
