### PR TITLE
feat(molecule/modal): fix margins

### DIFF
--- a/components/molecule/modal/src/index.scss
+++ b/components/molecule/modal/src/index.scss
@@ -197,6 +197,14 @@ body.is-MoleculeModal-open {
       height: $pb-molecule-modal-content;
     }
 
+    &:first-child {
+      margin-top: 0;
+    }
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
     &--without-indentation {
       margin: 0;
     }

--- a/components/molecule/modal/src/index.scss
+++ b/components/molecule/modal/src/index.scss
@@ -197,14 +197,6 @@ body.is-MoleculeModal-open {
       height: $pb-molecule-modal-content;
     }
 
-    :first-child {
-      margin-top: 0;
-    }
-
-    :last-child {
-      margin-bottom: 0;
-    }
-
     &--without-indentation {
       margin: 0;
     }


### PR DESCRIPTION
Fix margins that breaks styles. The modal shouldn't add styles to the content of the modal, since the developer that is using the modal should add the styles needed