### PR TITLE
Fix/avoid breaking change because new default prop

### DIFF
--- a/components/molecule/dropdownList/src/index.js
+++ b/components/molecule/dropdownList/src/index.js
@@ -13,10 +13,11 @@ const SIZES = {
 
 const MoleculeDropdownList = ({
   children,
-  value,
-  size,
-  visible,
   onSelect,
+  alwaysRender,
+  size,
+  value,
+  visible,
   ...props
 }) => {
   const refDropdownList = useRef()
@@ -78,12 +79,12 @@ const MoleculeDropdownList = ({
     ev.stopPropagation()
   }
 
-  if (!visible) return null
+  if (!visible && !alwaysRender) return null
 
   return (
     <ul
       ref={refDropdownList}
-      tabIndex="0"
+      tabIndex={0}
       onKeyDown={handleKeyDown}
       className={classNames}
     >
@@ -95,26 +96,29 @@ const MoleculeDropdownList = ({
 MoleculeDropdownList.displayName = 'MoleculeDropdownList'
 
 MoleculeDropdownList.propTypes = {
+  /** No matter if is visible or invisible, render always the content */
+  alwaysRender: PropTypes.bool,
+
   /** Content to be included in the list (MoleculeDropdownOption) */
   children: PropTypes.node,
 
-  /** Visible or not */
-  visible: PropTypes.bool,
-
-  /** selected value */
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+  /** callback on select option */
+  onSelect: PropTypes.func,
 
   /** size (height) of the list */
   size: PropTypes.oneOf(Object.values(SIZES)),
 
-  /** callback on select option */
-  onSelect: PropTypes.func
+  /** selected value */
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+
+  /** Visible or not */
+  visible: PropTypes.bool
 }
 
 MoleculeDropdownList.defaultProps = {
-  visible: true,
-  size: SIZES.SMALL,
-  onSelect: () => {}
+  alwaysRender: true,
+  onSelect: () => {},
+  size: SIZES.SMALL
 }
 
 export default MoleculeDropdownList

--- a/test/molecule/dropdownList/index.js
+++ b/test/molecule/dropdownList/index.js
@@ -75,9 +75,41 @@ describe('molecule/dropdownList', () => {
         expect(element).to.be.not.undefined
       })
 
-      it('should NOT render the children if it is not visible', async () => {
+      it('should render the children if it is not visible', async () => {
         // Given
         const props = {
+          visible: false
+        }
+        // When
+        const {container} = setup({
+          ...testDefaultProps,
+          ...props
+        })()
+        // Then
+        expect(container).to.be.not.undefined
+        expect(container.children.length).to.be.equal(1)
+      })
+
+      it('should render the children if it is not visible but alwaysRender is enabled', async () => {
+        // Given
+        const props = {
+          alwaysRender: true,
+          visible: false
+        }
+        // When
+        const {container} = setup({
+          ...testDefaultProps,
+          ...props
+        })()
+        // Then
+        expect(container).to.be.not.undefined
+        expect(container.children.length).to.be.equal(1)
+      })
+
+      it('should NOT render the children if it is not visible and alwaysRender is disabled', async () => {
+        // Given
+        const props = {
+          alwaysRender: false,
           visible: false
         }
         // When


### PR DESCRIPTION
Previous work on this component was a breaking change: https://github.com/SUI-Components/sui-components/pull/1066/files#diff-c5c8beaee04b6354545d1ab1cbd5fdb0R115

In production now Fotocasa is showing by default the Dropdown when this should be keeping the previous behaviour of not showing nothing: 
![image](https://user-images.githubusercontent.com/1561955/80703792-bc533380-8ae3-11ea-802b-7a00cd1d79b5.png)

In this PR:
- Fix the breaking change, making `visible` a falsy value by default.
- Add a prop to keep the old behaviour (even invisible, the content is rendered).
- Add a new prop in order to be able to avoid render when invisible. If you want to avoid the component to be rendered on invisible, put `alwaysRender` to `false`.
- Add new tests to check the new and old behaviour.
