### PR TITLE
docs(atom/tooltip): add button to show/hide tooltip

### DIFF
--- a/demo/atom/tooltip/demo/index.js
+++ b/demo/atom/tooltip/demo/index.js
@@ -352,6 +352,9 @@ const Demo = () => {
               december
             </u>
           </AtomTooltipBase>
+          <button onClick={() => setIsOpen(!isOpen)}>
+            {isOpen ? 'hide tooltip' : 'open tooltip'}
+          </button>
         </p>
       </div>
     </div>

--- a/demo/atom/tooltip/demo/index.js
+++ b/demo/atom/tooltip/demo/index.js
@@ -352,10 +352,10 @@ const Demo = () => {
               december
             </u>
           </AtomTooltipBase>
-          <button onClick={() => setIsOpen(!isOpen)}>
-            {isOpen ? 'hide tooltip' : 'open tooltip'}
-          </button>
         </p>
+        <button onClick={() => setIsOpen(!isOpen)}>
+          {isOpen ? 'hide tooltip' : 'open tooltip'}
+        </button>
       </div>
     </div>
   )


### PR DESCRIPTION
## atom/tooltip

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improve documentation

### Description, Motivation and Context
This PR adds a new button to manage show/hide tooltip from outside. Upgrade previous PR #1121 

### Screenshots - Animations
![image](https://user-images.githubusercontent.com/3933098/82034902-1e449900-969f-11ea-92f0-cfef65e02697.png)


