### PR TITLE
feat: bulk-add assets folder to .npmignore

### DIFF
--- a/components/atom/backToTop/.npmignore
+++ b/components/atom/backToTop/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/atom/card/.npmignore
+++ b/components/atom/card/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/atom/checkbox/.npmignore
+++ b/components/atom/checkbox/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/atom/helpText/.npmignore
+++ b/components/atom/helpText/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/atom/icon/.npmignore
+++ b/components/atom/icon/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/atom/image/.npmignore
+++ b/components/atom/image/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/atom/input/.npmignore
+++ b/components/atom/input/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/atom/label/.npmignore
+++ b/components/atom/label/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/atom/panel/.npmignore
+++ b/components/atom/panel/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/atom/popover/.npmignore
+++ b/components/atom/popover/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/atom/progressBar/.npmignore
+++ b/components/atom/progressBar/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/atom/radioButton/.npmignore
+++ b/components/atom/radioButton/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/atom/slider/.npmignore
+++ b/components/atom/slider/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/atom/spinner/.npmignore
+++ b/components/atom/spinner/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/atom/switch/.npmignore
+++ b/components/atom/switch/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/atom/table/.npmignore
+++ b/components/atom/table/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/atom/textarea/.npmignore
+++ b/components/atom/textarea/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/atom/toast/.npmignore
+++ b/components/atom/toast/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/atom/tooltip/.npmignore
+++ b/components/atom/tooltip/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/atom/upload/.npmignore
+++ b/components/atom/upload/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/atom/validationText/.npmignore
+++ b/components/atom/validationText/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/behavior/sticky/.npmignore
+++ b/components/behavior/sticky/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/autosuggest/.npmignore
+++ b/components/molecule/autosuggest/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/autosuggestField/.npmignore
+++ b/components/molecule/autosuggestField/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/badgeCounter/.npmignore
+++ b/components/molecule/badgeCounter/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/breadcrumb/.npmignore
+++ b/components/molecule/breadcrumb/.npmignore
@@ -1,2 +1,4 @@
 
 src
+assets
+

--- a/components/molecule/buttonGroup/.npmignore
+++ b/components/molecule/buttonGroup/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/buttonGroupField/.npmignore
+++ b/components/molecule/buttonGroupField/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/checkboxField/.npmignore
+++ b/components/molecule/checkboxField/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/collapsible/.npmignore
+++ b/components/molecule/collapsible/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/dataCounter/.npmignore
+++ b/components/molecule/dataCounter/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/dropdownList/.npmignore
+++ b/components/molecule/dropdownList/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/dropdownOption/.npmignore
+++ b/components/molecule/dropdownOption/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/field/.npmignore
+++ b/components/molecule/field/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/inputField/.npmignore
+++ b/components/molecule/inputField/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/inputTags/.npmignore
+++ b/components/molecule/inputTags/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/modal/.npmignore
+++ b/components/molecule/modal/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/notification/.npmignore
+++ b/components/molecule/notification/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/pagination/.npmignore
+++ b/components/molecule/pagination/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/photoUploader/.npmignore
+++ b/components/molecule/photoUploader/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/progressSteps/.npmignore
+++ b/components/molecule/progressSteps/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/quickAction/.npmignore
+++ b/components/molecule/quickAction/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/radioButtonField/.npmignore
+++ b/components/molecule/radioButtonField/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/radioButtonGroup/.npmignore
+++ b/components/molecule/radioButtonGroup/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/rating/.npmignore
+++ b/components/molecule/rating/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/select/.npmignore
+++ b/components/molecule/select/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/selectField/.npmignore
+++ b/components/molecule/selectField/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/selectPopover/.npmignore
+++ b/components/molecule/selectPopover/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/tabs/.npmignore
+++ b/components/molecule/tabs/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/textareaField/.npmignore
+++ b/components/molecule/textareaField/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/molecule/thumbnail/.npmignore
+++ b/components/molecule/thumbnail/.npmignore
@@ -1,1 +1,2 @@
 src
+assets

--- a/components/organism/nestedCheckboxes/.npmignore
+++ b/components/organism/nestedCheckboxes/.npmignore
@@ -1,1 +1,2 @@
 src
+assets


### PR DESCRIPTION
Ignoring static assets used for documentation thus reducing our published package size. 