### PR TITLE
Fix/node label prop type

### DIFF
--- a/components/molecule/checkboxField/src/index.js
+++ b/components/molecule/checkboxField/src/index.js
@@ -54,7 +54,7 @@ MoleculeCheckboxField.propTypes = {
   label: PropTypes.string,
 
   /** React node to be displayed as label if there is not a label */
-  nodeLabel: PropTypes.node,
+  nodeLabel: PropTypes.element,
 
   /** used as label for attribute and input element id */
   id: PropTypes.string.isRequired,

--- a/components/molecule/field/src/index.js
+++ b/components/molecule/field/src/index.js
@@ -46,7 +46,7 @@ const MoleculeLabel = ({
 
 MoleculeLabel.propTypes = {
   label: PropTypes.string,
-  nodeLabel: PropTypes.node,
+  nodeLabel: PropTypes.element,
   type: PropTypes.oneOf(Object.values(AtomLabelTypes)),
   name: PropTypes.string,
   onClickLabel: PropTypes.func

--- a/components/molecule/field/src/index.js
+++ b/components/molecule/field/src/index.js
@@ -144,7 +144,7 @@ MoleculeField.propTypes = {
   label: PropTypes.string,
 
   /** React node to be displayed as label of the textarea if there is not a given label value */
-  nodeLabel: PropTypes.node,
+  nodeLabel: PropTypes.element,
 
   /** If true it will set the label type to 'CONTRAST' */
   useContrastLabel: PropTypes.bool,

--- a/components/molecule/radioButtonField/src/index.js
+++ b/components/molecule/radioButtonField/src/index.js
@@ -44,7 +44,7 @@ MoleculeRadioButtonField.propTypes = {
   label: PropTypes.string,
 
   /** React node to be displayed as label if there is not a label */
-  nodeLabel: PropTypes.node,
+  nodeLabel: PropTypes.element,
 
   /** used as label for attribute and input element id */
   id: PropTypes.string.isRequired,


### PR DESCRIPTION
Change propType of `nodeLabel` from `node` to `element`.

**Why?**
Since nodeLabel is cloned [here](https://github.com/SUI-Components/sui-components/blob/master/components/molecule/field/src/index.js#L38) the [API of React.cloneElement](https://es.reactjs.org/docs/react-api.html#cloneelement) accepts as an argument only elements and not other node subtypes (like strings, etc)


Note: PropType Node: Anything that can be rendered: numbers, strings, elements or an array
Note: All elements are nodes but not all nodes are elements