### PR TITLE
feat(atom/input): add autofocus attribute as a prop

### DIFF
--- a/components/atom/input/src/Input/Component/index.js
+++ b/components/atom/input/src/Input/Component/index.js
@@ -71,6 +71,7 @@ const Input = ({
   max,
   step,
   autoComplete,
+  autoFocus,
   onChange = DEFAULT_PROPS.ON_CHANGE,
   onEnter = DEFAULT_PROPS.ON_ENTER,
   onEnterKey = DEFAULT_PROPS.ON_ENTER_KEY,
@@ -128,6 +129,7 @@ const Input = ({
       min={min}
       step={step}
       autoComplete={autoComplete}
+      autoFocus={autoFocus}
       required={required}
       pattern={pattern}
       inputMode={inputMode}
@@ -174,6 +176,8 @@ Input.propTypes = {
   step: PropTypes.number,
   /** specifies whether or not an input field should have autocomplete enabled (on|off) */
   autoComplete: PropTypes.string,
+  /** native autofocus attribute */
+  autoFocus: PropTypes.bool,
   /* text, password, date or number */
   type: PropTypes.string,
   /* value of the control */

--- a/components/atom/input/src/index.js
+++ b/components/atom/input/src/index.js
@@ -109,6 +109,9 @@ AtomInput.propTypes = {
   /** specifies whether or not an input field should have autocomplete enabled (on|off) */
   autoComplete: PropTypes.string,
 
+  /** native autofocus attribute */
+  autoFocus: PropTypes.bool,
+
   /** true = error, false = success, null = neutral */
   errorState: PropTypes.bool,
 


### PR DESCRIPTION
- add `autofocus` attribute as prop

If you want to know more about `autofocus` attribute: https://developers.google.com/web/fundamentals/design-and-ux/input/forms#the_autofocus_attribute