### PR TITLE
feat(molecule/accordion): add default sass variable on molecule accor…

### DIFF
--- a/components/molecule/accordion/src/_settings.scss
+++ b/components/molecule/accordion/src/_settings.scss
@@ -1,5 +1,6 @@
 $bd-accordion-tab-container: $bdw-s $c-gray-lightest groove !default;
 $bd-accordion-tab-container-none: 0 $c-gray-lightest groove !default;
+$bdrs-accordion-tab: $bdrs-none !default;
 $bdrs-accordion-tab-scrollbar-thumb: $bdrs-l !default;
 $bdw-accordion-tab-scrollbar: $bdw-xl !default;
 $bgc-accordion-tab-container: $c-white !default;

--- a/components/molecule/accordion/src/index.scss
+++ b/components/molecule/accordion/src/index.scss
@@ -13,6 +13,7 @@
   padding: 0;
   position: relative;
   width: 100%;
+  border-radius: $bdrs-accordion-tab;
 
   &:last-child {
     border-bottom: $bd-accordion-tab-container;
@@ -99,6 +100,7 @@
     background-color: $bgc-accordion-tab-container;
     position: relative;
     width: 100%;
+    border-radius: $bdrs-accordion-tab;
   }
 
   &Icon {


### PR DESCRIPTION
- add sass variable to molecule accordion to be able to display rounded borders on tabs.
Default is the same behavior as actual, no rounded borders