### PR TITLE
feat(molecule/autosuggest): add leftIcon prop for single-selection autosuggest

### DIFF
--- a/components/molecule/autosuggest/src/components/SingleSelection.js
+++ b/components/molecule/autosuggest/src/components/SingleSelection.js
@@ -21,6 +21,7 @@ const MoleculeAutosuggestSingleSelection = ({
   size,
   innerRefInput,
   refMoleculeAutosuggest,
+  leftIcon,
   rightIcon,
   iconClear,
   placeholder,
@@ -59,6 +60,7 @@ const MoleculeAutosuggestSingleSelection = ({
         onClickClear={handleClear}
         onChange={handleChange}
         iconClear={!disabled && iconClear}
+        leftIcon={leftIcon}
         rightIcon={rightIcon}
         onClickRightIcon={handleRightClick}
         reference={innerRefInput}

--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -270,7 +270,10 @@ MoleculeAutosuggest.propTypes = {
   state: PropTypes.oneOf(Object.values(AUTOSUGGEST_STATES)),
 
   /* Button prop to be passe down to the input field */
-  rightButton: PropTypes.node
+  rightButton: PropTypes.node,
+
+  /** Left UI Icon */
+  leftIcon: PropTypes.node
 }
 
 MoleculeAutosuggest.defaultProps = {

--- a/demo/molecule/autosuggest/demo/Icons/index.js
+++ b/demo/molecule/autosuggest/demo/Icons/index.js
@@ -29,4 +29,14 @@ const IconArrowDown = () => (
   </svg>
 )
 
-export {IconClose, IconArrowDown}
+const IconSearch = () => (
+  <svg viewBox="0 0 24 24">
+    <path
+      d="M18.8,17.4l5.7,5.7c0.4,0.4,0.4,1,0,1.4s-1,0.4-1.4,0l-5.7-5.7c-1.6,1.3-3.6,2-5.7,2c-5.1,0-9.2-4.1-9.2-9.2
+s4.1-9.2,9.2-9.2s9.2,4.1,9.2,9.2C20.8,13.8,20.1,15.8,18.8,17.4z M11.7,18.8c4,0,7.2-3.2,7.2-7.2s-3.2-7.2-7.2-7.2
+s-7.2,3.2-7.2,7.2S7.7,18.8,11.7,18.8z"
+    />
+  </svg>
+)
+
+export {IconClose, IconArrowDown, IconSearch}

--- a/demo/molecule/autosuggest/demo/index.js
+++ b/demo/molecule/autosuggest/demo/index.js
@@ -16,7 +16,7 @@ import AutosuggestSingleWithAsyncOptions from './components/AutosuggestSingleFro
 
 import ComboCountries from './components/ComboCountries'
 
-import {IconClose} from './Icons'
+import {IconClose, IconSearch} from './Icons'
 import {getAsyncCountriesFromQuery} from './services'
 import './index.scss'
 
@@ -59,6 +59,7 @@ const Demo = () => (
     <div className={CLASS_DEMO_SECTION}>
       <h3>with Placeholder</h3>
       <MoleculeAutosuggestWithState
+        leftIcon={<IconSearch />}
         placeholder="Type a Country name..."
         onChange={(_, {value}) => console.log(value)}
         onEnter={() => console.log('Enter pressed')}


### PR DESCRIPTION
**What is in this PR?**
This PR adds support for passing an optional `leftIcon` prop to the `AtomInput` included inside. It already has a `rightIcon` prop but the left version was missing.


**Screenshots**
![image](https://user-images.githubusercontent.com/1534217/86615055-3a382d00-bfb4-11ea-9742-ad360b529bc2.png)

