### PR TITLE
feat(atom/tooltip): add color property to make component customizable

### DIFF
--- a/components/atom/tooltip/src/config.js
+++ b/components/atom/tooltip/src/config.js
@@ -1,0 +1,54 @@
+/**
+ * Base class for the component
+ */
+export const BASE_CLASS = 'sui-AtomTooltip'
+
+/**
+ * Class for the inner element
+ */
+export const CLASS_INNER = `${BASE_CLASS}-inner`
+
+/**
+ * Class for the arrow element
+ */
+export const CLASS_ARROW = `${BASE_CLASS}-arrow`
+
+/**
+ * Class for the preffix placement
+ */
+export const PREFIX_PLACEMENT = `${BASE_CLASS}-`
+
+/**
+ * Class for the target element
+ */
+export const CLASS_TARGET = `${BASE_CLASS}-target`
+
+/**
+ * Available colors for the tooltip
+ */
+export const COLORS = [
+  'primary',
+  'accent',
+  'neutral',
+  'success',
+  'alert',
+  'error'
+]
+
+/**
+ * Available placements for the tooltip
+ */
+export const PLACEMENTS = {
+  TOP: 'top',
+  TOP_START: 'top-start',
+  TOP_END: 'top-end',
+  RIGHT: 'right',
+  RIGHT_START: 'right-start',
+  RIGHT_END: 'right-end',
+  BOTTOM: 'bottom',
+  BOTTOM_START: 'bottom-start',
+  BOTTOM_END: 'bottom-end',
+  LEFT: 'left',
+  LEFT_START: 'left-start',
+  LEFT_END: 'left-end'
+}

--- a/components/atom/tooltip/src/index.js
+++ b/components/atom/tooltip/src/index.js
@@ -294,7 +294,15 @@ AtomTooltip.propTypes = {
   color: PropTypes.oneOf(COLORS)
 }
 
-export default withIntersectionObserver(withOpenToggle(AtomTooltip))
+const ExportedAtomTooltip = withIntersectionObserver(
+  withOpenToggle(AtomTooltip)
+)
+
+ExportedAtomTooltip.COLORS = COLORS
+ExportedAtomTooltip.PLACEMENTS = PLACEMENTS
+
+AtomTooltip.COLORS = COLORS
+AtomTooltip.PLACEMENTS = PLACEMENTS
+
+export default ExportedAtomTooltip
 export {AtomTooltip as AtomTooltipBase}
-export {COLORS as atomTooltipColors}
-export {PLACEMENTS as atomTooltipPlacements}

--- a/components/atom/tooltip/src/index.js
+++ b/components/atom/tooltip/src/index.js
@@ -1,28 +1,27 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
+import cx from 'classnames'
 
 import {withIntersectionObserver, withOpenToggle} from '@s-ui/hoc'
 
-const BASE_CLASS = 'sui-AtomTooltip'
-const CLASS_INNER = `${BASE_CLASS}-inner`
-const CLASS_ARROW = `${BASE_CLASS}-arrow`
-const PREFIX_PLACEMENT = `${BASE_CLASS}-`
-const CLASS_TARGET = `${BASE_CLASS}-target`
+import {
+  BASE_CLASS,
+  CLASS_ARROW,
+  CLASS_INNER,
+  CLASS_TARGET,
+  COLORS,
+  PREFIX_PLACEMENT,
+  PLACEMENTS
+} from './config'
 
-const PLACEMENTS = {
-  TOP: 'top',
-  TOP_START: 'top-start',
-  TOP_END: 'top-end',
-  RIGHT: 'right',
-  RIGHT_START: 'right-start',
-  RIGHT_END: 'right-end',
-  BOTTOM: 'bottom',
-  BOTTOM_START: 'bottom-start',
-  BOTTOM_END: 'bottom-end',
-  LEFT: 'left',
-  LEFT_START: 'left-start',
-  LEFT_END: 'left-end'
+const createClasses = (array, sufix = '') => {
+  return array.reduce(
+    (res, key) => ({...res, [key]: `${BASE_CLASS}--${key}${sufix}`}),
+    {}
+  )
 }
+
+const COLOR_CLASSES = createClasses(COLORS, 'Color')
 
 class AtomTooltip extends Component {
   state = {Tooltip: null}
@@ -190,24 +189,27 @@ class AtomTooltip extends Component {
 
   render() {
     const {
-      hideArrow,
+      autohide,
+      color,
       content: HtmlContent,
       delay,
-      autohide,
+      hideArrow,
       placement
     } = this.props // eslint-disable-line react/prop-types
 
     const {Tooltip} = this.state
     const target = this.refTarget.current
     const restrictedProps = {
-      hideArrow,
-      target,
-      delay,
       autohide,
-      placement
+      delay,
+      hideArrow,
+      placement,
+      target
     }
     let {isVisible, isOpen} = this.props // eslint-disable-line react/prop-types
     if (!isVisible && isOpen) isOpen = false
+
+    const classNames = cx(BASE_CLASS, color && COLOR_CLASSES[color])
 
     return (
       <>
@@ -217,7 +219,7 @@ class AtomTooltip extends Component {
             {...restrictedProps}
             isOpen={isOpen}
             toggle={this.handleToggle} // eslint-disable-line
-            className={BASE_CLASS}
+            className={classNames}
             innerClassName={CLASS_INNER}
             arrowClassName={CLASS_ARROW}
             placementPrefix={PREFIX_PLACEMENT}
@@ -278,8 +280,21 @@ AtomTooltip.propTypes = {
   ]),
 
   /** Time in miliseconds for longpress duration */
-  longPressTime: PropTypes.number
+  longPressTime: PropTypes.number,
+
+  /**
+   * Color of tooltip:
+   * 'primary' (default),
+   * 'accent',
+   * 'neutral',
+   * 'success',
+   * 'alert',
+   * 'error'
+   */
+  color: PropTypes.oneOf(COLORS)
 }
 
 export default withIntersectionObserver(withOpenToggle(AtomTooltip))
-export {AtomTooltip as AtomTooltipBase, PLACEMENTS as atomTooltipPlacements}
+export {AtomTooltip as AtomTooltipBase}
+export {COLORS as atomTooltipColors}
+export {PLACEMENTS as atomTooltipPlacements}

--- a/components/atom/tooltip/src/index.js
+++ b/components/atom/tooltip/src/index.js
@@ -284,7 +284,7 @@ AtomTooltip.propTypes = {
 
   /**
    * Color of tooltip:
-   * 'primary' (default),
+   * 'primary',
    * 'accent',
    * 'neutral',
    * 'success',

--- a/components/atom/tooltip/src/index.scss
+++ b/components/atom/tooltip/src/index.scss
@@ -31,6 +31,33 @@ $class-inner: '#{$base-class}-inner';
 $class-arrow: '#{$base-class}-arrow';
 $class-target: '#{$base-class}-target';
 
+$c-atom-tooltip-colors: (
+  'primary': (
+    $c-primary,
+    $c-white
+  ),
+  'accent': (
+    $c-accent,
+    $c-white
+  ),
+  'neutral': (
+    $c-gray,
+    $c-white
+  ),
+  'success': (
+    $c-success,
+    $c-white
+  ),
+  'alert': (
+    $c-alert,
+    $c-white
+  ),
+  'error': (
+    $c-error,
+    $c-white
+  )
+) !default;
+
 #{$class-target} {
   color: $c-atom-tooltip-target;
   font-size: $fz-atom-tooltip-target;
@@ -178,6 +205,51 @@ $class-target: '#{$base-class}-target';
 
     &[x-placement^='left'] {
       @extend #{$base-class}--left;
+    }
+  }
+
+  @each $name, $pair in $c-atom-tooltip-colors {
+    $color: nth($pair, 1);
+    $color-invert: nth($pair, 2);
+
+    &--#{$name}Color {
+      #{$class-inner} {
+        background-color: $color;
+        border-color: $color;
+        color: $color-invert;
+      }
+
+      &#{$base-class}--top {
+        #{$class-arrow} {
+          &::before {
+            border-top-color: $color;
+          }
+        }
+      }
+
+      &#{$base-class}--right {
+        #{$class-arrow} {
+          &::before {
+            border-right-color: $color;
+          }
+        }
+      }
+
+      &#{$base-class}--bottom {
+        #{$class-arrow} {
+          &::before {
+            border-bottom-color: $color;
+          }
+        }
+      }
+
+      &#{$base-class}--left {
+        #{$class-arrow} {
+          &::before {
+            border-left-color: $color;
+          }
+        }
+      }
     }
   }
 }

--- a/demo/atom/tooltip/playground
+++ b/demo/atom/tooltip/playground
@@ -1,4 +1,4 @@
-/* global atomTooltipPlacements, React */
+/* global React */
 /* eslint-disable react/react-in-jsx-scope, react/jsx-no-undef */
 
 const listContainerStyles = {
@@ -185,20 +185,20 @@ return (
           {/* --- top --- */}
           <li style={listItemTop}>
             <AtomTooltip
-              placement={atomTooltipPlacements.TOP_START}
+              placement={AtomTooltip.TOP_START}
               content={() => <code>placement='top-start'</code>}
             >
               <strong tabIndex="5">top-start</strong>
             </AtomTooltip>
 
             <AtomTooltip
-              placement={atomTooltipPlacements.TOP}
+              placement={AtomTooltip.TOP}
               content={() => <code>placement='top'</code>}
             >
               <strong tabIndex="6">top</strong>
             </AtomTooltip>
             <AtomTooltip
-              placement={atomTooltipPlacements.TOP_END}
+              placement={AtomTooltip.TOP_END}
               content={() => <code>placement='top-end'</code>}
             >
               <strong tabIndex="7">top-end</strong>
@@ -208,7 +208,7 @@ return (
           {/* --- right --- */}
           <li style={listItemRight}>
             <AtomTooltip
-              placement={atomTooltipPlacements.RIGHT_START}
+              placement={AtomTooltip.RIGHT_START}
               content={() => <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit<br /><code>placement='right-start'</code></span>}
             >
               <strong tabIndex="8" style={{textAlign: 'right'}}>
@@ -216,7 +216,7 @@ return (
               </strong>
             </AtomTooltip>
             <AtomTooltip
-              placement={atomTooltipPlacements.RIGHT}
+              placement={AtomTooltip.RIGHT}
               content={() => <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit<br /><code>placement='right'</code></span>}
             >
               <strong tabIndex="9" style={{textAlign: 'right'}}>
@@ -224,7 +224,7 @@ return (
               </strong>
             </AtomTooltip>
             <AtomTooltip
-              placement={atomTooltipPlacements.RIGHT_END}
+              placement={AtomTooltip.RIGHT_END}
               content={() => <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit<br /><code>placement='right-end'</code></span>}
             >
               <strong tabIndex="10" style={{textAlign: 'right'}}>
@@ -236,19 +236,19 @@ return (
           {/* --- bottom --- */}
           <li style={listItemBottom}>
             <AtomTooltip
-              placement={atomTooltipPlacements.BOTTOM_START}
+              placement={AtomTooltip.BOTTOM_START}
               content={() => <code>placement='bottom-start'</code>}
             >
               <strong tabIndex="11">bottom-start</strong>
             </AtomTooltip>
             <AtomTooltip
-              placement={atomTooltipPlacements.BOTTOM}
+              placement={AtomTooltip.BOTTOM}
               content={() => <code>placement='bottom'</code>}
             >
               <strong tabIndex="12">bottom</strong>
             </AtomTooltip>
             <AtomTooltip
-              placement={atomTooltipPlacements.BOTTOM_END}
+              placement={AtomTooltip.BOTTOM_END}
               content={() => <code>placement='bottom-end'</code>}
             >
               <strong tabIndex="13">bottom-end</strong>
@@ -258,19 +258,19 @@ return (
           {/* --- left --- */}
           <li style={listItemLeft}>
             <AtomTooltip
-              placement={atomTooltipPlacements.LEFT_START}
+              placement={AtomTooltip.LEFT_START}
               content={() => <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit<br /><code>placement='left-start'</code></span>}
             >
               <strong tabIndex="14">left-start</strong>
             </AtomTooltip>
             <AtomTooltip
-              placement={atomTooltipPlacements.LEFT}
+              placement={AtomTooltip.LEFT}
               content={() => <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit<br /><code>placement='left'</code></span>}
             >
               <strong tabIndex="15">left</strong>
             </AtomTooltip>
             <AtomTooltip
-              placement={atomTooltipPlacements.LEFT_END}
+              placement={AtomTooltip.LEFT_END}
               content={() => <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit<br /><code>placement='left-end'</code></span>}
             >
               <strong tabIndex="16">left-end</strong>
@@ -339,7 +339,7 @@ return (
     >
       <p>
         Lorem ipsum dolor sit amet{' '}
-        <AtomTooltip placement={atomTooltipPlacements.BOTTOM_END}>
+        <AtomTooltip placement={AtomTooltip.BOTTOM_END}>
           <strong
             title="Hendrerit varius luctus scelerisque habitant ridiculus, vulputate mollis
           platea nunc sociosqu magna, suscipit montes ullamcorper vivamus. Montes
@@ -366,7 +366,7 @@ return (
       <p>
         Lorem ipsum dolor sit amet{' '}
         <AtomTooltip
-          placement={atomTooltipPlacements.RIGHT}
+          placement={AtomTooltip.RIGHT}
           content={() => (
             <>
               Hello <strong>world</strong>!

--- a/demo/atom/tooltip/playground
+++ b/demo/atom/tooltip/playground
@@ -85,6 +85,67 @@ return (
         </AtomTooltip>
       </p>
     </div>
+    <h2>Color tooltip</h2>
+    <p>
+      We can set <code>color</code> property to <code>AtomTooltip</code> in order use theme colors.
+    </p>
+    <div
+      style={{
+        border: '1px solid #CCC',
+        background: '#fff',
+        marginTop: '10px',
+        padding: '10px'
+      }}
+    >
+      <p>
+        Lorem ipsum dolor sit amet{' '}
+        <AtomTooltip color="primary">
+          <u title="This is the primary color" tabIndex="1">
+            primary color
+          </u>
+        </AtomTooltip>
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet{' '}
+        <AtomTooltip color="accent">
+          <u title="This is the accent color" tabIndex="1">
+            accent color
+          </u>
+        </AtomTooltip>
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet{' '}
+        <AtomTooltip color="neutral">
+          <u title="This is the neutral color" tabIndex="1">
+            neutral color
+          </u>
+        </AtomTooltip>
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet{' '}
+        <AtomTooltip color="success">
+          <u title="This is the success color" tabIndex="1">
+            success color
+          </u>
+        </AtomTooltip>
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet{' '}
+        <AtomTooltip color="alert">
+          <u title="This is the alert color" tabIndex="1">
+            alert color
+          </u>
+        </AtomTooltip>
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet{' '}
+        <AtomTooltip color="error">
+          <u title="This is the error color" tabIndex="1">
+            error color
+          </u>
+        </AtomTooltip>
+      </p>
+    </div>
     <h2>HTML for content of the tooltip </h2>
     <p>
       We can also set HTML as content of the Tooltip by passing a React component to the prop <code>content</code> of <code>AtomTooltip</code>.


### PR DESCRIPTION
## atom/tooltip
**TASK**:  #1120

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description, Motivation and Context
Nowadays, the `AtomTooltip` displays only in black color, and this force developers to override it by SASS variables. 

As a developer, I need an `AtomTooltip` component following the theme colors to grant me more power. 

This PR allow to `AtomTooltip` to use the theme colors (primary, accent, neutral, success, alert and error) and by default use the black color.

### Screenshots - Animations
![captured](https://user-images.githubusercontent.com/3933098/81825283-bf641000-9536-11ea-906d-91501afa72b1.gif)
