### PR TITLE
feat(molecule/autosuggest): add onFocus to Autosuggest

### DIFF
--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -279,7 +279,7 @@ MoleculeAutosuggest.propTypes = {
   /** Left UI Icon */
   leftIcon: PropTypes.node,
 
-  /** callback triggered when the user press focuses the input */
+  /** callback triggered when the user focuses on the input */
   onFocus: PropTypes.func
 }
 

--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -41,6 +41,7 @@ const MoleculeAutosuggest = ({multiselection, ...props}) => {
     onChange,
     onBlur,
     onEnter,
+    onFocus,
     isOpen,
     keysCloseList,
     keysSelection,
@@ -123,7 +124,10 @@ const MoleculeAutosuggest = ({multiselection, ...props}) => {
     }
   }
 
-  const handleFocusIn = ev => setFocus(true)
+  const handleFocusIn = ev => {
+    onFocus(ev)
+    setFocus(true)
+  }
 
   const handleFocusOut = ev => {
     ev.persist()
@@ -273,7 +277,10 @@ MoleculeAutosuggest.propTypes = {
   rightButton: PropTypes.node,
 
   /** Left UI Icon */
-  leftIcon: PropTypes.node
+  leftIcon: PropTypes.node,
+
+  /** callback triggered when the user press focuses the input */
+  onFocus: PropTypes.func,
 }
 
 MoleculeAutosuggest.defaultProps = {
@@ -282,6 +289,7 @@ MoleculeAutosuggest.defaultProps = {
   onToggle: () => {},
   onEnter: () => {},
   onSelect: () => {},
+  onFocus: () => {},
   keysSelection: [' ', 'Enter'],
   keysCloseList: ['Escape']
 }

--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -280,7 +280,7 @@ MoleculeAutosuggest.propTypes = {
   leftIcon: PropTypes.node,
 
   /** callback triggered when the user press focuses the input */
-  onFocus: PropTypes.func,
+  onFocus: PropTypes.func
 }
 
 MoleculeAutosuggest.defaultProps = {


### PR DESCRIPTION
**What does this PR do?**
We need to be able to detect when the user makes focus on the autosuggest.

**Any background context you can provide?**
We will use the onFocusHandler to activate some experiments.