### PR TITLE
feat(atom/tooltip): support secondary color

### DIFF
--- a/components/atom/tooltip/src/config.js
+++ b/components/atom/tooltip/src/config.js
@@ -28,6 +28,7 @@ export const CLASS_TARGET = `${BASE_CLASS}-target`
  */
 export const COLORS = [
   'primary',
+  'secondary',
   'accent',
   'neutral',
   'success',

--- a/components/atom/tooltip/src/index.scss
+++ b/components/atom/tooltip/src/index.scss
@@ -36,6 +36,10 @@ $c-atom-tooltip-colors: (
     $c-primary,
     $c-white
   ),
+  'secondary': (
+    $c-secondary,
+    $c-white
+  ),
   'accent': (
     $c-accent,
     $c-white


### PR DESCRIPTION
## atom/tooltip

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

We want to allow `atom/tooltip` component to use the new `secondary` [color recently defined at `sui-theme` ](https://github.com/SUI-Components/sui-theme/pull/211).

### Screenshots - Animations

Example: 

```javascript 
<AtomTooltip color="secondary" />
```