### PR TITLE
feat(molecule/photoUploader): add preview to be returned on callback,…

### DIFF
--- a/components/molecule/photoUploader/README.md
+++ b/components/molecule/photoUploader/README.md
@@ -20,7 +20,7 @@ Every modification of the list will return a list of Blobs (jpeg encoded!) to be
 
 > `file` (Object) it's the new uploaded file.
 
-> `preview` (String) a preview url to use if you wanna preview the images outside the photoUploader component
+> `previewUrl` (String) a preview url to use if you wanna preview the images outside the photoUploader component
 
 ## Installation
 

--- a/components/molecule/photoUploader/README.md
+++ b/components/molecule/photoUploader/README.md
@@ -20,6 +20,8 @@ Every modification of the list will return a list of Blobs (jpeg encoded!) to be
 
 > `file` (Object) it's the new uploaded file.
 
+> `preview` (String) a preview url to use if you wanna preview the images outside the photoUploader component
+
 ## Installation
 
 ```sh

--- a/components/molecule/photoUploader/src/index.js
+++ b/components/molecule/photoUploader/src/index.js
@@ -110,11 +110,21 @@ const MoleculePhotoUploader = ({
   const _callbackPhotosUploaded = list => {
     if (list.length) {
       const blobsArray = list.reduce((array, currentFile) => {
-        const {blob, url, isNew, isModified, hasErrors, file} = currentFile
-        array.push({blob, url, isNew, isModified, hasErrors, file})
+        const {
+          blob,
+          url,
+          isNew,
+          isModified,
+          hasErrors,
+          file,
+          preview
+        } = currentFile
+        array.push({blob, url, isNew, isModified, hasErrors, file, preview})
         return [...array]
       }, [])
       callbackPhotosUploaded(blobsArray)
+    } else {
+      callbackPhotosUploaded([])
     }
   }
 

--- a/components/molecule/photoUploader/src/index.js
+++ b/components/molecule/photoUploader/src/index.js
@@ -108,24 +108,28 @@ const MoleculePhotoUploader = ({
   })
 
   const _callbackPhotosUploaded = list => {
-    if (list.length) {
-      const blobsArray = list.reduce((array, currentFile) => {
-        const {
-          blob,
-          url,
-          isNew,
-          isModified,
-          hasErrors,
-          file,
-          preview
-        } = currentFile
-        array.push({blob, url, isNew, isModified, hasErrors, file, preview})
-        return [...array]
-      }, [])
-      callbackPhotosUploaded(blobsArray)
-    } else {
-      callbackPhotosUploaded([])
-    }
+    const blobsArray = list.reduce((array, currentFile) => {
+      const {
+        blob,
+        url,
+        isNew,
+        isModified,
+        hasErrors,
+        file,
+        preview
+      } = currentFile
+      array.push({
+        blob,
+        url,
+        isNew,
+        isModified,
+        hasErrors,
+        file,
+        previewUrl: preview
+      })
+      return [...array]
+    }, [])
+    callbackPhotosUploaded(blobsArray)
   }
 
   const _onDropRejected = rejectedFiles => {


### PR DESCRIPTION
Add `previewUrl` as a string returned on callback, useful if you wanna preview images outside the `photoUploader` component.

Also, fix a callback bug produced when all images are deleted.
Before: when all images are deleted, no callback.
Now: when all images are deleted, an empty array is returned.