### PR TITLE
fix(atom/tooltip): retrocompatibility between different export types

### DIFF
--- a/components/atom/tooltip/src/index.js
+++ b/components/atom/tooltip/src/index.js
@@ -294,7 +294,17 @@ AtomTooltip.propTypes = {
   color: PropTypes.oneOf(COLORS)
 }
 
-export default withIntersectionObserver(withOpenToggle(AtomTooltip))
+const ExportedAtomTooltip = withIntersectionObserver(
+  withOpenToggle(AtomTooltip)
+)
+
+ExportedAtomTooltip.COLORS = COLORS
+ExportedAtomTooltip.PLACEMENTS = PLACEMENTS
+
+AtomTooltip.COLORS = COLORS
+AtomTooltip.PLACEMENTS = PLACEMENTS
+
+export default ExportedAtomTooltip
 export {AtomTooltip as AtomTooltipBase}
 export {COLORS as atomTooltipColors}
 export {PLACEMENTS as atomTooltipPlacements}


### PR DESCRIPTION
To avoid jump to a new major release, allowing retrocompatibility between two ways of export. 