### PR TITLE
Fix typo and correct language

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -1,15 +1,15 @@
 # Welcome to SUI Components
 
-### SUI Components is an Open-Source, high-quality library of reusable React components that empower teams to craft any product with ease.
+### SUI Components is an Open-Source, high quality library of React components that empowers teams to craft any product with ease.
 
 ## Contribute
 
 <a href="https://github.com/SUI-Components/sui-components/issues/new?template=report-a-bug---issue.md" target="_blank">Report a bug or issue</a>
 
-<a href="https://github.com/SUI-Components/sui-components/issues/new?template=improve-and-existing-component.md" target="_blank">Improve and existing component</a>
+<a href="https://github.com/SUI-Components/sui-components/issues/new?template=improve-and-existing-component.md" target="_blank">Improve an existing component</a>
 
 <a href="https://github.com/SUI-Components/sui-components/issues/new?template=propose-a-new-component.md" target="_blank">Propose a new component</a>
 
 ## Current status
 
-<a href="https://pages.github.mpi-internal.com/scmspain/sui-dashboard/" target="_blank">SUI Dashboard</a> <i>(Restricted to Adevinta members)</i>
+<a href="https://pages.github.mpi-internal.com/scmspain/sui-dashboard/" target="_blank">SUI Dashboard</a> <i>(Restricted to Adevintians)</i>


### PR DESCRIPTION
- Typo on "and" instead of "an"
- Removed the word "reusable" from components
- Removed "members"
