### PR TITLE
fix(molecule/photoUploader): prevent submit form when button is clicked

### DIFF
--- a/components/molecule/photoUploader/src/InitialState.js
+++ b/components/molecule/photoUploader/src/InitialState.js
@@ -31,7 +31,12 @@ const InitialState = ({
         </span>
       </div>
       <div className={`${BASE_CLASS_NAME}-buttonState`}>
-        <Button color={buttonColor} size={buttonSize} design={buttonDesign}>
+        <Button
+          color={buttonColor}
+          design={buttonDesign}
+          isButton
+          size={buttonSize}
+        >
           {buttonText}
         </Button>
       </div>


### PR DESCRIPTION
## molecule/photoUploader
**TASK**: #1100


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
When we use the `molecule/photoUploader` component inside a form and click on File Upload button, this fire a `onSubmit` form action. So, I suggest to use `isButton` prop inside File Upload button, to prevent this.

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->

![Grabaciondepantalla2020-04-22alas8 54 50](https://user-images.githubusercontent.com/3933098/80032196-19028d00-84eb-11ea-9bcf-28ddd20cde98.gif)

