### PR TITLE
Feature/add full width prop to checkbox field

### DIFF
--- a/components/molecule/checkboxField/src/index.js
+++ b/components/molecule/checkboxField/src/index.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import cx from 'classnames'
 
 import MoleculeField from '@s-ui/react-molecule-field'
 import AtomCheckbox from '@s-ui/react-atom-checkbox'
@@ -22,7 +21,7 @@ const MoleculeCheckboxField = ({
   ...props
 }) => {
   return (
-    <div className={cx(BASE_CLASS, fullWidth && `${BASE_CLASS}--fullWidth`)}>
+    <div className={BASE_CLASS}>
       <MoleculeField
         name={id}
         label={label}
@@ -62,7 +61,7 @@ MoleculeCheckboxField.propTypes = {
   /** used as label for attribute and input element id */
   id: PropTypes.string.isRequired,
 
-  /** Makes the container full width */
+  /** Makes MoleculeField full width */
   fullWidth: PropTypes.bool,
 
   /* onChange callback */

--- a/components/molecule/checkboxField/src/index.js
+++ b/components/molecule/checkboxField/src/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import cx from 'classnames'
 
 import MoleculeField from '@s-ui/react-molecule-field'
 import AtomCheckbox from '@s-ui/react-atom-checkbox'
@@ -10,6 +11,7 @@ const MoleculeCheckboxField = ({
   id,
   label,
   nodeLabel,
+  fullWidth,
   successText,
   errorText,
   alertText,
@@ -20,11 +22,12 @@ const MoleculeCheckboxField = ({
   ...props
 }) => {
   return (
-    <div className={BASE_CLASS}>
+    <div className={cx(BASE_CLASS, fullWidth && `${BASE_CLASS}--fullWidth`)}>
       <MoleculeField
         name={id}
         label={label}
         nodeLabel={nodeLabel}
+        fullWidth={fullWidth}
         successText={successText}
         errorText={errorText}
         alertText={alertText}
@@ -58,6 +61,9 @@ MoleculeCheckboxField.propTypes = {
 
   /** used as label for attribute and input element id */
   id: PropTypes.string.isRequired,
+
+  /** Makes the container full width */
+  fullWidth: PropTypes.bool,
 
   /* onChange callback */
   onChange: PropTypes.func,

--- a/components/molecule/checkboxField/src/index.scss
+++ b/components/molecule/checkboxField/src/index.scss
@@ -3,10 +3,6 @@
 @import '~@s-ui/react-atom-checkbox/lib/index';
 
 .sui-MoleculeCheckboxField {
-  &--fullWidth {
-    width: 100%;
-  }
-
   input[type='checkbox'] {
     margin: 0;
   }

--- a/components/molecule/checkboxField/src/index.scss
+++ b/components/molecule/checkboxField/src/index.scss
@@ -3,6 +3,10 @@
 @import '~@s-ui/react-atom-checkbox/lib/index';
 
 .sui-MoleculeCheckboxField {
+  &--fullWidth {
+    width: 100%;
+  }
+
   input[type='checkbox'] {
     margin: 0;
   }

--- a/components/molecule/field/src/index.js
+++ b/components/molecule/field/src/index.js
@@ -11,6 +11,7 @@ import AtomHelpText from '@s-ui/react-atom-help-text'
 const BASE_CLASS = 'sui-MoleculeField'
 const CLASS_INLINE = `${BASE_CLASS}--inline`
 const CLASS_AUTOHIDE = `${BASE_CLASS}--autohide`
+const CLASS_FULLWIDTH = `${BASE_CLASS}--fullWidth`
 const CLASS_INLINE_REVERSE = `${CLASS_INLINE}-reverse`
 const CLASS_NODE_LABEL_CONTAINER = `${BASE_CLASS}-nodeLabelContainer`
 const CLASS_INPUT_CONTAINER = `${BASE_CLASS}-inputContainer`
@@ -60,6 +61,7 @@ const MoleculeField = ({
   alertText,
   label,
   nodeLabel,
+  fullWidth,
   useContrastLabel,
   helpText,
   name,
@@ -72,7 +74,8 @@ const MoleculeField = ({
     BASE_CLASS,
     inline && CLASS_INLINE,
     inline && reverse && CLASS_INLINE_REVERSE,
-    autoHideHelpText && CLASS_AUTOHIDE
+    autoHideHelpText && CLASS_AUTOHIDE,
+    fullWidth && CLASS_FULLWIDTH
   )
 
   let statusValidationText, typeValidationLabel, typeValidationText
@@ -145,6 +148,9 @@ MoleculeField.propTypes = {
 
   /** React node to be displayed as label of the textarea if there is not a given label value */
   nodeLabel: PropTypes.node,
+
+  /** Makes the container full width */
+  fullWidth: PropTypes.bool,
 
   /** If true it will set the label type to 'CONTRAST' */
   useContrastLabel: PropTypes.bool,

--- a/components/molecule/field/src/index.js
+++ b/components/molecule/field/src/index.js
@@ -149,7 +149,7 @@ MoleculeField.propTypes = {
   /** React node to be displayed as label of the textarea if there is not a given label value */
   nodeLabel: PropTypes.node,
 
-  /** Makes the container full width */
+  /** Makes nodeLabelContainer full width */
   fullWidth: PropTypes.bool,
 
   /** If true it will set the label type to 'CONTRAST' */

--- a/components/molecule/field/src/index.scss
+++ b/components/molecule/field/src/index.scss
@@ -32,6 +32,11 @@ $atomHelpText-class: '.sui-AtomHelpText';
     }
   }
 
+  &--fullWidth #{$base-class}-nodeLabelContainer {
+    min-width: 0; // https://css-tricks.com/flexbox-truncated-text/
+    width: 100%;
+  }
+
   &-labelContainer {
     align-items: $ai-molecule-field-label-container;
     display: flex;

--- a/demo/molecule/checkboxField/demo/index.js
+++ b/demo/molecule/checkboxField/demo/index.js
@@ -43,6 +43,20 @@ const Demo = () => {
           />
         </li>
         <li style={styleListItem}>
+          <h2>With Html Label + fullWidth</h2>
+          <MoleculeCheckboxField
+            id="info-help-text"
+            fullWidth
+            nodeLabel={
+              <div style={{display: 'flex', border: '1px dashed #000'}}>
+                <div style={{flexGrow: 1}}>I'm full width</div>
+                <button>Action</button>
+              </div>
+            }
+            onChange={(e, {name, value}) => console.log({[name]: value})}
+          />
+        </li>
+        <li style={styleListItem}>
           <h2>With Success Validation HelpText</h2>
           <MoleculeCheckboxField
             id="success-help-text"


### PR DESCRIPTION
The following spacing can only be accomplished if `fullWidth` prop is provided to `MoleculeCkeckboxField`, which depends on `MoleculeField`.

<img width="326" alt="Screenshot 2020-05-04 at 23 43 35" src="https://user-images.githubusercontent.com/4168389/81016780-5eb34400-8e61-11ea-9388-c722bfe75d41.png">
