### PR TITLE
feat(molecule/photoUploader): fix NotRepeatedFilter

### DIFF
--- a/components/molecule/photoUploader/src/fileTools.js
+++ b/components/molecule/photoUploader/src/fileTools.js
@@ -42,7 +42,9 @@ export const filterValidFiles = ({
         lastModified: newFileLastModified
       } = fileToFilter
       const isFileAlready = files.some(file => {
-        const {path, size, lastModified} = file.properties
+        const {url, properties} = file
+        if (url) return false
+        const {path, size, lastModified} = properties
         return (
           path === newFilePath &&
           size === newFileSize &&


### PR DESCRIPTION
Fix a bug that appears when the component checks images already uploaded to filter the repeated ones.