### PR TITLE
Feature: dropdown option with line wrapping

### DIFF
--- a/components/molecule/dropdownOption/src/_settings.scss
+++ b/components/molecule/dropdownOption/src/_settings.scss
@@ -1,3 +1,4 @@
 $c-dropdown-option-disabled: color-variation($c-gray, 3) !default;
 $mih-dropdown-option: 40px !default;
+$h-dropdown-option: $mih-dropdown-option !default; // deprecated
 $bgc-dropdown-option-hover: $c-gray-lightest !default;

--- a/components/molecule/dropdownOption/src/_settings.scss
+++ b/components/molecule/dropdownOption/src/_settings.scss
@@ -1,3 +1,3 @@
 $c-dropdown-option-disabled: color-variation($c-gray, 3) !default;
-$h-dropdown-option: 40px !default;
+$mih-dropdown-option: 40px !default;
 $bgc-dropdown-option-hover: $c-gray-lightest !default;

--- a/components/molecule/dropdownOption/src/index.js
+++ b/components/molecule/dropdownOption/src/index.js
@@ -51,7 +51,8 @@ const MoleculeDropdownOption = ({
       `${CLASS_TEXT}--${MODIFIER_THREE_LINES}`,
     textWrap === TEXT_WRAP_STYLES.LINE_WRAP &&
       `${CLASS_TEXT}--${MODIFIER_LINE_WRAP}`,
-    textWrap === TEXT_WRAP_STYLES.NO_WRAP &&
+    ((!withTwoLinesText && !textWrap) ||
+      textWrap === TEXT_WRAP_STYLES.NO_WRAP) &&
       `${CLASS_TEXT}--${MODIFIER_NO_WRAP}`
   ])
 

--- a/components/molecule/dropdownOption/src/index.js
+++ b/components/molecule/dropdownOption/src/index.js
@@ -10,7 +10,7 @@ const BASE_CLASS = 'sui-MoleculeDropdownOption'
 const CLASS_CHECKBOX = `${BASE_CLASS}-checkbox`
 const MODIFIER_TWO_LINES = `twoLines`
 const MODIFIER_THREE_LINES = `threeLines`
-const MODIFIER_ELLIPSIS = 'ellipsis'
+const MODIFIER_NO_WRAP = 'noWrap'
 const MODIFIER_LINE_WRAP = 'lineWrap'
 const CLASS_TEXT = `${BASE_CLASS}-text`
 const CLASS_DISABLED = `${BASE_CLASS}--disabled`
@@ -18,7 +18,7 @@ const CLASS_HIGHLIGHTED = `is-highlighted`
 const CLASS_HIGHLIGHTED_MARK = `${BASE_CLASS}-mark`
 
 const TEXT_WRAP_STYLES = {
-  NO_WRAP: 'nowWrap',
+  NO_WRAP: 'noWrap',
   TWO_LINES: 'twoLines',
   THREE_LINES: 'threeLines',
   LINE_WRAP: 'lineWrap'
@@ -35,7 +35,7 @@ const MoleculeDropdownOption = ({
   innerRef,
   value,
   withTwoLinesText,
-  textWrap = TEXT_WRAP_STYLES.NO_WRAP
+  textWrap
 }) => {
   const className = cx(BASE_CLASS, {
     [CLASS_CHECKBOX]: checkbox,
@@ -52,7 +52,7 @@ const MoleculeDropdownOption = ({
     textWrap === TEXT_WRAP_STYLES.LINE_WRAP &&
       `${CLASS_TEXT}--${MODIFIER_LINE_WRAP}`,
     textWrap === TEXT_WRAP_STYLES.NO_WRAP &&
-      `${CLASS_TEXT}--${MODIFIER_ELLIPSIS}`
+      `${CLASS_TEXT}--${MODIFIER_NO_WRAP}`
   ])
 
   const {handleClick, handleKeyDown, handleFocus} = handlersFactory({

--- a/components/molecule/dropdownOption/src/index.js
+++ b/components/molecule/dropdownOption/src/index.js
@@ -10,6 +10,7 @@ const BASE_CLASS = 'sui-MoleculeDropdownOption'
 const CLASS_CHECKBOX = `${BASE_CLASS}-checkbox`
 const MODIFIER_TWO_LINES = `twoLines`
 const MODIFIER_ELLIPSIS = 'ellipsis'
+const MODIFIER_LINE_WRAP = 'lineWrap'
 const CLASS_TEXT = `${BASE_CLASS}-text`
 const CLASS_DISABLED = `${BASE_CLASS}--disabled`
 const CLASS_HIGHLIGHTED = `is-highlighted`
@@ -25,7 +26,8 @@ const MoleculeDropdownOption = ({
   onSelect,
   innerRef,
   value,
-  withTwoLinesText
+  withTwoLinesText,
+  withLineWrap
 }) => {
   const className = cx(BASE_CLASS, {
     [CLASS_CHECKBOX]: checkbox,
@@ -35,9 +37,9 @@ const MoleculeDropdownOption = ({
 
   const innerClassName = cx([
     CLASS_TEXT,
-    withTwoLinesText
-      ? `${CLASS_TEXT}--${MODIFIER_TWO_LINES}`
-      : `${CLASS_TEXT}--${MODIFIER_ELLIPSIS}`
+    withTwoLinesText && `${CLASS_TEXT}--${MODIFIER_TWO_LINES}`,
+    withLineWrap && `${CLASS_TEXT}--${MODIFIER_LINE_WRAP}`,
+    !withTwoLinesText && !withLineWrap && `${CLASS_TEXT}--${MODIFIER_ELLIPSIS}`
   ])
 
   const {handleClick, handleKeyDown, handleFocus} = handlersFactory({
@@ -138,7 +140,10 @@ MoleculeDropdownOption.propTypes = {
   innerRef: PropTypes.object,
 
   /** Text with css clamp = 2 */
-  withTwoLinesText: PropTypes.bool
+  withTwoLinesText: PropTypes.bool,
+
+  /** Multi-line text */
+  withLineWrap: PropTypes.bool
 }
 
 MoleculeDropdownOption.defaultProps = {

--- a/components/molecule/dropdownOption/src/index.js
+++ b/components/molecule/dropdownOption/src/index.js
@@ -9,12 +9,20 @@ import handlersFactory from './handlersFactory'
 const BASE_CLASS = 'sui-MoleculeDropdownOption'
 const CLASS_CHECKBOX = `${BASE_CLASS}-checkbox`
 const MODIFIER_TWO_LINES = `twoLines`
+const MODIFIER_THREE_LINES = `threeLines`
 const MODIFIER_ELLIPSIS = 'ellipsis'
 const MODIFIER_LINE_WRAP = 'lineWrap'
 const CLASS_TEXT = `${BASE_CLASS}-text`
 const CLASS_DISABLED = `${BASE_CLASS}--disabled`
 const CLASS_HIGHLIGHTED = `is-highlighted`
 const CLASS_HIGHLIGHTED_MARK = `${BASE_CLASS}-mark`
+
+const TEXT_WRAP_STYLES = {
+  NO_WRAP: 'nowWrap',
+  TWO_LINES: 'twoLines',
+  THREE_LINES: 'threeLines',
+  LINE_WRAP: 'lineWrap'
+}
 
 const MoleculeDropdownOption = ({
   children,
@@ -27,7 +35,7 @@ const MoleculeDropdownOption = ({
   innerRef,
   value,
   withTwoLinesText,
-  withLineWrap
+  textWrap = TEXT_WRAP_STYLES.NO_WRAP
 }) => {
   const className = cx(BASE_CLASS, {
     [CLASS_CHECKBOX]: checkbox,
@@ -37,9 +45,14 @@ const MoleculeDropdownOption = ({
 
   const innerClassName = cx([
     CLASS_TEXT,
-    withTwoLinesText && `${CLASS_TEXT}--${MODIFIER_TWO_LINES}`,
-    withLineWrap && `${CLASS_TEXT}--${MODIFIER_LINE_WRAP}`,
-    !withTwoLinesText && !withLineWrap && `${CLASS_TEXT}--${MODIFIER_ELLIPSIS}`
+    (withTwoLinesText || textWrap === TEXT_WRAP_STYLES.TWO_LINES) &&
+      `${CLASS_TEXT}--${MODIFIER_TWO_LINES}`,
+    textWrap === TEXT_WRAP_STYLES.THREE_LINES &&
+      `${CLASS_TEXT}--${MODIFIER_THREE_LINES}`,
+    textWrap === TEXT_WRAP_STYLES.LINE_WRAP &&
+      `${CLASS_TEXT}--${MODIFIER_LINE_WRAP}`,
+    textWrap === TEXT_WRAP_STYLES.NO_WRAP &&
+      `${CLASS_TEXT}--${MODIFIER_ELLIPSIS}`
   ])
 
   const {handleClick, handleKeyDown, handleFocus} = handlersFactory({
@@ -142,8 +155,8 @@ MoleculeDropdownOption.propTypes = {
   /** Text with css clamp = 2 */
   withTwoLinesText: PropTypes.bool,
 
-  /** Multi-line text */
-  withLineWrap: PropTypes.bool
+  /** Text wrapping options */
+  textWrap: PropTypes.oneOf(TEXT_WRAP_STYLES)
 }
 
 MoleculeDropdownOption.defaultProps = {
@@ -157,3 +170,4 @@ MoleculeDropdownOption.defaultProps = {
 
 export default MoleculeDropdownOption
 export {handlersFactory}
+export {TEXT_WRAP_STYLES as MoleculeDropdownOptionTextWrapStyles}

--- a/components/molecule/dropdownOption/src/index.scss
+++ b/components/molecule/dropdownOption/src/index.scss
@@ -9,6 +9,7 @@ $fw-molecule-dropdown-option-selected-text: $fw-bold !default;
 $fz-molecule-dropdown-option-text: inherit !default;
 $fw-molecule-dropdown-option--highlight-mark: normal !default;
 $lh-molecule-dropdown-option-line-wrap-text: $lh-m !default;
+$ln-molecule-dropdown-option-two-lines-text: $lh-molecule-dropdown-option-line-wrap-text !default; // deprecated
 $ml-molecule-dropdown-option-text: $m-s !default;
 $p-molecule-dropdown-option: $p-l !default;
 $pl-molecule-dropdown-option: $p-molecule-dropdown-option !default;

--- a/components/molecule/dropdownOption/src/index.scss
+++ b/components/molecule/dropdownOption/src/index.scss
@@ -9,14 +9,20 @@ $fw-molecule-dropdown-option-selected-text: $fw-bold !default;
 $fz-molecule-dropdown-option-text: inherit !default;
 $fw-molecule-dropdown-option--highlight-mark: normal !default;
 $ln-molecule-dropdown-option-two-lines-text: $lh-m !default;
+$ln-molecule-dropdown-option-line-wrap-text: $lh-m !default;
 $ml-molecule-dropdown-option-text: $m-s !default;
 $p-molecule-dropdown-option: $p-l !default;
+$pl-molecule-dropdown-option: $p-molecule-dropdown-option !default;
+$pr-molecule-dropdown-option: $p-molecule-dropdown-option !default;
+$pt-molecule-dropdown-option: 0 !default;
+$pb-molecule-dropdown-option: 0 !default;
 
 .sui-MoleculeDropdownOption {
   align-items: center;
   display: flex;
   min-height: $mih-dropdown-option;
-  padding: 0 $p-molecule-dropdown-option;
+  padding: $pt-molecule-dropdown-option $pr-molecule-dropdown-option
+    $pb-molecule-dropdown-option $pl-molecule-dropdown-option;
 
   &-mark {
     color: $c-molecule-dropdown-option--highlight-mark;
@@ -38,6 +44,10 @@ $p-molecule-dropdown-option: $p-l !default;
     &--ellipsis {
       text-overflow: ellipsis;
       white-space: nowrap;
+    }
+
+    &--lineWrap {
+      line-height: $ln-molecule-dropdown-option-line-wrap-text;
     }
 
     &--twoLines {

--- a/components/molecule/dropdownOption/src/index.scss
+++ b/components/molecule/dropdownOption/src/index.scss
@@ -14,7 +14,7 @@ $p-molecule-dropdown-option: $p-l !default;
 .sui-MoleculeDropdownOption {
   align-items: center;
   display: flex;
-  height: $h-dropdown-option;
+  min-height: $mih-dropdown-option;
   padding: 0 $p-molecule-dropdown-option;
 
   &-mark {

--- a/components/molecule/dropdownOption/src/index.scss
+++ b/components/molecule/dropdownOption/src/index.scss
@@ -8,8 +8,7 @@ $bg-molecule-dropdown-option-selected: none !default;
 $fw-molecule-dropdown-option-selected-text: $fw-bold !default;
 $fz-molecule-dropdown-option-text: inherit !default;
 $fw-molecule-dropdown-option--highlight-mark: normal !default;
-$ln-molecule-dropdown-option-two-lines-text: $lh-m !default;
-$ln-molecule-dropdown-option-line-wrap-text: $lh-m !default;
+$lh-molecule-dropdown-option-line-wrap-text: $lh-m !default;
 $ml-molecule-dropdown-option-text: $m-s !default;
 $p-molecule-dropdown-option: $p-l !default;
 $pl-molecule-dropdown-option: $p-molecule-dropdown-option !default;
@@ -46,22 +45,23 @@ $pb-molecule-dropdown-option: 0 !default;
       white-space: nowrap;
     }
 
-    &--lineWrap {
-      line-height: $ln-molecule-dropdown-option-line-wrap-text;
+    &--lineWrap,
+    &--twoLines,
+    &--threeLines {
+      line-height: $lh-molecule-dropdown-option-line-wrap-text;
+    }
+
+    &--twoLines,
+    &--threeLines {
+      -webkit-box-orient: vertical;
+      display: -webkit-box;
     }
 
     &--twoLines {
-      -webkit-box-orient: vertical;
       -webkit-line-clamp: 2;
-      display: -webkit-box;
-      line-height: $ln-molecule-dropdown-option-two-lines-text;
     }
-
     &--threeLines {
-      -webkit-box-orient: vertical;
       -webkit-line-clamp: 3;
-      display: -webkit-box;
-      line-height: $ln-molecule-dropdown-option-two-lines-text;
     }
   }
 

--- a/components/molecule/dropdownOption/src/index.scss
+++ b/components/molecule/dropdownOption/src/index.scss
@@ -56,6 +56,13 @@ $pb-molecule-dropdown-option: 0 !default;
       display: -webkit-box;
       line-height: $ln-molecule-dropdown-option-two-lines-text;
     }
+
+    &--threeLines {
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 3;
+      display: -webkit-box;
+      line-height: $ln-molecule-dropdown-option-two-lines-text;
+    }
   }
 
   &.is-selected:not(&-checkbox) {

--- a/components/molecule/dropdownOption/src/index.scss
+++ b/components/molecule/dropdownOption/src/index.scss
@@ -9,6 +9,7 @@ $fw-molecule-dropdown-option-selected-text: $fw-bold !default;
 $fz-molecule-dropdown-option-text: inherit !default;
 $fw-molecule-dropdown-option--highlight-mark: normal !default;
 $ln-molecule-dropdown-option-two-lines-text: $lh-m !default;
+$ml-molecule-dropdown-option-text: $m-s !default;
 $p-molecule-dropdown-option: $p-l !default;
 
 .sui-MoleculeDropdownOption {
@@ -32,7 +33,7 @@ $p-molecule-dropdown-option: $p-l !default;
   &-text {
     font-size: $fz-molecule-dropdown-option-text;
     overflow: hidden;
-    margin-left: $m-s;
+    margin-left: $ml-molecule-dropdown-option-text;
 
     &--ellipsis {
       text-overflow: ellipsis;

--- a/components/molecule/dropdownOption/src/index.scss
+++ b/components/molecule/dropdownOption/src/index.scss
@@ -40,9 +40,9 @@ $pb-molecule-dropdown-option: 0 !default;
     font-size: $fz-molecule-dropdown-option-text;
     overflow: hidden;
     margin-left: $ml-molecule-dropdown-option-text;
+    text-overflow: ellipsis;
 
-    &--ellipsis {
-      text-overflow: ellipsis;
+    &--noWrap {
       white-space: nowrap;
     }
 

--- a/demo/molecule/dropdownOption/demo/index.js
+++ b/demo/molecule/dropdownOption/demo/index.js
@@ -1,7 +1,9 @@
 /* eslint-disable react/prop-types, no-unused-vars, no-console */
 
 import React from 'react'
-import MoleculeDropdownOption from '../../../../components/molecule/dropdownOption/src'
+import MoleculeDropdownOption, {
+  MoleculeDropdownOptionTextWrapStyles
+} from '../../../../components/molecule/dropdownOption/src'
 import './index.scss'
 
 import BasicDropdownOptions from './BasicDropdownOptions'
@@ -105,18 +107,47 @@ const Demo = () => (
           eiusmod tempor incididunt ut labore et dolore magna aliqua.
         </MoleculeDropdownOption>
       </div>
-      <h3>Two lines text clamp</h3>
+      <h3>Two lines text clamp (deprecated prop withTwoLinesText)</h3>
       <div className={CLASS_DEMO_OPTION}>
         <MoleculeDropdownOption value="option-basic" withTwoLinesText>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
           eiusmod tempor incididunt ut labore et dolore magna aliqua.
         </MoleculeDropdownOption>
       </div>
+      <h3>With Two Lines Wrap</h3>
+      <div className={CLASS_DEMO_OPTION}>
+        <MoleculeDropdownOption
+          value="option-basic"
+          textWrap={MoleculeDropdownOptionTextWrapStyles.TWO_LINES}
+        >
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat.
+        </MoleculeDropdownOption>
+      </div>
+      <h3>With Three Lines Wrap</h3>
+      <div className={CLASS_DEMO_OPTION}>
+        <MoleculeDropdownOption
+          value="option-basic"
+          textWrap={MoleculeDropdownOptionTextWrapStyles.THREE_LINES}
+        >
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat.
+        </MoleculeDropdownOption>
+      </div>
       <h3>With Line Wrap</h3>
       <div className={CLASS_DEMO_OPTION}>
-        <MoleculeDropdownOption value="option-basic" withLineWrap>
+        <MoleculeDropdownOption
+          value="option-basic"
+          textWrap={MoleculeDropdownOptionTextWrapStyles.LINE_WRAP}
+        >
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat.
         </MoleculeDropdownOption>
       </div>
     </div>

--- a/demo/molecule/dropdownOption/demo/index.js
+++ b/demo/molecule/dropdownOption/demo/index.js
@@ -112,6 +112,13 @@ const Demo = () => (
           eiusmod tempor incididunt ut labore et dolore magna aliqua.
         </MoleculeDropdownOption>
       </div>
+      <h3>With Line Wrap</h3>
+      <div className={CLASS_DEMO_OPTION}>
+        <MoleculeDropdownOption value="option-basic" withLineWrap>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </MoleculeDropdownOption>
+      </div>
     </div>
   </div>
 )


### PR DESCRIPTION
- added prop `textWrap` which allows for different multi-line wrapping for lengthy options
- exported `textWrap` style options as `MoleculeDropdownOptionTextWrapStyles`: `NO_WRAP` (default), `TWO_LINES`, `THREE_LINES`, `LINE_WRAP`
- `line-height` turned into `min-line-height` for dropdown options
- added sass variables so padding can be controlled more granularly

This will now be possible:
![image](https://user-images.githubusercontent.com/18154356/88316468-2dd40400-cd18-11ea-82e9-d7005817cac0.png)

