### PR TITLE
fix(molecule/autosuggest): clicks on dropdown scrollbar won't focus out

### DIFF
--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -127,15 +127,16 @@ const MoleculeAutosuggest = ({multiselection, ...props}) => {
 
   const handleFocusOut = ev => {
     ev.persist()
+    const {current: domContainer} = refMoleculeAutosuggest
     const {current: domInnerInput} = refMoleculeAutosuggestInput
     const {current: optionsFromRef} = refsMoleculeAutosuggestOptions
     const options = optionsFromRef.map(getTarget)
 
     setTimeout(() => {
       const currentElementFocused = getCurrentElementFocused()
-      const focusOutFromOutside = ![domInnerInput, ...options].includes(
-        currentElementFocused
-      )
+      const focusOutFromOutside =
+        ![domInnerInput, ...options].includes(currentElementFocused) &&
+        !domContainer.contains(currentElementFocused)
       if (focusOutFromOutside) {
         if (isOpen) {
           closeList(ev)


### PR DESCRIPTION
## Molecule/Autosuggest
**TASK**: [26628](https://jira.scmspain.com/browse/MTR-26628)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
Up until now, our Autosuggest component was considering clicks on the scrollbar of the dropdown component as focusing out of the component, when it shouldn't actually be a focus out interaction. 

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
The current behaviour:
![bugfix_autosuggest_scroll_0](https://user-images.githubusercontent.com/18154356/79560643-39c08200-80a8-11ea-885b-21f006fa0357.gif)

The component behaviour after the fix:
![bugfix_autosuggest_scroll_1](https://user-images.githubusercontent.com/18154356/79560654-3f1dcc80-80a8-11ea-8f74-3da46fc600d1.gif)
