### PR TITLE
feat(atom/table): refactor component, added cellPadding & borderBottom props

### DIFF
--- a/components/atom/table/README.md
+++ b/components/atom/table/README.md
@@ -14,8 +14,16 @@ $ npm install @s-ui/react-atom-table --save
 
 ### Basic usage
 
+#### CSS
+
+```scss
+@import '@s-ui/react-atom-table/lib/index';
+```
+
+#### Javascript
+
 ```js
-import AtomTable from '@s-ui/react-table-basic'
+import AtomTable from '@s-ui/react-atom-table'
 
 const contentHead = [
   'Versión',

--- a/components/atom/table/src/index.js
+++ b/components/atom/table/src/index.js
@@ -8,6 +8,7 @@ const CELL_TYPE = {
 }
 
 const CELL_PADDING = {
+  none: false,
   xs: 'xs',
   s: 's',
   m: 'm',
@@ -20,7 +21,7 @@ const AtomTable = ({
   body,
   foot,
   fullWidth,
-  cellPadding = false,
+  cellPadding = CELL_PADDING.none,
   borderBottom = false
 }) => {
   const hasHead = Boolean(head?.length)
@@ -29,7 +30,7 @@ const AtomTable = ({
   const tableClass = cx(`${baseClass}`, {
     [`${baseClass}--fullWidth`]: fullWidth
   })
-  const headerClass = cx(`${baseClass}-cell ${baseClass}-headerCell`, {
+  const headerClass = cx(`${baseClass}-cell`, `${baseClass}-headerCell`, {
     [`${baseClass}-cell--${cellPadding}`]: cellPadding
   })
 
@@ -39,7 +40,7 @@ const AtomTable = ({
         <thead>
           <tr>
             {head.map((element, index) => (
-              <th key={index} className={`${headerClass}`}>
+              <th key={index} className={headerClass}>
                 {element}
               </th>
             ))}
@@ -135,5 +136,5 @@ AtomTable.propTypes = {
   borderBottom: PropTypes.bool
 }
 
-export {CELL_TYPE as AtomTableCellTypes, CELL_PADDING as AtomTableCellPadding}
+export {CELL_TYPE as atomTableCellTypes, CELL_PADDING as atomTableCellPadding}
 export default AtomTable

--- a/components/atom/table/src/index.js
+++ b/components/atom/table/src/index.js
@@ -7,12 +7,30 @@ const CELL_TYPE = {
   data: 'td'
 }
 
-const AtomTable = ({head, body, foot, fullWidth}) => {
+const CELL_PADDING = {
+  xs: 'sizeXS',
+  s: 'sizeS',
+  m: 'sizeM',
+  l: 'sizeL',
+  xl: 'sizeL'
+}
+
+const AtomTable = ({
+  head,
+  body,
+  foot,
+  fullWidth,
+  cellPadding,
+  borderBottom = false
+}) => {
   const hasHead = Boolean(head?.length)
   const hasFoot = Boolean(foot?.length)
   const baseClass = 'react-AtomTable'
   const tableClass = cx(`${baseClass}`, {
     [`${baseClass}--fullWidth`]: fullWidth
+  })
+  const headerClass = cx(`${baseClass}-cell ${baseClass}-headerCell`, {
+    [`${baseClass}-cell--${cellPadding}`]: cellPadding
   })
 
   return (
@@ -21,10 +39,7 @@ const AtomTable = ({head, body, foot, fullWidth}) => {
         <thead>
           <tr>
             {head.map((element, index) => (
-              <th
-                key={index}
-                className={`${baseClass}-cell ${baseClass}-headerCell`}
-              >
+              <th key={index} className={`${headerClass}`}>
                 {element}
               </th>
             ))}
@@ -43,7 +58,9 @@ const AtomTable = ({head, body, foot, fullWidth}) => {
                 colspan = 1
               } = cell
               const cellClassName = cx(`${baseClass}-cell`, {
-                [`${baseClass}-cell--noWrap`]: isNowrap
+                [`${baseClass}-cell--noWrap`]: isNowrap,
+                [`${baseClass}-cell--${cellPadding}`]: cellPadding,
+                [`${baseClass}-cell--borderBottom`]: borderBottom
               })
 
               return (
@@ -78,19 +95,45 @@ const AtomTable = ({head, body, foot, fullWidth}) => {
 AtomTable.displayName = 'AtomTable'
 
 AtomTable.propTypes = {
+  /**
+   * Table head content
+   */
   head: PropTypes.array,
+  /**
+   * Table body content.
+   * You can define per row:
+   *  - colspan: as a number
+   *  - content: as a string or React component
+   *  - type: of cell (th,td)
+   *  - isNowrap: to add no-wrap behavior to the cell
+   */
   body: PropTypes.arrayOf(
     PropTypes.arrayOf(
       PropTypes.shape({
+        colspan: PropTypes.number,
         content: PropTypes.string.isRequired,
         type: PropTypes.oneOf(Object.values(CELL_TYPE)),
         isNowrap: PropTypes.bool
       })
     )
   ).isRequired,
+  /**
+   * Cell padding size (xs,x,m,l,xl)
+   */
+  cellPadding: PropTypes.oneOf(Object.values(CELL_PADDING)),
+  /**
+   * Table foot conntent
+   */
   foot: PropTypes.array,
-  fullWidth: PropTypes.bool
+  /**
+   * With fullWith you have a full width behavior
+   */
+  fullWidth: PropTypes.bool,
+  /**
+   * Add a default border bootom to all cells
+   */
+  borderBottom: PropTypes.bool
 }
 
-export {CELL_TYPE as AtomTableTypes}
+export {CELL_TYPE as AtomTableTypes, CELL_PADDING as AtomTableCellPadding}
 export default AtomTable

--- a/components/atom/table/src/index.js
+++ b/components/atom/table/src/index.js
@@ -8,7 +8,6 @@ const CELL_TYPE = {
 }
 
 const CELL_PADDING = {
-  none: false,
   xs: 'xs',
   s: 's',
   m: 'm',
@@ -21,17 +20,17 @@ const AtomTable = ({
   body,
   foot,
   fullWidth,
-  cellPadding = CELL_PADDING.none,
-  borderBottom = false
+  cellPadding,
+  borderBottom
 }) => {
   const hasHead = Boolean(head?.length)
   const hasFoot = Boolean(foot?.length)
   const baseClass = 'react-AtomTable'
   const tableClass = cx(`${baseClass}`, {
-    [`${baseClass}--fullWidth`]: fullWidth
+    [`${baseClass}--fullWidth`]: Boolean(fullWidth)
   })
   const headerClass = cx(`${baseClass}-cell`, `${baseClass}-headerCell`, {
-    [`${baseClass}-cell--${cellPadding}`]: cellPadding
+    [`${baseClass}-cell--${cellPadding}`]: Boolean(cellPadding)
   })
 
   return (
@@ -60,8 +59,8 @@ const AtomTable = ({
               } = cell
               const cellClassName = cx(`${baseClass}-cell`, {
                 [`${baseClass}-cell--noWrap`]: isNowrap,
-                [`${baseClass}-cell--${cellPadding}`]: cellPadding,
-                [`${baseClass}-cell--borderBottom`]: borderBottom
+                [`${baseClass}-cell--${cellPadding}`]: Boolean(cellPadding),
+                [`${baseClass}-cell--borderBottom`]: Boolean(borderBottom)
               })
 
               return (

--- a/components/atom/table/src/index.js
+++ b/components/atom/table/src/index.js
@@ -8,11 +8,11 @@ const CELL_TYPE = {
 }
 
 const CELL_PADDING = {
-  xs: 'sizeXS',
-  s: 'sizeS',
-  m: 'sizeM',
-  l: 'sizeL',
-  xl: 'sizeL'
+  xs: 'xs',
+  s: 's',
+  m: 'm',
+  l: 'l',
+  xl: 'l'
 }
 
 const AtomTable = ({
@@ -20,7 +20,7 @@ const AtomTable = ({
   body,
   foot,
   fullWidth,
-  cellPadding,
+  cellPadding = false,
   borderBottom = false
 }) => {
   const hasHead = Boolean(head?.length)
@@ -135,5 +135,5 @@ AtomTable.propTypes = {
   borderBottom: PropTypes.bool
 }
 
-export {CELL_TYPE as AtomTableTypes, CELL_PADDING as AtomTableCellPadding}
+export {CELL_TYPE as AtomTableCellTypes, CELL_PADDING as AtomTableCellPadding}
 export default AtomTable

--- a/components/atom/table/src/index.scss
+++ b/components/atom/table/src/index.scss
@@ -20,19 +20,19 @@
       border-bottom: 1px solid $c-gray-light-5;
     }
 
-    &--sizeXS {
+    &--xs {
       padding: $p-xs;
     }
-    &--sizeS {
+    &--s {
       padding: $p-s;
     }
-    &--sizeM {
+    &--m {
       padding: $p-m;
     }
-    &--sizeL {
+    &--l {
       padding: $p-l;
     }
-    &--sizeXL {
+    &--xl {
       padding: $p-xl;
     }
 

--- a/components/atom/table/src/index.scss
+++ b/components/atom/table/src/index.scss
@@ -16,8 +16,25 @@
   }
 
   &-cell {
-    border-bottom: 1px solid $c-gray-light-5;
-    padding: $p-l;
+    &--borderBottom {
+      border-bottom: 1px solid $c-gray-light-5;
+    }
+
+    &--sizeXS {
+      padding: $p-xs;
+    }
+    &--sizeS {
+      padding: $p-s;
+    }
+    &--sizeM {
+      padding: $p-m;
+    }
+    &--sizeL {
+      padding: $p-l;
+    }
+    &--sizeXL {
+      padding: $p-xl;
+    }
 
     &--noWrap {
       white-space: nowrap;

--- a/demo/atom/table/playground
+++ b/demo/atom/table/playground
@@ -1,9 +1,9 @@
 const CELL_PADDING = {
-  xs: 'sizeXS',
-  s: 'sizeS',
-  m: 'sizeM',
-  l: 'sizeL',
-  xl: 'sizeL'
+  xs: 'xs',
+  s: 's',
+  m: 'm',
+  l: 'l',
+  xl: 'xl'
 }
 
 const PriceComponent = () => (

--- a/demo/atom/table/playground
+++ b/demo/atom/table/playground
@@ -1,3 +1,11 @@
+const CELL_PADDING = {
+  xs: 'sizeXS',
+  s: 'sizeS',
+  m: 'sizeM',
+  l: 'sizeL',
+  xl: 'sizeL'
+}
+
 const PriceComponent = () => (
   <div>
     <span>Desde </span>
@@ -90,11 +98,12 @@ return (
 
     <hr/>
 
-    <h2>Version with thead, tbody and tfoot</h2>
+    <h2>Version with thead, tbody and tfoot and fullWidth behavior</h2>
     <AtomTable 
       head={contentHeadMook}
       body={contentBodyMook}
       foot={contentFootMook}
+      fullWidth
     />
     <br/>
     <hr/>
@@ -109,6 +118,18 @@ return (
 
     <h2>Version only with tbody</h2>
     <AtomTable body={contentBodyMook} />
+    <br/>
+    <hr/>
+
+    <h2>Version with thead, tbody and tfoot, and the props cellPadding and borderBottom</h2>
+    <AtomTable
+      head={contentHeadMook}
+      body={contentBodyMook}
+      foot={contentFootMook}
+      fullWidth
+      cellPadding={CELL_PADDING.l}
+      borderBottom
+    />
     <br/>
   </div>
 )


### PR DESCRIPTION
## In this Pull Request

- [x] Improve and fix README documentation
- [x] Added `cellPadding` prop to define the cell padding, now by default the cells don't have padding. 
- [x] Added `borderBottom` prop to define a default (hard coded) border bottom, now by default the cells don't have padding. 
- [x] Added props documentation to have the API documentation in SUI Studio
- [x] Added new sample in the demo

## Demo

<img width="790" alt="table" src="https://user-images.githubusercontent.com/1307927/83242747-2d4a4180-a19d-11ea-9037-5511704275e7.png">
