### PR TITLE
fix(molecule/dropdownList): fix default value for list border-radius

### DIFF
--- a/components/molecule/dropdownList/src/index.scss
+++ b/components/molecule/dropdownList/src/index.scss
@@ -8,7 +8,7 @@ $bc-dropdown-list: $c-white !default;
 $bd-dropdown-list: $bdw-s solid color-variation($c-gray, 2) !default;
 $p-dropdown-list: $p-s !default;
 $bxsh-dropdown-list: $bxsh-l !default;
-$bdrs-dropdown-list: none !default;
+$bdrs-dropdown-list: 0 !default;
 $bxz-dropdown-list: inherit !default;
 
 .sui-MoleculeDropdownList {


### PR DESCRIPTION
The default value for the list border radius should be `0` and not `none`, because `border-radius` is a shorthand for the other four props (`border-top-left-radius...`) which only accept a numeric value (+ unit).

More info: https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius

