### PR TITLE
feat(molecule/selectPopover): add hide actions prop

### DIFF
--- a/components/molecule/selectPopover/src/index.js
+++ b/components/molecule/selectPopover/src/index.js
@@ -18,6 +18,7 @@ function MoleculeSelectPopover({
   acceptButtonText,
   cancelButtonText,
   children,
+  hideActions,
   iconArrowDown: IconArrowDown,
   isSelected = false,
   onAccept = () => {},
@@ -113,12 +114,14 @@ function MoleculeSelectPopover({
       {isOpen && (
         <div className={popoverClassName} ref={popoverRef}>
           <div className={`${BASE_CLASS}-popoverContent`}>{children}</div>
-          <div className={`${BASE_CLASS}-popoverActionBar`}>
-            <Button onClick={handleOnCancel} design="flat">
-              {cancelButtonText}
-            </Button>
-            <Button onClick={handleOnAccept}>{acceptButtonText}</Button>
-          </div>
+          {!hideActions && (
+            <div className={`${BASE_CLASS}-popoverActionBar`}>
+              <Button onClick={handleOnCancel} design="flat">
+                {cancelButtonText}
+              </Button>
+              <Button onClick={handleOnAccept}>{acceptButtonText}</Button>
+            </div>
+          )}
         </div>
       )}
     </div>
@@ -130,6 +133,7 @@ MoleculeSelectPopover.propTypes = {
   acceptButtonText: PropTypes.string.isRequired,
   cancelButtonText: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
+  hideActions: PropTypes.bool,
   iconArrowDown: PropTypes.node.isRequired,
   isSelected: PropTypes.bool,
   onAccept: PropTypes.func,

--- a/demo/molecule/selectPopover/demo/index.js
+++ b/demo/molecule/selectPopover/demo/index.js
@@ -23,6 +23,7 @@ const Demo = () => {
   const [size, setSize] = useState(selectPopoverSizes.MEDIUM)
   const [placement, setPlacement] = useState(selectPopoverPlacements.RIGHT)
   const [hasEvents, setHasEvents] = useState(false)
+  const [actionsAreHidden, setActionsAreHidden] = useState(false)
 
   const handleChangeItem = event => {
     const {target} = event
@@ -79,17 +80,32 @@ const Demo = () => {
         ))}
       </MoleculeSelect>
       <br />
-      <input
-        type="checkbox"
-        checked={hasEvents}
-        onChange={ev => setHasEvents(ev.target.checked)}
-      />
-      <label>With events (onOpen & onClose)</label>
+      <div>
+        <label>
+          <input
+            type="checkbox"
+            checked={hasEvents}
+            onChange={ev => setHasEvents(ev.target.checked)}
+          />
+          With events (onOpen & onClose)
+        </label>
+      </div>
+      <div>
+        <label>
+          <input
+            type="checkbox"
+            checked={actionsAreHidden}
+            onChange={ev => setActionsAreHidden(ev.target.checked)}
+          />
+          Actions are hidden
+        </label>
+      </div>
 
       <h3>Component</h3>
       <MoleculeSelectPopover
         acceptButtonText="Aceptar"
         cancelButtonText="Cancelar"
+        hideActions={actionsAreHidden}
         iconArrowDown={IconArrowDown}
         isSelected={isSelected}
         onAccept={() => setItems(unconfirmedItems)}


### PR DESCRIPTION
We have a use case where interactive elements residing inside the content are **sometimes** enough to proceed, so bottom actions of `molecule/selectPopover` are not necessary.

Proposed `hideActions` prop just prevents them from rendering if passed.