### PR TITLE
feat(molecule/photoUploader): fix to avoid rotation based on exif, if…

### DIFF
--- a/components/molecule/photoUploader/src/photoTools.js
+++ b/components/molecule/photoUploader/src/photoTools.js
@@ -19,15 +19,24 @@ export function formatToBase64({
       reader.onload = () => {
         getExifOrientation(file)
           .then(getExifOrientationResult => {
-            switch (getExifOrientationResult) {
-              case (3, 4):
-                options.rotation = 180
-                break
-              case (5, 6):
-                options.rotation = 90
-                break
-              case (7, 8):
-                options.rotation = 270
+            /*
+             *  Since Chrome 81, image EXIF orientation is respected by default.
+             *  Latest Safari (13.1 as of now) is also working correctly.
+             */
+            const browserAutoRotates =
+              getComputedStyle(document.body).imageOrientation == 'from-image' // eslint-disable-line
+
+            if (!browserAutoRotates) {
+              switch (getExifOrientationResult) {
+                case (3, 4):
+                  options.rotation = 180
+                  break
+                case (5, 6):
+                  options.rotation = 90
+                  break
+                case (7, 8):
+                  options.rotation = 270
+              }
             }
             return resizeImage({
               base64Image: reader.result,


### PR DESCRIPTION
Fix to avoid rotation based on EXIF, if the browser has this feature by default.

Browsers affected: Since Chrome 81, and Safari 13.1 (also Chrome Mobile and iOS). Firefox with some bugs, not fully support this.

Both WebKit (iOS) and Android (Chrome) have just recently changed the default behavior of the image-orientation CSS property. While it was none before, it is now from-image. This means: Before, they ignored the EXIF data of an image by default, while they are now using it to auto-correct the image. Which breaks our own rotation auto-correction.

Has been tested on:

- [x] Chrome (desktop)
- [x] Safari (desktop and iOS device)
- [x] Firefox (desktop)
- [x] Samsung Browser (Android device)
- [x] Chrome Mobile (Android and iOS device)