### PR TITLE
Feat/autosuggest add input mode and type props

### DIFF
--- a/components/atom/input/src/index.js
+++ b/components/atom/input/src/index.js
@@ -143,4 +143,4 @@ AtomInput.propTypes = {
 AtomInput.displayName = 'AtomInput'
 
 export default AtomInput
-export {inputSizes, inputStates}
+export {inputSizes, inputStates, TYPES as inputTypes}

--- a/components/molecule/autosuggest/src/components/MultipleSelection.js
+++ b/components/molecule/autosuggest/src/components/MultipleSelection.js
@@ -26,7 +26,9 @@ const MoleculeAutosuggestFieldMultiSelection = ({
   disabled,
   required,
   tabIndex,
-  autoComplete
+  autoComplete,
+  inputMode,
+  type
 }) => {
   const MoleculeInputTagsRef = useRef()
 
@@ -88,6 +90,8 @@ const MoleculeAutosuggestFieldMultiSelection = ({
         required={required}
         tabIndex={tabIndex}
         autoComplete={autoComplete}
+        inputMode={inputMode}
+        type={type}
       />
       <MoleculeDropdownList
         checkbox

--- a/components/molecule/autosuggest/src/components/SingleSelection.js
+++ b/components/molecule/autosuggest/src/components/SingleSelection.js
@@ -29,7 +29,9 @@ const MoleculeAutosuggestSingleSelection = ({
   required,
   tabIndex,
   autoComplete,
-  rightButton
+  rightButton,
+  inputMode,
+  type
 }) => {
   const handleSelection = (ev, {value}) => {
     onChange(ev, {value})
@@ -71,6 +73,8 @@ const MoleculeAutosuggestSingleSelection = ({
         tabIndex={tabIndex}
         autoComplete={autoComplete}
         button={rightButton}
+        inputMode={inputMode}
+        type={type}
       />
       {value && (
         <MoleculeDropdownList

--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import cx from 'classnames'
 
 import {moleculeDropdownListSizes as SIZES} from '@s-ui/react-molecule-dropdown-list'
+import {inputTypes} from '@s-ui/react-atom-input'
 
 import MoleculeAutosuggestSingleSelection from './components/SingleSelection'
 import MoleculeAutosuggestMultipleSelection from './components/MultipleSelection'
@@ -280,7 +281,13 @@ MoleculeAutosuggest.propTypes = {
   leftIcon: PropTypes.node,
 
   /** callback triggered when the user focuses on the input */
-  onFocus: PropTypes.func
+  onFocus: PropTypes.func,
+
+  /** To select input keyboard mode on mobile. It can be 'numeric', 'decimal', 'email', etc */
+  inputMode: PropTypes.string,
+
+  /** native input types (text, date, ...), 'sui-password' */
+  type: PropTypes.oneOf(Object.values(inputTypes))
 }
 
 MoleculeAutosuggest.defaultProps = {


### PR DESCRIPTION
- export `inputTypes` from `atom/input`
- add new props: `inputMode` [more info](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode) and `type` in `molecule/autosuggest` component (already defined in `atom/input` component).