### PR TITLE
feat(atom/table): added the colspan feature

### DIFF
--- a/components/atom/table/src/index.js
+++ b/components/atom/table/src/index.js
@@ -36,14 +36,23 @@ const AtomTable = ({head, body, foot, fullWidth}) => {
         {body.map((row, index) => (
           <tr key={index}>
             {row.map((cell, index) => {
-              const {type: Element = CELL_TYPE.data} = cell
+              const {
+                type: Element = CELL_TYPE.data,
+                content = '',
+                isNowrap,
+                colspan = 1
+              } = cell
               const cellClassName = cx(`${baseClass}-cell`, {
-                [`${baseClass}-cell--noWrap`]: cell.isNowrap
+                [`${baseClass}-cell--noWrap`]: isNowrap
               })
 
               return (
-                <Element key={index} className={cellClassName}>
-                  {cell.content}
+                <Element
+                  key={index}
+                  className={cellClassName}
+                  colspan={colspan}
+                >
+                  {content}
                 </Element>
               )
             })}

--- a/demo/atom/table/playground
+++ b/demo/atom/table/playground
@@ -35,6 +35,22 @@ const contentBodyMook = [
   ],
   [
     {
+      content: 'This <td> element has a colspan 6',
+      colspan: 6
+    }
+  ],
+  [
+    {
+      content: 'This <td> element has a colspan 3',
+      colspan: 3
+    },
+    {
+      content: 'This <td> element has a colspan 3',
+      colspan: 3
+    }
+  ],
+  [
+    {
       content: 'Volkswagen Golf Edition 1.0 TSI 85kW',
       type: 'th'
     },


### PR DESCRIPTION
## In this Pull Request

- [x] Added the `colspan` feature
- [x] Refactor the cell props
- [x] Added the new feature on the demo

## Demo

<img width="799" alt="table-basic-colspan" src="https://user-images.githubusercontent.com/1307927/83140311-2b757500-a0ee-11ea-9073-c3a8789d2f55.png">
