### PR TITLE
fix(atom/popover): touch mobile does not close

### DIFF
--- a/components/atom/popover/src/index.js
+++ b/components/atom/popover/src/index.js
@@ -48,9 +48,11 @@ function AtomPopover({
     })
   }
 
-  const handleToggle = () => {
-    setInternalShowPopover(!internalShowPopover)
-    onClose()
+  const handleToggle = e => {
+    if (e && e.type !== 'touchstart') {
+      setInternalShowPopover(!internalShowPopover)
+      onClose()
+    }
   }
 
   return (


### PR DESCRIPTION
## Super Temporal Fix

fix mobile bug that does not close popover when clicking element that opens it.

Bug
![2](https://user-images.githubusercontent.com/32937662/87961479-0978ed00-cab6-11ea-8d34-bb35ebec90bd.gif)

It is a "magic" solution

What really happens?

The `reactstrap` popover used inside the sui component atom/popover, is not used properly. 

As a side effect, when the popover is open and the user clicks the same element that opens the popover:
-  in desktop:
    - `extendChildren` `onClick` function is executed in first place, changing `internalShowPopover` from **true** to true.
    - `handleToggle` function is executed then, changing `internalShowPopover` from true to **false**.

So it goes from **true --> false** (OK!)

- in mobile:
    - `handleToggle` function is executed in the first place, changing `internalShowPopover` from **true** to false.
    -`extendChildren` `onClick` function is executed in first place, changing `internalShowPopover` from false to **true**.

So it goes from **true --> false --> true** (WRONG!)
