### PR TITLE
fix(atom/table): small fix colspan to colSpan

### DIFF
--- a/components/atom/table/src/index.js
+++ b/components/atom/table/src/index.js
@@ -67,7 +67,7 @@ const AtomTable = ({
                 <Element
                   key={index}
                   className={cellClassName}
-                  colspan={colspan}
+                  colSpan={colspan}
                 >
                   {content}
                 </Element>


### PR DESCRIPTION
Small fix for naming colspan to colSpan.

![image](https://user-images.githubusercontent.com/11008947/84044018-4629d280-a9a7-11ea-8a9b-0d0051300c38.png)
