### PR TITLE
docs(examples): standardise all H1 and wrappers across all demos

### DIFF
--- a/demo/atom/actionButton/playground
+++ b/demo/atom/actionButton/playground
@@ -46,8 +46,8 @@ const ButtonsColorsRow = props => (
 
 return (
   <div>
-
-    <Title>Colors</Title>
+    <h1>Action Button</h1>
+    <h2>Colours</h2>
     <ButtonsColorsTable>
       <ButtonsColorsRow style="filledNegative" />
       <ButtonsColorsRow style="filledPositive" />

--- a/demo/atom/badge/playground
+++ b/demo/atom/badge/playground
@@ -10,6 +10,7 @@ const stylesBlock = {
 
 return (
   <div>
+    <h1>Badge</h1>
     <h2>With Container</h2>
     <h3>Small</h3>
     <p style={stylesBlock}>

--- a/demo/atom/button/playground
+++ b/demo/atom/button/playground
@@ -136,7 +136,8 @@ const ButtonsSocialRow = props => (
 
 return (
   <div>
-    <Title>Colors</Title>
+    <h1>Button</h1>
+    <h2>Colours</h2>
     <ButtonsColorsTable>
       <ButtonsColorsRow design="solid" />
       <ButtonsColorsRow design="outline" />

--- a/demo/atom/card/demo/index.js
+++ b/demo/atom/card/demo/index.js
@@ -32,126 +32,133 @@ const CarInfoLinks = () => (
 
 const Demo = () => {
   return (
-    <div>
-      <h1>AtomCard</h1>
-      <div className="DemoAtomCard-section">
+    <div className="sui-StudioPreview">
+      <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+        <h1>Card</h1>
+        <div className="DemoAtomCard-section">
+          <h2>
+            Basic with <code>href</code>
+          </h2>
+          <AtomCard
+            tabIndex="1"
+            media={CarImage}
+            content={CarInfo}
+            href={urlTarget}
+          />
+        </div>
+        <div className="DemoAtomCard-section">
+          <h2>
+            Basic without <code>href</code>
+          </h2>
+          <AtomCard tabIndex="2" media={CarImage} content={CarInfoLinks} />
+        </div>
+        <div className="DemoAtomCard-section">
+          <h2>
+            Basic with <code>href</code> and secondary actions
+          </h2>
+          <AtomCard
+            tabIndex="2"
+            media={CarImage}
+            href={urlTarget}
+            content={CarInfoLinks}
+          />
+        </div>
+        <div className="DemoAtomCard-section">
+          <h2>
+            Basic with <code>highlight</code>
+          </h2>
+          <AtomCard
+            tabIndex="3"
+            media={CarImage}
+            content={CarInfo}
+            href={urlTarget}
+            highlight
+          />
+        </div>
+        <div className="DemoAtomCard-section DemoAtomCard-section--vertical">
+          <h2>Vertical</h2>
+          <AtomCard
+            tabIndex="4"
+            media={CarImage}
+            content={CarInfo}
+            href={urlTarget}
+            vertical
+          />
+        </div>
         <h2>
-          Basic with <code>href</code>
+          Responsive using <code>@s-ui/react-layout-media-query</code>
         </h2>
-        <AtomCard
-          tabIndex="1"
-          media={CarImage}
-          content={CarInfo}
-          href={urlTarget}
-        />
-      </div>
-      <div className="DemoAtomCard-section">
-        <h2>
-          Basic without <code>href</code>
-        </h2>
-        <AtomCard tabIndex="2" media={CarImage} content={CarInfoLinks} />
-      </div>
-      <div className="DemoAtomCard-section">
-        <h2>
-          Basic with <code>href</code> and secondary actions
-        </h2>
-        <AtomCard
-          tabIndex="2"
-          media={CarImage}
-          href={urlTarget}
-          content={CarInfoLinks}
-        />
-      </div>
-      <div className="DemoAtomCard-section">
-        <h2>
-          Basic with <code>highlight</code>
-        </h2>
-        <AtomCard
-          tabIndex="3"
-          media={CarImage}
-          content={CarInfo}
-          href={urlTarget}
-          highlight
-        />
-      </div>
-      <div className="DemoAtomCard-section DemoAtomCard-section--vertical">
-        <h2>Vertical</h2>
-        <AtomCard
-          tabIndex="4"
-          media={CarImage}
-          content={CarInfo}
-          href={urlTarget}
-          vertical
-        />
-      </div>
-      <h2>
-        Responsive using <code>@s-ui/react-layout-media-query</code>
-      </h2>
-      <div className="DemoAtomCard-section DemoAtomCard-section--responsive">
-        <h2>From Horizontal to Vertical Responsive</h2>
-        <LayoutMediaQuery>
-          {({S}) => {
-            if (S)
+        <div className="DemoAtomCard-section DemoAtomCard-section--responsive">
+          <h2>From Horizontal to Vertical Responsive</h2>
+          <LayoutMediaQuery>
+            {({S}) => {
+              if (S)
+                return (
+                  <AtomCard
+                    tabIndex="5"
+                    media={CarImage}
+                    content={CarInfo}
+                    href={urlTarget}
+                  />
+                )
               return (
                 <AtomCard
                   tabIndex="5"
                   media={CarImage}
                   content={CarInfo}
                   href={urlTarget}
+                  vertical
                 />
               )
-            return (
-              <AtomCard
-                tabIndex="5"
-                media={CarImage}
-                content={CarInfo}
-                href={urlTarget}
-                vertical
-              />
-            )
-          }}
-        </LayoutMediaQuery>
-      </div>
-      <div className="DemoAtomCard-section DemoAtomCard-section--responsive-vertical">
-        <h2>From Vertical to Horizontal Responsive</h2>
-        <LayoutMediaQuery>
-          {({S}) => {
-            if (S)
+            }}
+          </LayoutMediaQuery>
+        </div>
+        <div className="DemoAtomCard-section DemoAtomCard-section--responsive-vertical">
+          <h2>From Vertical to Horizontal Responsive</h2>
+          <LayoutMediaQuery>
+            {({S}) => {
+              if (S)
+                return (
+                  <AtomCard
+                    tabIndex="5"
+                    media={CarImage}
+                    content={CarInfo}
+                    href={urlTarget}
+                  />
+                )
               return (
                 <AtomCard
                   tabIndex="5"
                   media={CarImage}
                   content={CarInfo}
                   href={urlTarget}
+                  vertical
                 />
               )
-            return (
-              <AtomCard
-                tabIndex="5"
-                media={CarImage}
-                content={CarInfo}
-                href={urlTarget}
-                vertical
-              />
-            )
-          }}
-        </LayoutMediaQuery>
-      </div>
-      <h2>Responsive using MediaQueries</h2>
-      <div className="DemoAtomCard-section DemoAtomCard-section--big">
-        <h2>From Vertical (mobile) to Horizontal (desktop)</h2>
-        <AtomCard
-          tabIndex="6"
-          media={CarImage}
-          content={CarInfo}
-          href={urlTarget}
-          responsive
-        />
-      </div>
-      <h2>Basic without image</h2>
-      <div className="DemoAtomCard-section DemoAtomCard-section--big">
-        <h2>From Vertical (mobile) to Horizontal (desktop)</h2>
-        <AtomCard tabIndex="6" content={CarInfo} href={urlTarget} responsive />
+            }}
+          </LayoutMediaQuery>
+        </div>
+        <h2>Responsive using MediaQueries</h2>
+        <div className="DemoAtomCard-section DemoAtomCard-section--big">
+          <h2>From Vertical (mobile) to Horizontal (desktop)</h2>
+          <AtomCard
+            tabIndex="6"
+            media={CarImage}
+            content={CarInfo}
+            href={urlTarget}
+            responsive
+          />
+        </div>
+        <h2>Basic without image</h2>
+        <div className="DemoAtomCard-section DemoAtomCard-section--big">
+          <h2>From Vertical (mobile) to Horizontal (desktop)</h2>
+          <AtomCard
+            tabIndex="6"
+            content={CarInfo}
+            href={urlTarget}
+            responsive
+          />
+        </div>
       </div>
     </div>
   )

--- a/demo/atom/checkbox/demo/index.js
+++ b/demo/atom/checkbox/demo/index.js
@@ -35,74 +35,77 @@ const Demo = () => {
   const [isNative, setIsNative] = useState(false)
 
   return (
-    <div className={BASE_CLASS_DEMO}>
-      <AtomSwitch
-        label="Choose Design"
-        labelLeft="Custom"
-        labelRight="Native"
-        onToggle={setIsNative}
-      />
-      <h1>AtomCheckbox</h1>
-      <h2>Use Cases</h2>
-      <div className={CLASS_SECTION}>
-        <h3>Checked with onChange method</h3>
+    <div className="sui-StudioPreview">
+      <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+        <h1>Checkbox</h1>
+        <AtomSwitch
+          label="Choose Design"
+          labelLeft="Custom"
+          labelRight="Native"
+          onToggle={setIsNative}
+        />
+
+        <h2>Use Cases</h2>
+        <div className={CLASS_SECTION}>
+          <h3>Checked with onChange method</h3>
+          <AtomCheckbox
+            isNative={isNative}
+            id="checkbox1"
+            checked={checkboxValue}
+            checkedIcon={IconCheck}
+            onChange={() => setCheckboxValue(!checkboxValue)}
+          />
+        </div>
+        <div className={CLASS_SECTION}>
+          <h3>Intermediate</h3>
+          <AtomCheckbox
+            isNative={isNative}
+            id="checkbox2"
+            checkedIcon={IconCheck}
+            intermediate
+            intermediateIcon={IconHalfCheck}
+            onChange={noop}
+          />
+        </div>
+        <div className={CLASS_SECTION}>
+          <h3>Unchecked</h3>
+          <AtomCheckbox
+            isNative={isNative}
+            id="checkbox3"
+            checkedIcon={IconCheck}
+            onChange={noop}
+          />
+        </div>
+
+        <h2>Disabled</h2>
+        <h3>Checked</h3>
         <AtomCheckbox
           isNative={isNative}
-          id="checkbox1"
-          checked={checkboxValue}
+          id="checkbox4"
+          disabled
+          checked
           checkedIcon={IconCheck}
-          onChange={() => setCheckboxValue(!checkboxValue)}
+          onChange={noop}
         />
-      </div>
-      <div className={CLASS_SECTION}>
         <h3>Intermediate</h3>
         <AtomCheckbox
           isNative={isNative}
-          id="checkbox2"
-          checkedIcon={IconCheck}
+          id="checkbox5"
+          disabled
           intermediate
+          checkedIcon={IconCheck}
           intermediateIcon={IconHalfCheck}
           onChange={noop}
         />
-      </div>
-      <div className={CLASS_SECTION}>
         <h3>Unchecked</h3>
         <AtomCheckbox
           isNative={isNative}
-          id="checkbox3"
+          id="checkbox5"
+          disabled
           checkedIcon={IconCheck}
           onChange={noop}
         />
       </div>
-
-      <h2>Disabled</h2>
-      <h3>Checked</h3>
-      <AtomCheckbox
-        isNative={isNative}
-        id="checkbox4"
-        disabled
-        checked
-        checkedIcon={IconCheck}
-        onChange={noop}
-      />
-      <h3>Intermediate</h3>
-      <AtomCheckbox
-        isNative={isNative}
-        id="checkbox5"
-        disabled
-        intermediate
-        checkedIcon={IconCheck}
-        intermediateIcon={IconHalfCheck}
-        onChange={noop}
-      />
-      <h3>Unchecked</h3>
-      <AtomCheckbox
-        isNative={isNative}
-        id="checkbox5"
-        disabled
-        checkedIcon={IconCheck}
-        onChange={noop}
-      />
     </div>
   )
 }

--- a/demo/atom/helpText/playground
+++ b/demo/atom/helpText/playground
@@ -10,6 +10,7 @@ const input = {
 }
 return (
   <div>
+    <h1>Help Text</h1>
     <input style={input}
       type='text'
     />

--- a/demo/atom/icon/demo/index.js
+++ b/demo/atom/icon/demo/index.js
@@ -59,215 +59,227 @@ export default function() {
   const [selectedIcon, setIcon] = useState(ICONS[0])
 
   return (
-    <div className="DemoAtomIcon">
-      <ul className="DemoAtomIcon-select">
-        <li className="DemoAtomIcon-option" style={{minWidth: '120px'}}>
-          Select your icon:
-        </li>
-        {ICONS.map(({name, Component}, idx) => (
-          <li
-            key={name}
-            className={`DemoAtomIcon-option ${
-              ICONS[idx].name === selectedIcon.name ? 'is-selected' : ''
-            }`}
-            onClick={() => setIcon(ICONS[idx])}
-          >
-            <AtomIcon size="large">{Component}</AtomIcon>
-            <strong>{name}</strong>
+    <div className="sui-StudioPreview">
+      <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+        <h1>Icon</h1>
+        <ul className="DemoAtomIcon-select">
+          <li className="DemoAtomIcon-option" style={{minWidth: '120px'}}>
+            Select your icon:
           </li>
-        ))}
-      </ul>
-      <h2 className="DemoAtomIcon-title">
-        <code>color</code> and <code>size</code> props matrix
-      </h2>
-      <table
-        className="sui-StudioTable DemoAtomIcon-table"
-        width="auto"
-        cellPadding="8"
-        cellSpacing="0"
-      >
-        <tbody>
-          <tr>
-            <td />
-            {Object.keys(ATOM_ICON_COLORS).map(color => {
+          {ICONS.map(({name, Component}, idx) => (
+            <li
+              key={name}
+              className={`DemoAtomIcon-option ${
+                ICONS[idx].name === selectedIcon.name ? 'is-selected' : ''
+              }`}
+              onClick={() => setIcon(ICONS[idx])}
+            >
+              <AtomIcon size="large">{Component}</AtomIcon>
+              <strong>{name}</strong>
+            </li>
+          ))}
+        </ul>
+        <h2 className="DemoAtomIcon-title">
+          <code>color</code> and <code>size</code> props matrix
+        </h2>
+        <table
+          className="sui-StudioTable DemoAtomIcon-table"
+          width="auto"
+          cellPadding="8"
+          cellSpacing="0"
+        >
+          <tbody>
+            <tr>
+              <td />
+              {Object.keys(ATOM_ICON_COLORS).map(color => {
+                return (
+                  <td key={color}>
+                    <h4 className="DemoAtomIcon-tableLabel">{color}</h4>
+                  </td>
+                )
+              })}
+            </tr>
+            {Object.keys(ATOM_ICON_SIZES).map(size => {
               return (
-                <td key={color}>
-                  <h4 className="DemoAtomIcon-tableLabel">{color}</h4>
-                </td>
+                <tr key={size}>
+                  <td key="label">
+                    <h4 className="DemoAtomIcon-tableLabel">{size}</h4>
+                  </td>
+                  {Object.keys(ATOM_ICON_COLORS).map(color => {
+                    return (
+                      <td key={color}>
+                        <AtomIcon color={color} size={size}>
+                          {selectedIcon.Component}
+                        </AtomIcon>
+                      </td>
+                    )
+                  })}
+                </tr>
               )
             })}
-          </tr>
-          {Object.keys(ATOM_ICON_SIZES).map(size => {
-            return (
-              <tr key={size}>
-                <td key="label">
-                  <h4 className="DemoAtomIcon-tableLabel">{size}</h4>
-                </td>
-                {Object.keys(ATOM_ICON_COLORS).map(color => {
-                  return (
-                    <td key={color}>
-                      <AtomIcon color={color} size={size}>
-                        {selectedIcon.Component}
-                      </AtomIcon>
-                    </td>
-                  )
-                })}
-              </tr>
-            )
-          })}
-        </tbody>
-      </table>
-      <h2 className="DemoAtomIcon-title">
-        Using <code>currentColor</code> color type
-      </h2>
-      <p>
-        <code>currentColor</code> value for <code>color</code> prop is the
-        default value and will inherit the color from the inmediate nearest
-        parent value of color property in CSS. This way you could safely make
-        your icon get a different color with endless posibilities to match your
-        designs without having to care about variables on the SUI components.
-      </p>
-      <section>
-        {CURRENT_COLOR_EXAMPLES.map(color => (
-          <p className="DemoAtomIcon-colorExample" key={color} style={{color}}>
-            <AtomIcon color="currentColor" size={ATOM_ICON_SIZES.extraLarge}>
-              {selectedIcon.Component}
-            </AtomIcon>
-            <code>The icon inherits the color of this text {color}</code>
-          </p>
-        ))}
-      </section>
+          </tbody>
+        </table>
+        <h2 className="DemoAtomIcon-title">
+          Using <code>currentColor</code> color type
+        </h2>
+        <p>
+          <code>currentColor</code> value for <code>color</code> prop is the
+          default value and will inherit the color from the inmediate nearest
+          parent value of color property in CSS. This way you could safely make
+          your icon get a different color with endless posibilities to match
+          your designs without having to care about variables on the SUI
+          components.
+        </p>
+        <section>
+          {CURRENT_COLOR_EXAMPLES.map(color => (
+            <p
+              className="DemoAtomIcon-colorExample"
+              key={color}
+              style={{color}}
+            >
+              <AtomIcon color="currentColor" size={ATOM_ICON_SIZES.extraLarge}>
+                {selectedIcon.Component}
+              </AtomIcon>
+              <code>The icon inherits the color of this text {color}</code>
+            </p>
+          ))}
+        </section>
 
-      <h2 className="DemoAtomIcon-title">
-        Using with the <code>AtomButton</code>
-      </h2>
-      <p>
-        While the <code>AtomButton</code> component was prepared without the{' '}
-        <code>AtomIcon</code> in mind, and thus strong styling is forced inside
-        the button, still you could safely use it.
-      </p>
-      <p>
-        <strong>
-          Using the <code>AtomButton</code> with only the icon:
-        </strong>{' '}
-        Pass the AtomIcon as <code>leftIcon</code> or <code>rightIcon</code> of
-        the <code>AtomButton</code>.
-      </p>
-      <section className="DemoAtomIcon-grid DemoAtomIcon-grid--small">
-        <AtomButton leftIcon={<AtomIcon>{selectedIcon.Component}</AtomIcon>} />
-      </section>
-      <p>
-        <strong>
-          Using the <code>AtomButton</code> with text:
-        </strong>{' '}
-        Use the prop <code>leftIcon</code> or <code>rightIcon</code> in order to
-        show the icon on the desired placement.
-      </p>
-      <p>
-        <strong>
-          <code>leftIcon</code>
-        </strong>
-      </p>
-      <section className="DemoAtomIcon-grid">
-        <AtomButton leftIcon={<AtomIcon>{selectedIcon.Component}</AtomIcon>}>
-          Left icon
-        </AtomButton>
-      </section>
-      <p>
-        <strong>
-          <code>rightIcon</code>
-        </strong>
-      </p>
-      <section className="DemoAtomIcon-grid">
-        <AtomButton rightIcon={<AtomIcon>{selectedIcon.Component}</AtomIcon>}>
-          Right icon
-        </AtomButton>
-      </section>
-      <p>
-        <strong>
-          Size will be automatically detected from <code>AtomButton</code>
-        </strong>{' '}
-        so you don't have to worry. Even if you try to use an incorrect size,
-        the size will be used correctly. Also, this will happen with the{' '}
-        <code>color</code> prop, so, if you try to use a different color with
-        the <code>AtomButton</code> it will be corrected for you.
-      </p>
-      <section className="DemoAtomIcon-grid">
-        <AtomButton
-          size="large"
-          rightIcon={<AtomIcon>{selectedIcon.Component}</AtomIcon>}
-        >
-          Large icon
-        </AtomButton>
+        <h2 className="DemoAtomIcon-title">
+          Using with the <code>AtomButton</code>
+        </h2>
+        <p>
+          While the <code>AtomButton</code> component was prepared without the{' '}
+          <code>AtomIcon</code> in mind, and thus strong styling is forced
+          inside the button, still you could safely use it.
+        </p>
+        <p>
+          <strong>
+            Using the <code>AtomButton</code> with only the icon:
+          </strong>{' '}
+          Pass the AtomIcon as <code>leftIcon</code> or <code>rightIcon</code>{' '}
+          of the <code>AtomButton</code>.
+        </p>
+        <section className="DemoAtomIcon-grid DemoAtomIcon-grid--small">
+          <AtomButton
+            leftIcon={<AtomIcon>{selectedIcon.Component}</AtomIcon>}
+          />
+        </section>
+        <p>
+          <strong>
+            Using the <code>AtomButton</code> with text:
+          </strong>{' '}
+          Use the prop <code>leftIcon</code> or <code>rightIcon</code> in order
+          to show the icon on the desired placement.
+        </p>
+        <p>
+          <strong>
+            <code>leftIcon</code>
+          </strong>
+        </p>
+        <section className="DemoAtomIcon-grid">
+          <AtomButton leftIcon={<AtomIcon>{selectedIcon.Component}</AtomIcon>}>
+            Left icon
+          </AtomButton>
+        </section>
+        <p>
+          <strong>
+            <code>rightIcon</code>
+          </strong>
+        </p>
+        <section className="DemoAtomIcon-grid">
+          <AtomButton rightIcon={<AtomIcon>{selectedIcon.Component}</AtomIcon>}>
+            Right icon
+          </AtomButton>
+        </section>
+        <p>
+          <strong>
+            Size will be automatically detected from <code>AtomButton</code>
+          </strong>{' '}
+          so you don't have to worry. Even if you try to use an incorrect size,
+          the size will be used correctly. Also, this will happen with the{' '}
+          <code>color</code> prop, so, if you try to use a different color with
+          the <code>AtomButton</code> it will be corrected for you.
+        </p>
+        <section className="DemoAtomIcon-grid">
+          <AtomButton
+            size="large"
+            rightIcon={<AtomIcon>{selectedIcon.Component}</AtomIcon>}
+          >
+            Large icon
+          </AtomButton>
 
-        <AtomButton rightIcon={<AtomIcon>{selectedIcon.Component}</AtomIcon>}>
-          Small icon
-        </AtomButton>
+          <AtomButton rightIcon={<AtomIcon>{selectedIcon.Component}</AtomIcon>}>
+            Small icon
+          </AtomButton>
 
-        <AtomButton
-          size="small"
-          rightIcon={<AtomIcon>{selectedIcon.Component}</AtomIcon>}
-        >
-          Small icon
-        </AtomButton>
+          <AtomButton
+            size="small"
+            rightIcon={<AtomIcon>{selectedIcon.Component}</AtomIcon>}
+          >
+            Small icon
+          </AtomButton>
 
-        <AtomButton
-          size="small"
-          rightIcon={<AtomIcon size="large">{selectedIcon.Component}</AtomIcon>}
-        >
-          Try large icon
-        </AtomButton>
-      </section>
-      <h2 className="DemoAtomIcon-title">Lazy icons</h2>
-      <p>
-        By default, icons will be rendered <strong>eagerly</strong>. That means
-        that they will be rendered on the server and, on the client, they will
-        be hydrated asap. You could use the prop <code>render</code> and use the{' '}
-        <code>lazy</code> value so the icons are rendered only when near the
-        viewport. That could be useful when icons are used on a footer or on
-        large lists.
-      </p>
-      <section className="DemoAtomIcon-grid">
-        <AtomButton
-          size="large"
-          rightIcon={
-            <AtomIcon render="lazy">{selectedIcon.Component}</AtomIcon>
-          }
-        >
-          Large icon
-        </AtomButton>
+          <AtomButton
+            size="small"
+            rightIcon={
+              <AtomIcon size="large">{selectedIcon.Component}</AtomIcon>
+            }
+          >
+            Try large icon
+          </AtomButton>
+        </section>
+        <h2 className="DemoAtomIcon-title">Lazy icons</h2>
+        <p>
+          By default, icons will be rendered <strong>eagerly</strong>. That
+          means that they will be rendered on the server and, on the client,
+          they will be hydrated asap. You could use the prop <code>render</code>{' '}
+          and use the <code>lazy</code> value so the icons are rendered only
+          when near the viewport. That could be useful when icons are used on a
+          footer or on large lists.
+        </p>
+        <section className="DemoAtomIcon-grid">
+          <AtomButton
+            size="large"
+            rightIcon={
+              <AtomIcon render="lazy">{selectedIcon.Component}</AtomIcon>
+            }
+          >
+            Large icon
+          </AtomButton>
 
-        <AtomButton
-          render="lazy"
-          rightIcon={
-            <AtomIcon render="lazy">{selectedIcon.Component}</AtomIcon>
-          }
-        >
-          Small icon
-        </AtomButton>
+          <AtomButton
+            render="lazy"
+            rightIcon={
+              <AtomIcon render="lazy">{selectedIcon.Component}</AtomIcon>
+            }
+          >
+            Small icon
+          </AtomButton>
 
-        <AtomButton
-          size="small"
-          render="lazy"
-          rightIcon={
-            <AtomIcon render="lazy">{selectedIcon.Component}</AtomIcon>
-          }
-        >
-          Small icon
-        </AtomButton>
+          <AtomButton
+            size="small"
+            render="lazy"
+            rightIcon={
+              <AtomIcon render="lazy">{selectedIcon.Component}</AtomIcon>
+            }
+          >
+            Small icon
+          </AtomButton>
 
-        <AtomButton
-          size="small"
-          render="lazy"
-          rightIcon={
-            <AtomIcon render="lazy" size="large">
-              {selectedIcon.Component}
-            </AtomIcon>
-          }
-        >
-          Try large icon
-        </AtomButton>
-      </section>
+          <AtomButton
+            size="small"
+            render="lazy"
+            rightIcon={
+              <AtomIcon render="lazy" size="large">
+                {selectedIcon.Component}
+              </AtomIcon>
+            }
+          >
+            Try large icon
+          </AtomButton>
+        </section>
+      </div>
     </div>
   )
 }

--- a/demo/atom/image/demo/index.js
+++ b/demo/atom/image/demo/index.js
@@ -30,100 +30,102 @@ const CLASS_DEMO_LIST_ITEM = `${BASE_CLASS_DEMO}-listItem`
 
 const Demo = () => {
   return (
-    <div className={BASE_CLASS_DEMO}>
-      <h1>AtomImage</h1>
-      <ul className={CLASS_DEMO_LIST}>
-        <li className={CLASS_DEMO_LIST_ITEM}>
-          <div className={CLASS_DEMO_CONTAINER_IMAGES}>
-            <AtomImage src={IMAGES.FINAL} alt="Nice View" />
-          </div>
-          <small style={{margin: '10px'}}>
-            Most simple Image with only required props
-          </small>
-        </li>
+    <div className="sui-StudioPreview">
+      <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+        <h1>Image</h1>
+        <ul className={CLASS_DEMO_LIST}>
+          <li className={CLASS_DEMO_LIST_ITEM}>
+            <div className={CLASS_DEMO_CONTAINER_IMAGES}>
+              <AtomImage src={IMAGES.FINAL} alt="Nice View" />
+            </div>
+            <small style={{margin: '10px'}}>
+              Most simple Image with only required props
+            </small>
+          </li>
 
-        <li className={CLASS_DEMO_LIST_ITEM}>
-          <div className={CLASS_DEMO_CONTAINER_IMAGES}>
-            <AtomImage
-              src={IMAGES.FINAL}
-              skeleton={IMAGES.SKELETON}
-              alt="Nice View"
-            />
-          </div>
-          <small style={{margin: '10px'}}>
-            Image with Skeleton while loading final image
-          </small>
-        </li>
+          <li className={CLASS_DEMO_LIST_ITEM}>
+            <div className={CLASS_DEMO_CONTAINER_IMAGES}>
+              <AtomImage
+                src={IMAGES.FINAL}
+                skeleton={IMAGES.SKELETON}
+                alt="Nice View"
+              />
+            </div>
+            <small style={{margin: '10px'}}>
+              Image with Skeleton while loading final image
+            </small>
+          </li>
 
-        <li className={CLASS_DEMO_LIST_ITEM}>
-          <div className={CLASS_DEMO_CONTAINER_IMAGES}>
-            <AtomImage
-              src={IMAGES.BAD}
-              spinner={<AtomSpinner />}
-              placeholder={IMAGES.PLACEHOLDER}
-              errorIcon={<ImageNotFoundIcon />}
-              errorText={defaultErrorText}
-              alt="Nice View"
-            />
-          </div>
-          <small style={{margin: '10px'}}>
-            Image with bad Image src and Error Box
-          </small>
-        </li>
+          <li className={CLASS_DEMO_LIST_ITEM}>
+            <div className={CLASS_DEMO_CONTAINER_IMAGES}>
+              <AtomImage
+                src={IMAGES.BAD}
+                spinner={<AtomSpinner />}
+                placeholder={IMAGES.PLACEHOLDER}
+                errorIcon={<ImageNotFoundIcon />}
+                errorText={defaultErrorText}
+                alt="Nice View"
+              />
+            </div>
+            <small style={{margin: '10px'}}>
+              Image with bad Image src and Error Box
+            </small>
+          </li>
 
-        <li className={CLASS_DEMO_LIST_ITEM}>
-          <div className={CLASS_DEMO_CONTAINER_IMAGES}>
-            <AtomImage
-              src={IMAGES.FINAL}
-              spinner={<AtomSpinner />}
-              placeholder={IMAGES.PLACEHOLDER}
-              alt="Nice View"
-            />
-          </div>
-          <small style={{margin: '10px'}}>
-            Image with placeholder and spinner while loading final image
-          </small>
-        </li>
+          <li className={CLASS_DEMO_LIST_ITEM}>
+            <div className={CLASS_DEMO_CONTAINER_IMAGES}>
+              <AtomImage
+                src={IMAGES.FINAL}
+                spinner={<AtomSpinner />}
+                placeholder={IMAGES.PLACEHOLDER}
+                alt="Nice View"
+              />
+            </div>
+            <small style={{margin: '10px'}}>
+              Image with placeholder and spinner while loading final image
+            </small>
+          </li>
 
-        <li className={CLASS_DEMO_LIST_ITEM}>
-          <div className={CLASS_DEMO_CONTAINER_IMAGES}>
-            <AtomImage
-              src={IMAGES.FINAL}
-              alt="Nice View"
-              spinner={<AtomSpinner />}
-            />
-          </div>
-          <small style={{margin: '10px'}}>
-            Image with spinner (only) while loading final image
-          </small>
-        </li>
+          <li className={CLASS_DEMO_LIST_ITEM}>
+            <div className={CLASS_DEMO_CONTAINER_IMAGES}>
+              <AtomImage
+                src={IMAGES.FINAL}
+                alt="Nice View"
+                spinner={<AtomSpinner />}
+              />
+            </div>
+            <small style={{margin: '10px'}}>
+              Image with spinner (only) while loading final image
+            </small>
+          </li>
 
-        <li className={CLASS_DEMO_LIST_ITEM}>
-          <div className={CLASS_DEMO_CONTAINER_IMAGES}>
-            <AtomImage
-              src={IMAGES.FINAL}
-              placeholder={IMAGES.PLACEHOLDER}
-              alt="Nice View"
-            />
-          </div>
-          <small style={{margin: '10px'}}>
-            Image with placeholder (only) while loading final image
-          </small>
-        </li>
-      </ul>
-      <blockquote>
-        <p>
-          Note: If images load too fast and you cannot appreciate the different
-          behaviours that can be set while images are loading, i recommend you
-          to simulate in your browser low-bandwidth conditions.
-        </p>
-        <p>
-          <a href="https://ma.ttias.be/simulate-low-bandwidth-conditions-with-chromes-network-throttling/">
-            Here
-          </a>{' '}
-          you have an explanation of how to do this in Chrome.
-        </p>
-      </blockquote>
+          <li className={CLASS_DEMO_LIST_ITEM}>
+            <div className={CLASS_DEMO_CONTAINER_IMAGES}>
+              <AtomImage
+                src={IMAGES.FINAL}
+                placeholder={IMAGES.PLACEHOLDER}
+                alt="Nice View"
+              />
+            </div>
+            <small style={{margin: '10px'}}>
+              Image with placeholder (only) while loading final image
+            </small>
+          </li>
+        </ul>
+        <blockquote>
+          <p>
+            Note: If images load too fast and you cannot appreciate the
+            different behaviours that can be set while images are loading, i
+            recommend you to simulate in your browser low-bandwidth conditions.
+          </p>
+          <p>
+            <a href="https://ma.ttias.be/simulate-low-bandwidth-conditions-with-chromes-network-throttling/">
+              Here
+            </a>{' '}
+            you have an explanation of how to do this in Chrome.
+          </p>
+        </blockquote>
+      </div>
     </div>
   )
 }

--- a/demo/atom/input/demo/index.js
+++ b/demo/atom/input/demo/index.js
@@ -16,188 +16,199 @@ const logoLocation = 'https://image.flaticon.com/icons/svg/67/67347.svg'
 const IconLocation = () => <img src={logoLocation} />
 
 export default () => (
-  <div style={{padding: '20px'}}>
-    <div style={field}>
-      <h4>Size MEDIUM</h4>
-      <AtomInput
-        size={inputSizes.MEDIUM}
-        name="first"
-        placeholder="Medium input"
-      />
-    </div>
-    <div style={field}>
-      <h4>Size SMALL</h4>
-      <AtomInput
-        size={inputSizes.SMALL}
-        name="first"
-        placeholder="Small input"
-      />
-    </div>
-    <div style={field}>
-      <h4>Size XSMALL</h4>
-      <AtomInput
-        size={inputSizes.XSMALL}
-        name="first"
-        placeholder="Extra Small input"
-      />
-    </div>
-    <div style={field}>
-      <h4>With placeholder</h4>
-      <AtomInput name="second" placeholder="Medium Input" />
-    </div>
-    <div style={field}>
-      <h4>With placeholder and value</h4>
-      <AtomInput
-        name="second"
-        placeholder="Medium Input"
-        value="Somewhere over the..."
-      />
-    </div>
-    <div style={field}>
-      <h4>Disabled</h4>
-      <AtomInput name="disabled" placeholder="Medium Disabled Input" disabled />
-    </div>
-    <div style={field}>
-      <h4>Read Only</h4>
-      <AtomInput name="disabled" value="Medium Read Only Input" readOnly />
-    </div>
-    <div style={field}>
-      <h4>Type: number</h4>
-      <AtomInput
-        type="number"
-        name="number"
-        placeholder="Number only input"
-        charsSize={10}
-      />
-    </div>
-    <div style={field}>
-      <h4>Type: date</h4>
-      <AtomInput type="date" name="date" charsSize={10} />
-    </div>
-    <div style={field}>
-      <h4>With leftAddon and rightAddon</h4>
-      <AtomInput
-        name="second"
-        placeholder="Medium Input"
-        leftAddon="http://"
-        rightAddon="@schibsted.com"
-      />
-    </div>
-    <div style={field}>
-      <h4>With leftIcon</h4>
-      <AtomInput
-        name="second"
-        placeholder="Medium Input"
-        leftIcon={<IconLocation />}
-      />
-    </div>
-    <div style={field}>
-      <h4>With leftIcon and rightAddon</h4>
-      <AtomInput
-        name="second"
-        placeholder="Medium Input"
-        leftIcon={<IconLocation />}
-        rightAddon="Location"
-      />
-    </div>
-    <div style={field}>
-      <h4>With errorState=false</h4>
-      <AtomInput name="second" placeholder="Success input" errorState={false} />
-    </div>
-    <div style={field}>
-      <h4>With errorState=true</h4>
-      <AtomInput name="second" placeholder="Error input" errorState />
-    </div>
-    <div style={field}>
-      <h4>With state="success"</h4>
-      <AtomInput name="second" placeholder="Success input" state="success" />
-    </div>
-    <div style={field}>
-      <h4>With state="error"</h4>
-      <AtomInput name="second" placeholder="Error input" state="error" />
-    </div>
-    <div style={field}>
-      <h4>With state="alert"</h4>
-      <AtomInput name="second" placeholder="Error input" state="alert" />
-    </div>
-    <div style={field}>
-      <h4>Type: sui-password</h4>
-      <AtomInput
-        type="sui-password"
-        name="password"
-        placeholder="Password Input"
-      />
-    </div>
-    <div style={field}>
-      <h4>Type: mask</h4>
-      <AtomInput
-        type="mask"
-        mask={bankAccountMask}
-        placeholder="ES00 0000 0000 00 0000000000"
-        charsSize={31}
-      />
-    </div>
-    <div style={field}>
-      <h4>With rightIcon</h4>
-      <AtomInput
-        name="second"
-        placeholder="Medium Input"
-        rightIcon={<IconLocation />}
-      />
-    </div>
-    <div style={field}>
-      <h4>With rightIcon and leftAddon</h4>
-      <AtomInput
-        name="second"
-        placeholder="Medium Input"
-        leftAddon="City"
-        rightIcon={<IconLocation />}
-      />
-    </div>
-    <div style={field}>
-      <h4>With rightIcon & handler on it</h4>
-      <AtomInput
-        name="second"
-        placeholder="Medium Input"
-        rightIcon={<IconLocation />}
-        onClickRightIcon={e => window.alert('clicked right icon')}
-      />
-    </div>
+  <div className="sui-StudioPreview">
+    <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+      <h1>Input</h1>
+      <div style={field}>
+        <h4>Size MEDIUM</h4>
+        <AtomInput
+          size={inputSizes.MEDIUM}
+          name="first"
+          placeholder="Medium input"
+        />
+      </div>
+      <div style={field}>
+        <h4>Size SMALL</h4>
+        <AtomInput
+          size={inputSizes.SMALL}
+          name="first"
+          placeholder="Small input"
+        />
+      </div>
+      <div style={field}>
+        <h4>Size XSMALL</h4>
+        <AtomInput
+          size={inputSizes.XSMALL}
+          name="first"
+          placeholder="Extra Small input"
+        />
+      </div>
+      <div style={field}>
+        <h4>With placeholder</h4>
+        <AtomInput name="second" placeholder="Medium Input" />
+      </div>
+      <div style={field}>
+        <h4>With placeholder and value</h4>
+        <AtomInput
+          name="second"
+          placeholder="Medium Input"
+          value="Somewhere over the..."
+        />
+      </div>
+      <div style={field}>
+        <h4>Disabled</h4>
+        <AtomInput
+          name="disabled"
+          placeholder="Medium Disabled Input"
+          disabled
+        />
+      </div>
+      <div style={field}>
+        <h4>Read Only</h4>
+        <AtomInput name="disabled" value="Medium Read Only Input" readOnly />
+      </div>
+      <div style={field}>
+        <h4>Type: number</h4>
+        <AtomInput
+          type="number"
+          name="number"
+          placeholder="Number only input"
+          charsSize={10}
+        />
+      </div>
+      <div style={field}>
+        <h4>Type: date</h4>
+        <AtomInput type="date" name="date" charsSize={10} />
+      </div>
+      <div style={field}>
+        <h4>With leftAddon and rightAddon</h4>
+        <AtomInput
+          name="second"
+          placeholder="Medium Input"
+          leftAddon="http://"
+          rightAddon="@schibsted.com"
+        />
+      </div>
+      <div style={field}>
+        <h4>With leftIcon</h4>
+        <AtomInput
+          name="second"
+          placeholder="Medium Input"
+          leftIcon={<IconLocation />}
+        />
+      </div>
+      <div style={field}>
+        <h4>With leftIcon and rightAddon</h4>
+        <AtomInput
+          name="second"
+          placeholder="Medium Input"
+          leftIcon={<IconLocation />}
+          rightAddon="Location"
+        />
+      </div>
+      <div style={field}>
+        <h4>With errorState=false</h4>
+        <AtomInput
+          name="second"
+          placeholder="Success input"
+          errorState={false}
+        />
+      </div>
+      <div style={field}>
+        <h4>With errorState=true</h4>
+        <AtomInput name="second" placeholder="Error input" errorState />
+      </div>
+      <div style={field}>
+        <h4>With state="success"</h4>
+        <AtomInput name="second" placeholder="Success input" state="success" />
+      </div>
+      <div style={field}>
+        <h4>With state="error"</h4>
+        <AtomInput name="second" placeholder="Error input" state="error" />
+      </div>
+      <div style={field}>
+        <h4>With state="alert"</h4>
+        <AtomInput name="second" placeholder="Error input" state="alert" />
+      </div>
+      <div style={field}>
+        <h4>Type: sui-password</h4>
+        <AtomInput
+          type="sui-password"
+          name="password"
+          placeholder="Password Input"
+        />
+      </div>
+      <div style={field}>
+        <h4>Type: mask</h4>
+        <AtomInput
+          type="mask"
+          mask={bankAccountMask}
+          placeholder="ES00 0000 0000 00 0000000000"
+          charsSize={31}
+        />
+      </div>
+      <div style={field}>
+        <h4>With rightIcon</h4>
+        <AtomInput
+          name="second"
+          placeholder="Medium Input"
+          rightIcon={<IconLocation />}
+        />
+      </div>
+      <div style={field}>
+        <h4>With rightIcon and leftAddon</h4>
+        <AtomInput
+          name="second"
+          placeholder="Medium Input"
+          leftAddon="City"
+          rightIcon={<IconLocation />}
+        />
+      </div>
+      <div style={field}>
+        <h4>With rightIcon & handler on it</h4>
+        <AtomInput
+          name="second"
+          placeholder="Medium Input"
+          rightIcon={<IconLocation />}
+          onClickRightIcon={e => window.alert('clicked right icon')}
+        />
+      </div>
 
-    <div style={field}>
-      <h4>No border</h4>
-      <AtomInput name="second" placeholder="Type something..." noBorder />
-    </div>
+      <div style={field}>
+        <h4>No border</h4>
+        <AtomInput name="second" placeholder="Type something..." noBorder />
+      </div>
 
-    <div style={field}>
-      <h4>onEnter</h4>
-      <AtomInput
-        name="on-enter-input"
-        onEnter={(ev, {value, name}) => {
-          ev.preventDefault()
-          window.alert(JSON.stringify({[name]: value}))
-        }}
-      />
-    </div>
+      <div style={field}>
+        <h4>onEnter</h4>
+        <AtomInput
+          name="on-enter-input"
+          onEnter={(ev, {value, name}) => {
+            ev.preventDefault()
+            window.alert(JSON.stringify({[name]: value}))
+          }}
+        />
+      </div>
 
-    <div style={field}>
-      <h4>onEnter on Tab</h4>
-      <AtomInput
-        name="on-tab-input"
-        onEnter={(ev, {value, name}) => {
-          ev.preventDefault()
-          window.alert(JSON.stringify({[name]: value}))
-        }}
-        onEnterKey="Tab"
-      />
-    </div>
-    <div style={field}>
-      <h4>Inline Form</h4>
-      <AtomInput
-        name="inlineForm"
-        placeholder="Inline Form"
-        button={<SuiButton>Submit</SuiButton>}
-      />
+      <div style={field}>
+        <h4>onEnter on Tab</h4>
+        <AtomInput
+          name="on-tab-input"
+          onEnter={(ev, {value, name}) => {
+            ev.preventDefault()
+            window.alert(JSON.stringify({[name]: value}))
+          }}
+          onEnterKey="Tab"
+        />
+      </div>
+      <div style={field}>
+        <h4>Inline Form</h4>
+        <AtomInput
+          name="inlineForm"
+          placeholder="Inline Form"
+          button={<SuiButton>Submit</SuiButton>}
+        />
+      </div>
     </div>
   </div>
 )

--- a/demo/atom/label/playground
+++ b/demo/atom/label/playground
@@ -1,7 +1,6 @@
 return (
   <div>
-    <br />
-    <br />
+    <h1>Label</h1>
     <div style={{marginBottom: '16px'}}>
       <AtomLabel
         name="atomLabelName1"

--- a/demo/atom/panel/playground
+++ b/demo/atom/panel/playground
@@ -14,7 +14,7 @@ const flexItem = {
 
 return (
   <div>
-    <h1>AtomPanel</h1>
+    <h1>Panel</h1>
     <h2>As Color Panel</h2>
     <div>
       <h3>Structure - Alpha</h3>

--- a/demo/atom/popover/demo/index.js
+++ b/demo/atom/popover/demo/index.js
@@ -26,47 +26,51 @@ const Demo = () => {
   )
 
   return (
-    <div className="DemoPopover">
-      <h1>Atom Popover</h1>
-      <label className="DemoPopover-label">Position</label>
-      <MoleculeSelect
-        value={position}
-        onChange={(ev, {value}) => setPosition(value)}
-        placeholder="Select a position..."
-        iconArrowDown={<IconArrowDown />}
-      >
-        {Object.keys(atomPopoverPositions).map(key => (
-          <MoleculeSelectOption key={key} value={atomPopoverPositions[key]}>
-            {key}
-          </MoleculeSelectOption>
-        ))}
-      </MoleculeSelect>
-      <br />
-      <label className="DemoPopover-label">Add close icon</label>
-      <input
-        type="checkbox"
-        checked={closeIcon}
-        onChange={ev => setCloseIcon(ev.target.checked)}
-      />
+    <div className="sui-StudioPreview">
+      <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+        <h1>Popover</h1>
+        <label className="DemoPopover-label">Position</label>
+        <MoleculeSelect
+          value={position}
+          onChange={(ev, {value}) => setPosition(value)}
+          placeholder="Select a position..."
+          iconArrowDown={<IconArrowDown />}
+        >
+          {Object.keys(atomPopoverPositions).map(key => (
+            <MoleculeSelectOption key={key} value={atomPopoverPositions[key]}>
+              {key}
+            </MoleculeSelectOption>
+          ))}
+        </MoleculeSelect>
+        <br />
+        <label className="DemoPopover-label">Add close icon</label>
+        <input
+          type="checkbox"
+          checked={closeIcon}
+          onChange={ev => setCloseIcon(ev.target.checked)}
+        />
 
-      <div className="DemoPopover-buttons">
-        <AtomPopover
-          closeIcon={closeIcon && <IconClose />}
-          placement={position}
-          onClose={() => console.log('CLOSE POPOVER!')}
-          content={renderContent()}
-          id="random-id"
-        >
-          <Button>Show Popover in component without "ref"</Button>
-        </AtomPopover>
-        <AtomPopover
-          closeIcon={closeIcon && <IconClose />}
-          placement={position}
-          onClose={() => console.log('CLOSE POPOVER!')}
-          content={renderContent()}
-        >
-          <div className="DemoPopover-button">Show Popover in HTML ELEMENT</div>
-        </AtomPopover>
+        <div className="DemoPopover-buttons">
+          <AtomPopover
+            closeIcon={closeIcon && <IconClose />}
+            placement={position}
+            onClose={() => console.log('CLOSE POPOVER!')}
+            content={renderContent()}
+            id="random-id"
+          >
+            <Button>Show Popover in component without "ref"</Button>
+          </AtomPopover>
+          <AtomPopover
+            closeIcon={closeIcon && <IconClose />}
+            placement={position}
+            onClose={() => console.log('CLOSE POPOVER!')}
+            content={renderContent()}
+          >
+            <div className="DemoPopover-button">
+              Show Popover in HTML ELEMENT
+            </div>
+          </AtomPopover>
+        </div>
       </div>
     </div>
   )

--- a/demo/atom/progressBar/playground
+++ b/demo/atom/progressBar/playground
@@ -147,7 +147,7 @@ const styleSection = {
 
 return (
   <div>
-    <h1>AtomLineProgressBar</h1>
+    <h1>Line Progress Bar</h1>
 
     <div style={styleSection}>
       <h2>Dynamic</h2>
@@ -181,7 +181,7 @@ return (
       <AtomProgressBar percentage={25} indicatorTotal />
     </div>
 
-    <h1>AtomCircleProgressBar</h1>
+    <h1>Circle Progress Bar</h1>
 
     <div style={styleSection}>
       <h2>Dynamic</h2>

--- a/demo/atom/radioButton/demo/index.js
+++ b/demo/atom/radioButton/demo/index.js
@@ -10,33 +10,35 @@ const CLASS_SECTION = `${BASE_CLASS_DEMO}-section`
 
 const Demo = () => {
   return (
-    <div className={BASE_CLASS_DEMO}>
-      <h1>AtomRadioButton</h1>
-      <h2>Use Cases</h2>
-      <div className={CLASS_SECTION}>
-        <h3>Basic</h3>
-        <AtomRadioButton
-          name="basic-favorite-beatle"
-          value="john"
-          onChange={(e, {name, value}) => console.log({[name]: value})}
-        />
-      </div>
-      <div className={CLASS_SECTION}>
-        <h3>Checked</h3>
-        <AtomRadioButton
-          name="checked-favorite-beatle"
-          value="paul"
-          checked
-          onChange={(e, {name, value}) => console.log({[name]: value})}
-        />
-      </div>
-      <div className={CLASS_SECTION}>
-        <h3>Disabled</h3>
-        <AtomRadioButton
-          name="disabled-favorite-beatle"
-          value="george"
-          disabled
-        />
+    <div className="sui-StudioPreview">
+      <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+        <h1>Radio-button</h1>
+        <h2>Use Cases</h2>
+        <div className={CLASS_SECTION}>
+          <h3>Basic</h3>
+          <AtomRadioButton
+            name="basic-favorite-beatle"
+            value="john"
+            onChange={(e, {name, value}) => console.log({[name]: value})}
+          />
+        </div>
+        <div className={CLASS_SECTION}>
+          <h3>Checked</h3>
+          <AtomRadioButton
+            name="checked-favorite-beatle"
+            value="paul"
+            checked
+            onChange={(e, {name, value}) => console.log({[name]: value})}
+          />
+        </div>
+        <div className={CLASS_SECTION}>
+          <h3>Disabled</h3>
+          <AtomRadioButton
+            name="disabled-favorite-beatle"
+            value="george"
+            disabled
+          />
+        </div>
       </div>
     </div>
   )

--- a/demo/atom/slider/playground
+++ b/demo/atom/slider/playground
@@ -22,7 +22,7 @@ const SliderWithState = ({value, onChange, ...otherProps}) => {
 
 return (
   <div>
-    <h1>AtomSlider</h1>
+    <h1>Slider</h1>
     <h2>Segmented</h2>
     <h3>Basic</h3>
     <div style={stylesSection}>

--- a/demo/atom/spinner/playground
+++ b/demo/atom/spinner/playground
@@ -67,7 +67,8 @@ class FullScreenSpinnerExample extends React.Component {
 }
 
 return (
-  <>
+  <div>
+    <h1>Spinner</h1>
     <h2>Infinite spinner</h2>
     <div style={boxStyle}>
       <p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</p>
@@ -90,5 +91,5 @@ return (
       <p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</p>
       <AtomSpinner noBackground />
     </div>
-  </>
+  </div>
 )

--- a/demo/atom/switch/playground
+++ b/demo/atom/switch/playground
@@ -26,7 +26,7 @@ const ValueParameter = () => {
 
 return (
 <div>
-  <h2>Atom Switch</h2>
+  <h1>Switch</h1>
   <h3>Styles</h3>
   <div style={ {...flexInlineContainer, ...stylesSection} } >
     <div style={itemInlineFlex}>

--- a/demo/atom/table/playground
+++ b/demo/atom/table/playground
@@ -93,8 +93,8 @@ const contentFootMook = [
 const handleClick = index => console.log(index)
 
 return (
-  <div style={{ maxWidth: 800, padding: 16 }}>
-    <h1>Atom Table</h1>
+  <div>
+    <h1>Table</h1>
     <p>Atom Table to show tabular information.</p>
 
     <hr/>

--- a/demo/atom/tag/playground
+++ b/demo/atom/tag/playground
@@ -13,7 +13,8 @@
     </svg>
   )
   return (
-    <div style={{float: 'left'}}>
+    <div>
+      <h1>Tag</h1>
       <h2>Standard Tags</h2>
       <p>
         <AtomTag label="Tag Structure" />{' '}

--- a/demo/atom/textarea/playground
+++ b/demo/atom/textarea/playground
@@ -29,7 +29,7 @@ const AtomTextareaWithState = withState(AtomTextarea)
 
 return (
   <div>
-    <h1>AtomTextarea</h1>
+    <h1>Text-area</h1>
     <h2>Basic Usage</h2>
     <p>
       <code>short</code> <em>size</em> by default

--- a/demo/atom/toast/demo/index.js
+++ b/demo/atom/toast/demo/index.js
@@ -32,69 +32,74 @@ const Demo = () => {
   )
 
   return (
-    <div className="DemoToast">
-      <h1>Atom Toast</h1>
-      <label className="DemoToast-label">Position</label>
-      <MoleculeSelect
-        value={position}
-        onChange={(ev, {value}) => setPosition(value)}
-        placeholder="Select a position..."
-        iconArrowDown={<IconArrowDown />}
-      >
-        {Object.keys(atomToastPositions).map(key => (
-          <MoleculeSelectOption key={key} value={atomToastPositions[key]}>
-            {key}
-          </MoleculeSelectOption>
-        ))}
-      </MoleculeSelect>
-      <label className="DemoToast-label">Auto close time</label>
-      <MoleculeSelect
-        value={autoCloseTime}
-        onChange={(ev, {value}) => setAutoCloseTime(value)}
-        placeholder="Select an auto close time..."
-        iconArrowDown={<IconArrowDown />}
-      >
-        {Object.keys(atomToastAutoCloseTimes).map(key => (
-          <MoleculeSelectOption key={key} value={atomToastAutoCloseTimes[key]}>
-            {key}
-          </MoleculeSelectOption>
-        ))}
-      </MoleculeSelect>
-      <label className="DemoToast-label">Auto close</label>
-      <input
-        type="checkbox"
-        checked={autoClose}
-        onChange={ev => setAutoClose(ev.target.checked)}
-      />
-      <label className="DemoToast-label">Global close</label>
-      <input
-        type="checkbox"
-        checked={globalClose}
-        onChange={ev => setGlobalClose(ev.target.checked)}
-      />
-      <label className="DemoToast-label">Effect</label>
-      <input
-        type="checkbox"
-        checked={effect}
-        onChange={ev => setEffect(ev.target.checked)}
-      />
-      <br />
-      <Button onClick={() => setShow(true)} fullWidth>
-        Show Toast
-      </Button>
-      {show && (
-        <AtomToast
-          autoClose={Boolean(autoClose)}
-          autoCloseTime={autoCloseTime}
-          effect={effect}
-          iconClose={<IconClose />}
-          position={position}
-          onClose={() => setShow(false)}
-          globalClose={globalClose}
+    <div className="sui-StudioPreview">
+      <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+        <h1>Toast</h1>
+        <label className="DemoToast-label">Position</label>
+        <MoleculeSelect
+          value={position}
+          onChange={(ev, {value}) => setPosition(value)}
+          placeholder="Select a position..."
+          iconArrowDown={<IconArrowDown />}
         >
-          {renderContent()}
-        </AtomToast>
-      )}
+          {Object.keys(atomToastPositions).map(key => (
+            <MoleculeSelectOption key={key} value={atomToastPositions[key]}>
+              {key}
+            </MoleculeSelectOption>
+          ))}
+        </MoleculeSelect>
+        <label className="DemoToast-label">Auto close time</label>
+        <MoleculeSelect
+          value={autoCloseTime}
+          onChange={(ev, {value}) => setAutoCloseTime(value)}
+          placeholder="Select an auto close time..."
+          iconArrowDown={<IconArrowDown />}
+        >
+          {Object.keys(atomToastAutoCloseTimes).map(key => (
+            <MoleculeSelectOption
+              key={key}
+              value={atomToastAutoCloseTimes[key]}
+            >
+              {key}
+            </MoleculeSelectOption>
+          ))}
+        </MoleculeSelect>
+        <label className="DemoToast-label">Auto close</label>
+        <input
+          type="checkbox"
+          checked={autoClose}
+          onChange={ev => setAutoClose(ev.target.checked)}
+        />
+        <label className="DemoToast-label">Global close</label>
+        <input
+          type="checkbox"
+          checked={globalClose}
+          onChange={ev => setGlobalClose(ev.target.checked)}
+        />
+        <label className="DemoToast-label">Effect</label>
+        <input
+          type="checkbox"
+          checked={effect}
+          onChange={ev => setEffect(ev.target.checked)}
+        />
+        <br />
+        <Button onClick={() => setShow(true)} fullWidth>
+          Show Toast
+        </Button>
+        {show && (
+          <AtomToast
+            autoClose={Boolean(autoClose)}
+            autoCloseTime={autoCloseTime}
+            effect={effect}
+            iconClose={<IconClose />}
+            position={position}
+            onClose={() => setShow(false)}
+            globalClose={globalClose}
+          >
+            {renderContent()}
+          </AtomToast>
+        )}
+      </div>
     </div>
   )
 }

--- a/demo/atom/tooltip/demo/index.js
+++ b/demo/atom/tooltip/demo/index.js
@@ -25,330 +25,333 @@ const Demo = () => {
   }
 
   return (
-    <div className="DemoTooltip">
-      <h1>AtomTooltip</h1>
-      <h2>Basic Usage</h2>
-      <p>
-        <code>AtomTooltip</code> will use the <code>title</code> (plain text) of
-        the wrapped element as content for the tooltip
-      </p>
-      <div className={`${baseClass}-boxExample`}>
+    <div className="sui-StudioPreview">
+      <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+        <h1>Tooltip</h1>
+        <h2>Basic Usage</h2>
         <p>
-          Lorem ipsum dolor sit amet{' '}
-          <AtomTooltip>
-            <u title="Last month of this year 2018" tabIndex="1">
-              december
-            </u>
-          </AtomTooltip>
+          <code>AtomTooltip</code> will use the <code>title</code> (plain text)
+          of the wrapped element as content for the tooltip
         </p>
-      </div>
-      <h2>Color tooltip</h2>
-      <p>
-        We can set <code>color</code> property to <code>AtomTooltip</code> in
-        order use theme colors.
-      </p>
-      <small>By default it will use the default color by SCSS (black).</small>
-      <div className={`${baseClass}-boxExample`}>
-        {COLORS.map(colorName => (
-          <p key={`color-${colorName}`}>
+        <div className={`${baseClass}-boxExample`}>
+          <p>
             Lorem ipsum dolor sit amet{' '}
-            <AtomTooltip color={colorName}>
-              <u title={`This is the ${colorName} color`} tabIndex="1">
-                {colorName} color
+            <AtomTooltip>
+              <u title="Last month of this year 2018" tabIndex="1">
+                december
               </u>
             </AtomTooltip>
           </p>
-        ))}
-      </div>
-      <h2>HTML for content of the tooltip </h2>
-      <p>
-        We can also set HTML as content of the Tooltip by passing a React
-        component to the prop <code>content</code> of <code>AtomTooltip</code>.
-      </p>
-      <small>
-        By default it will use the <code>title</code> of the wrapped element as
-        content of the tooltip
-      </small>
-      <div className={`${baseClass}-boxExample`}>
-        <p>
-          Lorem ipsum dolor sit amet{' '}
-          <AtomTooltip content={HtmlTooltipDecember}>
-            <strong tabIndex="1">december</strong>
-          </AtomTooltip>
-        </p>
-      </div>
-      <h2>
-        Positioning tooltip with <code>placement</code>
-      </h2>
-      <div>
-        <div className={`${baseClass}-boxExample`}>
-          <ul className={`${baseClass}-containerList`}>
-            {/* --- bottom --- */}
-            <li className={`${baseClass}-containerListItem--bottom`}>
-              <AtomTooltip
-                placement={PLACEMENTS.BOTTOM_START}
-                content={() => <code>placement='bottom-start'</code>}
-              >
-                <strong tabIndex="11">bottom-start</strong>
-              </AtomTooltip>
-              <AtomTooltip
-                placement={PLACEMENTS.BOTTOM}
-                content={() => <code>placement='bottom'</code>}
-              >
-                <strong tabIndex="12">bottom</strong>
-              </AtomTooltip>
-              <AtomTooltip
-                placement={PLACEMENTS.BOTTOM_END}
-                content={() => <code>placement='bottom-end'</code>}
-              >
-                <strong tabIndex="13">bottom-end</strong>
-              </AtomTooltip>
-            </li>
-
-            {/* --- left --- */}
-            <li className={`${baseClass}-containerListItem--left`}>
-              <AtomTooltip
-                placement={PLACEMENTS.LEFT_START}
-                content={() => (
-                  <span>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit
-                    <br />
-                    <code>placement='left-start'</code>
-                  </span>
-                )}
-              >
-                <strong tabIndex="14">left-start</strong>
-              </AtomTooltip>
-              <AtomTooltip
-                placement={PLACEMENTS.LEFT}
-                content={() => (
-                  <span>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit
-                    <br />
-                    <code>placement='left'</code>
-                  </span>
-                )}
-              >
-                <strong tabIndex="15">left</strong>
-              </AtomTooltip>
-              <AtomTooltip
-                placement={PLACEMENTS.LEFT_END}
-                content={() => (
-                  <span>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit
-                    <br />
-                    <code>placement='left-end'</code>
-                  </span>
-                )}
-              >
-                <strong tabIndex="16">left-end</strong>
-              </AtomTooltip>
-            </li>
-
-            {/* --- right --- */}
-            <li className={`${baseClass}-containerListItem--right`}>
-              <AtomTooltip
-                placement={PLACEMENTS.RIGHT_START}
-                content={() => (
-                  <span>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit
-                    <br />
-                    <code>placement='right-start'</code>
-                  </span>
-                )}
-              >
-                <strong
-                  className={`${baseClass}-containerListItem--rightLabel`}
-                  tabIndex="8"
-                >
-                  right-start
-                </strong>
-              </AtomTooltip>
-              <AtomTooltip
-                placement={PLACEMENTS.RIGHT}
-                content={() => (
-                  <span>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit
-                    <br />
-                    <code>placement='right'</code>
-                  </span>
-                )}
-              >
-                <strong
-                  className={`${baseClass}-containerListItem--rightLabel`}
-                  tabIndex="9"
-                >
-                  right
-                </strong>
-              </AtomTooltip>
-              <AtomTooltip
-                placement={PLACEMENTS.RIGHT_END}
-                content={() => (
-                  <span>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit
-                    <br />
-                    <code>placement='right-end'</code>
-                  </span>
-                )}
-              >
-                <strong
-                  className={`${baseClass}-containerListItem--rightLabel`}
-                  tabIndex="10"
-                >
-                  right-end
-                </strong>
-              </AtomTooltip>
-            </li>
-
-            {/* --- top --- */}
-            <li className={`${baseClass}-containerListItem--top`}>
-              <AtomTooltip
-                placement={PLACEMENTS.TOP_START}
-                content={() => <code>placement='top-start'</code>}
-              >
-                <strong tabIndex="5">top-start</strong>
-              </AtomTooltip>
-
-              <AtomTooltip
-                placement={PLACEMENTS.TOP}
-                content={() => <code>placement='top'</code>}
-              >
-                <strong tabIndex="6">top</strong>
-              </AtomTooltip>
-              <AtomTooltip
-                placement={PLACEMENTS.TOP_END}
-                content={() => <code>placement='top-end'</code>}
-              >
-                <strong tabIndex="7">top-end</strong>
-              </AtomTooltip>
-            </li>
-          </ul>
         </div>
-      </div>
-      <h2>
-        Maintain tooltip on hover over tooltp with <code>autohide=false</code>{' '}
-        (so users can select text in tooltip)
-      </h2>
-      <div className={`${baseClass}-boxExample`}>
+        <h2>Color tooltip</h2>
         <p>
-          Lorem ipsum dolor sit amet{' '}
-          <AtomTooltip autohide={false}>
-            <strong
-              title="Leo sagittis dignissim ornare egestas primis parturient ante diam fusce,
-          sollicitudin viverra felis inceptos turpis."
+          We can set <code>color</code> property to <code>AtomTooltip</code> in
+          order use theme colors.
+        </p>
+        <small>By default it will use the default color by SCSS (black).</small>
+        <div className={`${baseClass}-boxExample`}>
+          {COLORS.map(colorName => (
+            <p key={`color-${colorName}`}>
+              Lorem ipsum dolor sit amet{' '}
+              <AtomTooltip color={colorName}>
+                <u title={`This is the ${colorName} color`} tabIndex="1">
+                  {colorName} color
+                </u>
+              </AtomTooltip>
+            </p>
+          ))}
+        </div>
+        <h2>HTML for content of the tooltip </h2>
+        <p>
+          We can also set HTML as content of the Tooltip by passing a React
+          component to the prop <code>content</code> of <code>AtomTooltip</code>
+          .
+        </p>
+        <small>
+          By default it will use the <code>title</code> of the wrapped element
+          as content of the tooltip
+        </small>
+        <div className={`${baseClass}-boxExample`}>
+          <p>
+            Lorem ipsum dolor sit amet{' '}
+            <AtomTooltip content={HtmlTooltipDecember}>
+              <strong tabIndex="1">december</strong>
+            </AtomTooltip>
+          </p>
+        </div>
+        <h2>
+          Positioning tooltip with <code>placement</code>
+        </h2>
+        <div>
+          <div className={`${baseClass}-boxExample`}>
+            <ul className={`${baseClass}-containerList`}>
+              {/* --- bottom --- */}
+              <li className={`${baseClass}-containerListItem--bottom`}>
+                <AtomTooltip
+                  placement={PLACEMENTS.BOTTOM_START}
+                  content={() => <code>placement='bottom-start'</code>}
+                >
+                  <strong tabIndex="11">bottom-start</strong>
+                </AtomTooltip>
+                <AtomTooltip
+                  placement={PLACEMENTS.BOTTOM}
+                  content={() => <code>placement='bottom'</code>}
+                >
+                  <strong tabIndex="12">bottom</strong>
+                </AtomTooltip>
+                <AtomTooltip
+                  placement={PLACEMENTS.BOTTOM_END}
+                  content={() => <code>placement='bottom-end'</code>}
+                >
+                  <strong tabIndex="13">bottom-end</strong>
+                </AtomTooltip>
+              </li>
+
+              {/* --- left --- */}
+              <li className={`${baseClass}-containerListItem--left`}>
+                <AtomTooltip
+                  placement={PLACEMENTS.LEFT_START}
+                  content={() => (
+                    <span>
+                      Lorem ipsum dolor sit amet, consectetur adipiscing elit
+                      <br />
+                      <code>placement='left-start'</code>
+                    </span>
+                  )}
+                >
+                  <strong tabIndex="14">left-start</strong>
+                </AtomTooltip>
+                <AtomTooltip
+                  placement={PLACEMENTS.LEFT}
+                  content={() => (
+                    <span>
+                      Lorem ipsum dolor sit amet, consectetur adipiscing elit
+                      <br />
+                      <code>placement='left'</code>
+                    </span>
+                  )}
+                >
+                  <strong tabIndex="15">left</strong>
+                </AtomTooltip>
+                <AtomTooltip
+                  placement={PLACEMENTS.LEFT_END}
+                  content={() => (
+                    <span>
+                      Lorem ipsum dolor sit amet, consectetur adipiscing elit
+                      <br />
+                      <code>placement='left-end'</code>
+                    </span>
+                  )}
+                >
+                  <strong tabIndex="16">left-end</strong>
+                </AtomTooltip>
+              </li>
+
+              {/* --- right --- */}
+              <li className={`${baseClass}-containerListItem--right`}>
+                <AtomTooltip
+                  placement={PLACEMENTS.RIGHT_START}
+                  content={() => (
+                    <span>
+                      Lorem ipsum dolor sit amet, consectetur adipiscing elit
+                      <br />
+                      <code>placement='right-start'</code>
+                    </span>
+                  )}
+                >
+                  <strong
+                    className={`${baseClass}-containerListItem--rightLabel`}
+                    tabIndex="8"
+                  >
+                    right-start
+                  </strong>
+                </AtomTooltip>
+                <AtomTooltip
+                  placement={PLACEMENTS.RIGHT}
+                  content={() => (
+                    <span>
+                      Lorem ipsum dolor sit amet, consectetur adipiscing elit
+                      <br />
+                      <code>placement='right'</code>
+                    </span>
+                  )}
+                >
+                  <strong
+                    className={`${baseClass}-containerListItem--rightLabel`}
+                    tabIndex="9"
+                  >
+                    right
+                  </strong>
+                </AtomTooltip>
+                <AtomTooltip
+                  placement={PLACEMENTS.RIGHT_END}
+                  content={() => (
+                    <span>
+                      Lorem ipsum dolor sit amet, consectetur adipiscing elit
+                      <br />
+                      <code>placement='right-end'</code>
+                    </span>
+                  )}
+                >
+                  <strong
+                    className={`${baseClass}-containerListItem--rightLabel`}
+                    tabIndex="10"
+                  >
+                    right-end
+                  </strong>
+                </AtomTooltip>
+              </li>
+
+              {/* --- top --- */}
+              <li className={`${baseClass}-containerListItem--top`}>
+                <AtomTooltip
+                  placement={PLACEMENTS.TOP_START}
+                  content={() => <code>placement='top-start'</code>}
+                >
+                  <strong tabIndex="5">top-start</strong>
+                </AtomTooltip>
+
+                <AtomTooltip
+                  placement={PLACEMENTS.TOP}
+                  content={() => <code>placement='top'</code>}
+                >
+                  <strong tabIndex="6">top</strong>
+                </AtomTooltip>
+                <AtomTooltip
+                  placement={PLACEMENTS.TOP_END}
+                  content={() => <code>placement='top-end'</code>}
+                >
+                  <strong tabIndex="7">top-end</strong>
+                </AtomTooltip>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <h2>
+          Maintain tooltip on hover over tooltp with <code>autohide=false</code>{' '}
+          (so users can select text in tooltip)
+        </h2>
+        <div className={`${baseClass}-boxExample`}>
+          <p>
+            Lorem ipsum dolor sit amet{' '}
+            <AtomTooltip autohide={false}>
+              <strong
+                title="Leo sagittis dignissim ornare egestas primis parturient ante diam fusce,
+            sollicitudin viverra felis inceptos turpis."
+                tabIndex="1"
+              >
+                december
+              </strong>
+            </AtomTooltip>
+          </p>
+        </div>
+        <h2>Delay on show/hide and click outside to hide</h2>
+        <div className={`${baseClass}-boxExample`}>
+          <p>
+            Lorem ipsum dolor sit amet{' '}
+            <AtomTooltip delay={{show: 300, hide: 1500}}>
+              <strong
+                title="Vehicula neque sociis leo odio nostra fames ridiculus cubilia nunc,
+            ultricies tortor egestas vitae sed maecenas "
+                tabIndex="2"
+              >
+                november
+              </strong>
+            </AtomTooltip>
+          </p>
+        </div>
+        <h2>
+          Maximum of 4 lines with <em>ellipsis</em>
+        </h2>
+        <div className={`${baseClass}-boxExample`}>
+          <p>
+            Lorem ipsum dolor sit amet{' '}
+            <AtomTooltip placement={PLACEMENTS.BOTTOM_END}>
+              <strong
+                title="Hendrerit varius luctus scelerisque habitant ridiculus, vulputate mollis
+            platea nunc sociosqu magna, suscipit montes ullamcorper vivamus. Montes
+            aenean nostra magna inceptos himenaeos enim lacinia ornare libero,
+            quisque sed duis placerat hac arcu porttitor lobortis rutrum,"
+                tabIndex="3"
+              >
+                astros
+              </strong>
+            </AtomTooltip>
+          </p>
+        </div>
+        <h2>
+          Tooltip without arrow using <code>hideArrow</code>
+        </h2>
+        <div className={`${baseClass}-boxExample`}>
+          <p>
+            Lorem ipsum dolor sit amet{' '}
+            <AtomTooltip
+              placement={PLACEMENTS.RIGHT}
+              content={() => (
+                <>
+                  Hello <strong>world</strong>!
+                </>
+              )}
+              hideArrow
+            >
+              <strong tabIndex="4">astros</strong>
+            </AtomTooltip>
+          </p>
+        </div>
+        <h2>
+          Buttons with <code>onClick</code> can also have a tooltip
+        </h2>
+        <ul>
+          <li>
+            Desktop (Non-touch devices)→ <code>click</code>: button action |{' '}
+            <code>hover</code>: tooltip
+          </li>
+          <li>
+            Mobile (Touch devices)→ <code>click</code>: button action |{' '}
+            <code>long press</code>: tooltip
+          </li>
+        </ul>
+        <div className={`${baseClass}-boxExample`}>
+          <AtomTooltip>
+            <button
+              style={{
+                border: '1px solid #ccc',
+                fontSize: '30px'
+              }}
               tabIndex="1"
+              title="This menu display some cool options"
+              onClick={() => console.log('👍  action triggered')}
             >
-              december
-            </strong>
+              <img height="30" src={iconMenuHamburguer} alt="" />
+            </button>
           </AtomTooltip>
-        </p>
-      </div>
-      <h2>Delay on show/hide and click outside to hide</h2>
-      <div className={`${baseClass}-boxExample`}>
+        </div>
+        <h2>
+          Manage <b>isOpen</b> status from outside
+        </h2>
         <p>
-          Lorem ipsum dolor sit amet{' '}
-          <AtomTooltip delay={{show: 300, hide: 1500}}>
-            <strong
-              title="Vehicula neque sociis leo odio nostra fames ridiculus cubilia nunc,
-          ultricies tortor egestas vitae sed maecenas "
-              tabIndex="2"
-            >
-              november
-            </strong>
-          </AtomTooltip>
+          You can use the <b>isOpen</b> property to set to the AtomTooltipBase
+          if it should be shown or not.
         </p>
-      </div>
-      <h2>
-        Maximum of 4 lines with <em>ellipsis</em>
-      </h2>
-      <div className={`${baseClass}-boxExample`}>
-        <p>
-          Lorem ipsum dolor sit amet{' '}
-          <AtomTooltip placement={PLACEMENTS.BOTTOM_END}>
-            <strong
-              title="Hendrerit varius luctus scelerisque habitant ridiculus, vulputate mollis
-          platea nunc sociosqu magna, suscipit montes ullamcorper vivamus. Montes
-          aenean nostra magna inceptos himenaeos enim lacinia ornare libero,
-          quisque sed duis placerat hac arcu porttitor lobortis rutrum,"
-              tabIndex="3"
-            >
-              astros
-            </strong>
-          </AtomTooltip>
-        </p>
-      </div>
-      <h2>
-        Tooltip without arrow using <code>hideArrow</code>
-      </h2>
-      <div className={`${baseClass}-boxExample`}>
-        <p>
-          Lorem ipsum dolor sit amet{' '}
-          <AtomTooltip
-            placement={PLACEMENTS.RIGHT}
-            content={() => (
-              <>
-                Hello <strong>world</strong>!
-              </>
-            )}
-            hideArrow
-          >
-            <strong tabIndex="4">astros</strong>
-          </AtomTooltip>
-        </p>
-      </div>
-      <h2>
-        Buttons with <code>onClick</code> can also have a tooltip
-      </h2>
-      <ul>
-        <li>
-          Desktop (Non-touch devices)→ <code>click</code>: button action |{' '}
-          <code>hover</code>: tooltip
-        </li>
-        <li>
-          Mobile (Touch devices)→ <code>click</code>: button action |{' '}
-          <code>long press</code>: tooltip
-        </li>
-      </ul>
-      <div className={`${baseClass}-boxExample`}>
-        <AtomTooltip>
-          <button
-            style={{
-              border: '1px solid #ccc',
-              fontSize: '30px'
-            }}
-            tabIndex="1"
-            title="This menu display some cool options"
-            onClick={() => console.log('👍  action triggered')}
-          >
-            <img height="30" src={iconMenuHamburguer} alt="" />
+        <div className={`${baseClass}-boxExample`}>
+          <p>
+            Lorem ipsum dolor sit amet{' '}
+            <AtomTooltipBase isOpen={isOpen} innerRef={setInnerRef(ref1)}>
+              <u title="Last month of this year 2018" tabIndex="1">
+                december
+              </u>
+            </AtomTooltipBase>
+            &nbsp;and&nbsp;
+            <AtomTooltipBase isOpen={!isOpen} innerRef={setInnerRef(ref2)}>
+              <u title="Last month of this year 2018" tabIndex="1">
+                not december
+              </u>
+            </AtomTooltipBase>
+          </p>
+          <button onClick={() => setIsOpen(!isOpen)}>
+            {isOpen ? 'hide tooltip' : 'open tooltip'}
           </button>
-        </AtomTooltip>
-      </div>
-      <h2>
-        Manage <b>isOpen</b> status from outside
-      </h2>
-      <p>
-        You can use the <b>isOpen</b> property to set to the AtomTooltipBase if
-        it should be shown or not.
-      </p>
-      <div className={`${baseClass}-boxExample`}>
-        <p>
-          Lorem ipsum dolor sit amet{' '}
-          <AtomTooltipBase isOpen={isOpen} innerRef={setInnerRef(ref1)}>
-            <u title="Last month of this year 2018" tabIndex="1">
-              december
-            </u>
-          </AtomTooltipBase>
-          &nbsp;and&nbsp;
-          <AtomTooltipBase isOpen={!isOpen} innerRef={setInnerRef(ref2)}>
-            <u title="Last month of this year 2018" tabIndex="1">
-              not december
-            </u>
-          </AtomTooltipBase>
-        </p>
-        <button onClick={() => setIsOpen(!isOpen)}>
-          {isOpen ? 'hide tooltip' : 'open tooltip'}
-        </button>
+        </div>
       </div>
     </div>
   )

--- a/demo/atom/upload/demo/index.js
+++ b/demo/atom/upload/demo/index.js
@@ -71,98 +71,100 @@ class DynamicStatusContainer extends Component {
 
 const Demo = () => {
   return (
-    <div>
-      <h1>AtomUpload</h1>
-      <h2>Dynamic Behaviour</h2>
-      <div className="DemoAtomUpload-section DemoAtomUpload-section--responsive">
-        <p>
-          Click on the component or drag&drop some files to start upload
-          simulation
-        </p>
-        <DynamicStatusContainer
-          iconActive={<IconActive />}
-          textActive={textActive}
-          textExplanation={textExplanation}
-          iconUpload={<AtomSpinner noBackground />}
-          textUpload={textUpload}
-          iconSuccess={<IconSuccess />}
-          textSuccess={textSuccess}
-          iconError={<IconError />}
-          textError={textError}
-        />
-      </div>
-      <h2>Use Cases</h2>
-      <div className="DemoAtomUpload-section DemoAtomUpload-section--responsive">
-        <h3>Active</h3>
-        <LayoutMediaQuery>
-          {({XS}) => {
-            if (XS) {
+    <div className="sui-StudioPreview">
+      <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+        <h1>Upload</h1>
+        <h2>Dynamic Behaviour</h2>
+        <div className="DemoAtomUpload-section DemoAtomUpload-section--responsive">
+          <p>
+            Click on the component or drag&drop some files to start upload
+            simulation
+          </p>
+          <DynamicStatusContainer
+            iconActive={<IconActive />}
+            textActive={textActive}
+            textExplanation={textExplanation}
+            iconUpload={<AtomSpinner noBackground />}
+            textUpload={textUpload}
+            iconSuccess={<IconSuccess />}
+            textSuccess={textSuccess}
+            iconError={<IconError />}
+            textError={textError}
+          />
+        </div>
+        <h2>Use Cases</h2>
+        <div className="DemoAtomUpload-section DemoAtomUpload-section--responsive">
+          <h3>Active</h3>
+          <LayoutMediaQuery>
+            {({XS}) => {
+              if (XS) {
+                return (
+                  <AtomUpload
+                    status={uploadStatuses.ACTIVE}
+                    iconActive={<IconActive />}
+                    textActive={textActive}
+                    textExplanation={textExplanation}
+                  />
+                )
+              }
               return (
                 <AtomUpload
                   status={uploadStatuses.ACTIVE}
                   iconActive={<IconActive />}
                   textActive={textActive}
-                  textExplanation={textExplanation}
                 />
               )
-            }
-            return (
-              <AtomUpload
-                status={uploadStatuses.ACTIVE}
-                iconActive={<IconActive />}
-                textActive={textActive}
-              />
-            )
-          }}
-        </LayoutMediaQuery>
-      </div>
-      <div className="DemoAtomUpload-section DemoAtomUpload-section--responsive DemoAtomUpload-section--responsive-large">
-        <h3>Active</h3>
-        <LayoutMediaQuery>
-          {({XS}) => {
-            if (XS) {
+            }}
+          </LayoutMediaQuery>
+        </div>
+        <div className="DemoAtomUpload-section DemoAtomUpload-section--responsive DemoAtomUpload-section--responsive-large">
+          <h3>Active</h3>
+          <LayoutMediaQuery>
+            {({XS}) => {
+              if (XS) {
+                return (
+                  <AtomUpload
+                    status={uploadStatuses.ACTIVE}
+                    iconActive={<IconActive />}
+                    textActive={textActive}
+                    textExplanation={textExplanation}
+                  />
+                )
+              }
               return (
                 <AtomUpload
                   status={uploadStatuses.ACTIVE}
                   iconActive={<IconActive />}
                   textActive={textActive}
-                  textExplanation={textExplanation}
                 />
               )
-            }
-            return (
-              <AtomUpload
-                status={uploadStatuses.ACTIVE}
-                iconActive={<IconActive />}
-                textActive={textActive}
-              />
-            )
-          }}
-        </LayoutMediaQuery>
-      </div>
-      <div className="DemoAtomUpload-section DemoAtomUpload-section--responsive">
-        <h3>Upload</h3>
-        <AtomUpload
-          status={uploadStatuses.UPLOAD}
-          iconUpload={<AtomSpinner noBackground />}
-          textUpload={textUpload}
-        />
-      </div>
-      <div className="DemoAtomUpload-section DemoAtomUpload-section--responsive">
-        <h3>Success</h3>
-        <AtomUpload
-          status={uploadStatuses.SUCCESS}
-          iconSuccess={<IconSuccess />}
-          textSuccess={textSuccess}
-        />
-      </div>
-      <div className="DemoAtomUpload-section DemoAtomUpload-section--responsive">
-        <h3>Error</h3>
-        <AtomUpload
-          iconError={<IconError />}
-          textError={textError}
-          status={uploadStatuses.ERROR}
-        />
+            }}
+          </LayoutMediaQuery>
+        </div>
+        <div className="DemoAtomUpload-section DemoAtomUpload-section--responsive">
+          <h3>Upload</h3>
+          <AtomUpload
+            status={uploadStatuses.UPLOAD}
+            iconUpload={<AtomSpinner noBackground />}
+            textUpload={textUpload}
+          />
+        </div>
+        <div className="DemoAtomUpload-section DemoAtomUpload-section--responsive">
+          <h3>Success</h3>
+          <AtomUpload
+            status={uploadStatuses.SUCCESS}
+            iconSuccess={<IconSuccess />}
+            textSuccess={textSuccess}
+          />
+        </div>
+        <div className="DemoAtomUpload-section DemoAtomUpload-section--responsive">
+          <h3>Error</h3>
+          <AtomUpload
+            iconError={<IconError />}
+            textError={textError}
+            status={uploadStatuses.ERROR}
+          />
+        </div>
       </div>
     </div>
   )

--- a/demo/atom/validationText/playground
+++ b/demo/atom/validationText/playground
@@ -9,7 +9,8 @@ const input = {
   width: '100%',
 }
 return (
-  <div style={{margin: '16px'}}>
+  <div>
+    <h1>Validation Text</h1>
     <div style={{marginBottom: '16px'}}>
       <input style={input}
         type='text'

--- a/demo/molecule/autosuggest/demo/index.js
+++ b/demo/molecule/autosuggest/demo/index.js
@@ -34,159 +34,157 @@ const BASE_CLASS_DEMO = 'DemoMoleculeAutosuggest'
 const CLASS_DEMO_SECTION = `${BASE_CLASS_DEMO}-section`
 
 const Demo = () => (
-  <div className={BASE_CLASS_DEMO}>
-    {/*
-      <AutosuggestSingleWithAsyncOptions iconClear={<IconClose />} />
-    */}
-    <h1>
-      <code>MoleculeAutosuggest</code>
-    </h1>
-    <p>
-      El componente <code>Autosuggest</code> solo se usará cuando se pueda
-      escribir en el <code>input</code> (lo que generará una búsqueda en las
-      opciones del <code>DropdownList</code>)
-    </p>
-    <p>
-      En esta demo sólo se utiliza el tamaño por defecto del{' '}
-      <code>DropdownList</code> y las opciones básicas del{' '}
-      <code>DropdownOption</code>. Recuerda que en dichos componentes existen
-      más posibilidades si son necesarias
-    </p>
-    <h2>Single Selection</h2>
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>with Placeholder</h3>
-      <MoleculeAutosuggestWithState
-        leftIcon={<IconSearch />}
-        placeholder="Type a Country name..."
-        onChange={(_, {value}) => console.log(value)}
-        onEnter={() => console.log('Enter pressed')}
-        iconClear={<IconClose />}
-      />
-    </div>
+  <div className="sui-StudioPreview">
+    <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+      <h1>Autosuggest</h1>
+      <p>
+        El componente <code>Autosuggest</code> solo se usará cuando se pueda
+        escribir en el <code>input</code> (lo que generará una búsqueda en las
+        opciones del <code>DropdownList</code>)
+      </p>
+      <p>
+        En esta demo sólo se utiliza el tamaño por defecto del{' '}
+        <code>DropdownList</code> y las opciones básicas del{' '}
+        <code>DropdownOption</code>. Recuerda que en dichos componentes existen
+        más posibilidades si son necesarias
+      </p>
+      <h2>Single Selection</h2>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>with Placeholder</h3>
+        <MoleculeAutosuggestWithState
+          leftIcon={<IconSearch />}
+          placeholder="Type a Country name..."
+          onChange={(_, {value}) => console.log(value)}
+          onEnter={() => console.log('Enter pressed')}
+          iconClear={<IconClose />}
+        />
+      </div>
 
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>with preselected Value</h3>
-      <MoleculeAutosuggestWithState
-        value="Luxembourg"
-        onChange={(_, {value}) => console.log(value)}
-        iconClear={<IconClose />}
-      />
-    </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>with preselected Value</h3>
+        <MoleculeAutosuggestWithState
+          value="Luxembourg"
+          onChange={(_, {value}) => console.log(value)}
+          iconClear={<IconClose />}
+        />
+      </div>
 
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>disabled</h3>
-      <MoleculeAutosuggestWithState
-        value="Luxembourg"
-        onChange={(_, {value}) => console.log(value)}
-        iconClear={<IconClose />}
-        disabled
-      />
-    </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>disabled</h3>
+        <MoleculeAutosuggestWithState
+          value="Luxembourg"
+          onChange={(_, {value}) => console.log(value)}
+          iconClear={<IconClose />}
+          disabled
+        />
+      </div>
 
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>Whit autocomplete "off"</h3>
-      <MoleculeAutosuggestWithState
-        value="Luxembourg"
-        onChange={(_, {value}) => console.log(value)}
-        iconClear={<IconClose />}
-        autoComplete="off"
-      />
-    </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>Whit autocomplete "off"</h3>
+        <MoleculeAutosuggestWithState
+          value="Luxembourg"
+          onChange={(_, {value}) => console.log(value)}
+          iconClear={<IconClose />}
+          autoComplete="off"
+        />
+      </div>
 
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With no clear icon</h3>
-      <MoleculeAutosuggestWithState
-        value="Luxembourg"
-        onChange={(_, {value}) => console.log(value)}
-      />
-    </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With no clear icon</h3>
+        <MoleculeAutosuggestWithState
+          value="Luxembourg"
+          onChange={(_, {value}) => console.log(value)}
+        />
+      </div>
 
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>with Success State</h3>
-      <MoleculeAutosuggestWithState
-        placeholder="Type a Country name..."
-        onChange={(_, {value}) => console.log(value)}
-        onEnter={() => console.log('Enter pressed')}
-        state={MoleculeAutosuggestStates.SUCCESS}
-        iconClear={<IconClose />}
-      />
-    </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>with Success State</h3>
+        <MoleculeAutosuggestWithState
+          placeholder="Type a Country name..."
+          onChange={(_, {value}) => console.log(value)}
+          onEnter={() => console.log('Enter pressed')}
+          state={MoleculeAutosuggestStates.SUCCESS}
+          iconClear={<IconClose />}
+        />
+      </div>
 
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>with Error State</h3>
-      <MoleculeAutosuggestWithState
-        placeholder="Type a Country name..."
-        onChange={(_, {value}) => console.log(value)}
-        onEnter={() => console.log('Enter pressed')}
-        state={MoleculeAutosuggestStates.ERROR}
-        iconClear={<IconClose />}
-      />
-    </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>with Error State</h3>
+        <MoleculeAutosuggestWithState
+          placeholder="Type a Country name..."
+          onChange={(_, {value}) => console.log(value)}
+          onEnter={() => console.log('Enter pressed')}
+          state={MoleculeAutosuggestStates.ERROR}
+          iconClear={<IconClose />}
+        />
+      </div>
 
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>with Alert State</h3>
-      <MoleculeAutosuggestWithState
-        placeholder="Type a Country name..."
-        onChange={(_, {value}) => console.log(value)}
-        onEnter={() => console.log('Enter pressed')}
-        state={MoleculeAutosuggestStates.ALERT}
-        iconClear={<IconClose />}
-      />
-    </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>with Alert State</h3>
+        <MoleculeAutosuggestWithState
+          placeholder="Type a Country name..."
+          onChange={(_, {value}) => console.log(value)}
+          onEnter={() => console.log('Enter pressed')}
+          state={MoleculeAutosuggestStates.ALERT}
+          iconClear={<IconClose />}
+        />
+      </div>
 
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>with submit button</h3>
-      <MoleculeAutosuggestWithState
-        placeholder="Type a Country name..."
-        onChange={(_, {value}) => console.log(value)}
-        onEnter={() => console.log('Enter pressed')}
-        rightButton={<SuiButton>Submit</SuiButton>}
-      />
-    </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>with submit button</h3>
+        <MoleculeAutosuggestWithState
+          placeholder="Type a Country name..."
+          onChange={(_, {value}) => console.log(value)}
+          onEnter={() => console.log('Enter pressed')}
+          rightButton={<SuiButton>Submit</SuiButton>}
+        />
+      </div>
 
-    <h2>Multiple Selection</h2>
-    <p>
-      Este componente permite añadir nuevas opciones (como tags) aunque no esten
-      disponibles entre las opciones disponibles del <code>DropdownList</code>
-    </p>
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>with Placeholder</h3>
-      <MoleculeAutosuggestWithStateTags
-        placeholder="Type a Country name..."
-        onChangeTags={(_, {tags}) => console.log(tags)}
-        iconCloseTag={<IconClose />}
-        iconClear={<IconClose />}
-        multiselection
-      />
-    </div>
+      <h2>Multiple Selection</h2>
+      <p>
+        Este componente permite añadir nuevas opciones (como tags) aunque no
+        esten disponibles entre las opciones disponibles del{' '}
+        <code>DropdownList</code>
+      </p>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>with Placeholder</h3>
+        <MoleculeAutosuggestWithStateTags
+          placeholder="Type a Country name..."
+          onChangeTags={(_, {tags}) => console.log(tags)}
+          iconCloseTag={<IconClose />}
+          iconClear={<IconClose />}
+          multiselection
+        />
+      </div>
 
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With preselected Value</h3>
-      <MoleculeAutosuggestWithStateTags
-        tags={['India', 'Luxembourg']}
-        onChangeTags={(_, {tags}) => console.log(tags)}
-        iconCloseTag={<IconClose />}
-        iconClear={<IconClose />}
-        multiselection
-      />
-    </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With preselected Value</h3>
+        <MoleculeAutosuggestWithStateTags
+          tags={['India', 'Luxembourg']}
+          onChangeTags={(_, {tags}) => console.log(tags)}
+          iconCloseTag={<IconClose />}
+          iconClear={<IconClose />}
+          multiselection
+        />
+      </div>
 
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>Disabled</h3>
-      <MoleculeAutosuggestWithStateTags
-        tags={['India', 'Luxembourg']}
-        onChangeTags={(_, {tags}) => console.log(tags)}
-        iconCloseTag={<IconClose />}
-        iconClear={<IconClose />}
-        multiselection
-        disabled
-      />
-    </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>Disabled</h3>
+        <MoleculeAutosuggestWithStateTags
+          tags={['India', 'Luxembourg']}
+          onChangeTags={(_, {tags}) => console.log(tags)}
+          iconCloseTag={<IconClose />}
+          iconClear={<IconClose />}
+          multiselection
+          disabled
+        />
+      </div>
 
-    <h2>Dependant Selection</h2>
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With Placeholder</h3>
-      <ComboCountries />
+      <h2>Dependant Selection</h2>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With Placeholder</h3>
+        <ComboCountries />
+      </div>
     </div>
   </div>
 )

--- a/demo/molecule/autosuggestField/demo/index.js
+++ b/demo/molecule/autosuggestField/demo/index.js
@@ -29,111 +29,111 @@ const BASE_CLASS_DEMO = 'DemoMoleculeAutosuggestField'
 const CLASS_DEMO_SECTION = `${BASE_CLASS_DEMO}-section`
 
 const Demo = () => (
-  <div className={BASE_CLASS_DEMO}>
-    <h1>
-      <code>MoleculeAutosuggestField</code>
-    </h1>
-    <h2>Single Selection</h2>
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With Placeholder</h3>
-      <MoleculeAutosuggestFieldWithState
-        id="with-placeholder"
-        label="Country"
-        placeholder="Select a Country..."
-        onChange={(_, {value}) => console.log(value)}
-        iconClear={<IconClose />}
-      />
-    </div>
+  <div className="sui-StudioPreview">
+    <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+      <h1>Autosuggest field</h1>
+      <h2>Single Selection</h2>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With Placeholder</h3>
+        <MoleculeAutosuggestFieldWithState
+          id="with-placeholder"
+          label="Country"
+          placeholder="Select a Country..."
+          onChange={(_, {value}) => console.log(value)}
+          iconClear={<IconClose />}
+        />
+      </div>
 
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With Information HelpText</h3>
-      <MoleculeAutosuggestFieldWithState
-        id="with-info-help-text"
-        label="Country"
-        placeholder="Select a Country..."
-        onChange={(_, {value}) => console.log(value)}
-        helpText="The country selected will be added to your profile"
-        iconClear={<IconClose />}
-      />
-    </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With Information HelpText</h3>
+        <MoleculeAutosuggestFieldWithState
+          id="with-info-help-text"
+          label="Country"
+          placeholder="Select a Country..."
+          onChange={(_, {value}) => console.log(value)}
+          helpText="The country selected will be added to your profile"
+          iconClear={<IconClose />}
+        />
+      </div>
 
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With Success Validation HelpText</h3>
-      <MoleculeAutosuggestFieldWithState
-        id="with-success-validation-help-text"
-        label="Country"
-        placeholder="Select a Country..."
-        onChange={(_, {value}) => console.log(value)}
-        successText="Everything ok!"
-        iconClear={<IconClose />}
-      />
-    </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With Success Validation HelpText</h3>
+        <MoleculeAutosuggestFieldWithState
+          id="with-success-validation-help-text"
+          label="Country"
+          placeholder="Select a Country..."
+          onChange={(_, {value}) => console.log(value)}
+          successText="Everything ok!"
+          iconClear={<IconClose />}
+        />
+      </div>
 
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With Error validation HelpText</h3>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With Error validation HelpText</h3>
 
-      <MoleculeAutosuggestFieldWithState
-        id="with-error-validation-help-text"
-        label="Country"
-        placeholder="Select a Country..."
-        onChange={(_, {value}) => console.log(value)}
-        errorText="All wrong!"
-        iconClear={<IconClose />}
-      />
-    </div>
+        <MoleculeAutosuggestFieldWithState
+          id="with-error-validation-help-text"
+          label="Country"
+          placeholder="Select a Country..."
+          onChange={(_, {value}) => console.log(value)}
+          errorText="All wrong!"
+          iconClear={<IconClose />}
+        />
+      </div>
 
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With Alert validation HelpText</h3>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With Alert validation HelpText</h3>
 
-      <MoleculeAutosuggestFieldWithState
-        id="with-alert-validation-help-text"
-        label="Country"
-        placeholder="Select a Country..."
-        onChange={(_, {value}) => console.log(value)}
-        alertText="Something meh..."
-        iconClear={<IconClose />}
-      />
-    </div>
+        <MoleculeAutosuggestFieldWithState
+          id="with-alert-validation-help-text"
+          label="Country"
+          placeholder="Select a Country..."
+          onChange={(_, {value}) => console.log(value)}
+          alertText="Something meh..."
+          iconClear={<IconClose />}
+        />
+      </div>
 
-    <div className={CLASS_DEMO_SECTION} style={{background: '#2b91c1'}}>
-      <h3>With contrast label</h3>
-      <MoleculeAutosuggestField
-        id="with-placeholder"
-        label="Country"
-        placeholder="Select a Country..."
-        onChange={(_, {value}) => console.log(value)}
-        iconClear={<IconClose />}
-        useContrastLabel
-      />
-    </div>
+      <div className={CLASS_DEMO_SECTION} style={{background: '#2b91c1'}}>
+        <h3>With contrast label</h3>
+        <MoleculeAutosuggestField
+          id="with-placeholder"
+          label="Country"
+          placeholder="Select a Country..."
+          onChange={(_, {value}) => console.log(value)}
+          iconClear={<IconClose />}
+          useContrastLabel
+        />
+      </div>
 
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>Without label</h3>
-      <MoleculeAutosuggestField
-        id="with-placeholder"
-        placeholder="Select a Country..."
-        onChange={(_, {value}) => console.log(value)}
-        iconClear={<IconClose />}
-        useContrastLabel
-      />
-    </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>Without label</h3>
+        <MoleculeAutosuggestField
+          id="with-placeholder"
+          placeholder="Select a Country..."
+          onChange={(_, {value}) => console.log(value)}
+          iconClear={<IconClose />}
+          useContrastLabel
+        />
+      </div>
 
-    <h2>Multiple Selection</h2>
+      <h2>Multiple Selection</h2>
 
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With Error validation HelpText</h3>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With Error validation HelpText</h3>
 
-      <MoleculeAutosuggestFieldWithStateTags
-        id="multiple-selection-with-error-validation-help-text"
-        label="Country"
-        placeholder="Select a Country..."
-        errorText="All wrong!"
-        iconClear={<IconClose />}
-        iconCloseTag={<IconClose />}
-        multiselection
-        tags={['India', 'Luxembourg']}
-        onChangeTags={(_, {tags}) => console.log(tags)}
-      />
+        <MoleculeAutosuggestFieldWithStateTags
+          id="multiple-selection-with-error-validation-help-text"
+          label="Country"
+          placeholder="Select a Country..."
+          errorText="All wrong!"
+          iconClear={<IconClose />}
+          iconCloseTag={<IconClose />}
+          multiselection
+          tags={['India', 'Luxembourg']}
+          onChangeTags={(_, {tags}) => console.log(tags)}
+        />
+      </div>
     </div>
   </div>
 )

--- a/demo/molecule/badgeCounter/playground
+++ b/demo/molecule/badgeCounter/playground
@@ -11,7 +11,7 @@ const Icon = () => (
 
 return (
   <div>
-    <h1>MoleculeBadgeCounter</h1>
+    <h1>Badge Counter</h1>
     <h2>Small</h2>
     <p>
       <MoleculeBadgeCounter />

--- a/demo/molecule/breadcrumb/playground
+++ b/demo/molecule/breadcrumb/playground
@@ -27,7 +27,7 @@ const breadcrumbItems = [
 ]
 
 return (
-  <div style={{padding: '20px'}}>
+  <div>
     <h1>Breadcrumb</h1>
     <h2>Breadcrumb basic</h2>
     <BreadcrumbBasic icon={ArrowRight} items={breadcrumbItems} />

--- a/demo/molecule/buttonGroup/demo/index.js
+++ b/demo/molecule/buttonGroup/demo/index.js
@@ -43,149 +43,173 @@ const ButtonDesignByState = () => {
 
 const Demo = () => {
   return (
-    <div className="DemoMoleculeButtonGroup">
-      <h1>MoleculeButtonGroup</h1>
-      <div className="DemoMoleculeButtonGroup-section DemoMoleculeButtonGroup-designs">
-        <h2>As a group of buttons that trigger some action (or link)</h2>
-        <div>
-          <MoleculeButtonGroup>
-            <AtomButton design="solid" onClick={e => window.alert('clicked A')}>
-              A
-            </AtomButton>
-            <AtomButton design="solid" onClick={e => window.alert('clicked B')}>
-              B
-            </AtomButton>
-            <AtomButton design="solid" onClick={e => window.alert('clicked C')}>
-              C
-            </AtomButton>
-          </MoleculeButtonGroup>
-          <MoleculeButtonGroup>
-            <AtomButton
-              design="outline"
-              onClick={e => window.alert('clicked A')}
-            >
-              A
-            </AtomButton>
-            <AtomButton
-              design="outline"
-              onClick={e => window.alert('clicked B')}
-            >
-              B
-            </AtomButton>
-            <AtomButton
-              design="outline"
-              onClick={e => window.alert('clicked C')}
-            >
-              C
-            </AtomButton>
-          </MoleculeButtonGroup>
-          <MoleculeButtonGroup>
-            <AtomButton design="flat" onClick={e => window.alert('clicked A')}>
-              A
-            </AtomButton>
-            <AtomButton design="flat" onClick={e => window.alert('clicked B')}>
-              B
-            </AtomButton>
-            <AtomButton design="flat" onClick={e => window.alert('clicked C')}>
-              C
-            </AtomButton>
+    <div className="sui-StudioPreview">
+      <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+        <h1>Button Group</h1>
+        <div className="DemoMoleculeButtonGroup-section DemoMoleculeButtonGroup-designs">
+          <h2>As a group of buttons that trigger some action (or link)</h2>
+          <div>
+            <MoleculeButtonGroup>
+              <AtomButton
+                design="solid"
+                onClick={e => window.alert('clicked A')}
+              >
+                A
+              </AtomButton>
+              <AtomButton
+                design="solid"
+                onClick={e => window.alert('clicked B')}
+              >
+                B
+              </AtomButton>
+              <AtomButton
+                design="solid"
+                onClick={e => window.alert('clicked C')}
+              >
+                C
+              </AtomButton>
+            </MoleculeButtonGroup>
+            <MoleculeButtonGroup>
+              <AtomButton
+                design="outline"
+                onClick={e => window.alert('clicked A')}
+              >
+                A
+              </AtomButton>
+              <AtomButton
+                design="outline"
+                onClick={e => window.alert('clicked B')}
+              >
+                B
+              </AtomButton>
+              <AtomButton
+                design="outline"
+                onClick={e => window.alert('clicked C')}
+              >
+                C
+              </AtomButton>
+            </MoleculeButtonGroup>
+            <MoleculeButtonGroup>
+              <AtomButton
+                design="flat"
+                onClick={e => window.alert('clicked A')}
+              >
+                A
+              </AtomButton>
+              <AtomButton
+                design="flat"
+                onClick={e => window.alert('clicked B')}
+              >
+                B
+              </AtomButton>
+              <AtomButton
+                design="flat"
+                onClick={e => window.alert('clicked C')}
+              >
+                C
+              </AtomButton>
+            </MoleculeButtonGroup>
+          </div>
+          <div className="DemoMoleculeButtonGroup-negative">
+            <MoleculeButtonGroup>
+              <AtomButton
+                design="solid"
+                negative
+                onClick={e => window.alert('clicked A')}
+              >
+                A
+              </AtomButton>
+              <AtomButton
+                design="solid"
+                negative
+                onClick={e => window.alert('clicked B')}
+              >
+                B
+              </AtomButton>
+              <AtomButton
+                design="solid"
+                negative
+                onClick={e => window.alert('clicked C')}
+              >
+                C
+              </AtomButton>
+            </MoleculeButtonGroup>
+            <MoleculeButtonGroup>
+              <AtomButton
+                design="outline"
+                negative
+                onClick={e => window.alert('clicked A')}
+              >
+                A
+              </AtomButton>
+              <AtomButton
+                design="outline"
+                negative
+                onClick={e => window.alert('clicked B')}
+              >
+                B
+              </AtomButton>
+              <AtomButton
+                design="outline"
+                negative
+                onClick={e => window.alert('clicked C')}
+              >
+                C
+              </AtomButton>
+            </MoleculeButtonGroup>
+            <MoleculeButtonGroup>
+              <AtomButton
+                design="flat"
+                negative
+                onClick={e => window.alert('clicked A')}
+              >
+                A
+              </AtomButton>
+              <AtomButton
+                design="flat"
+                negative
+                onClick={e => window.alert('clicked B')}
+              >
+                B
+              </AtomButton>
+              <AtomButton
+                design="flat"
+                negative
+                onClick={e => window.alert('clicked C')}
+              >
+                C
+              </AtomButton>
+            </MoleculeButtonGroup>
+          </div>
+        </div>
+        <div className="DemoMoleculeButtonGroup-section">
+          <h2>
+            As a group of choices (only one can be selected) → 'input radio'
+            like
+          </h2>
+          <SimpleOptionsRadioForm />
+        </div>
+        <div className="DemoMoleculeButtonGroup-section">
+          <h2>
+            As a group of choices (several can be selected) → 'checkbox' like
+          </h2>
+          <SimpleOptionsCheckboxForm />
+        </div>
+        <div
+          style={{width: '500px'}}
+          className="DemoMoleculeButtonGroup-section"
+        >
+          <h2>specifying groupPositions</h2>
+          <MoleculeButtonGroup groupPositions={atomButtonGroupPositions}>
+            <AtomButton design="solid">A</AtomButton>
+            <AtomButton design="solid">B</AtomButton>
+            <AtomButton design="solid">C</AtomButton>
           </MoleculeButtonGroup>
         </div>
-        <div className="DemoMoleculeButtonGroup-negative">
-          <MoleculeButtonGroup>
-            <AtomButton
-              design="solid"
-              negative
-              onClick={e => window.alert('clicked A')}
-            >
-              A
-            </AtomButton>
-            <AtomButton
-              design="solid"
-              negative
-              onClick={e => window.alert('clicked B')}
-            >
-              B
-            </AtomButton>
-            <AtomButton
-              design="solid"
-              negative
-              onClick={e => window.alert('clicked C')}
-            >
-              C
-            </AtomButton>
-          </MoleculeButtonGroup>
-          <MoleculeButtonGroup>
-            <AtomButton
-              design="outline"
-              negative
-              onClick={e => window.alert('clicked A')}
-            >
-              A
-            </AtomButton>
-            <AtomButton
-              design="outline"
-              negative
-              onClick={e => window.alert('clicked B')}
-            >
-              B
-            </AtomButton>
-            <AtomButton
-              design="outline"
-              negative
-              onClick={e => window.alert('clicked C')}
-            >
-              C
-            </AtomButton>
-          </MoleculeButtonGroup>
-          <MoleculeButtonGroup>
-            <AtomButton
-              design="flat"
-              negative
-              onClick={e => window.alert('clicked A')}
-            >
-              A
-            </AtomButton>
-            <AtomButton
-              design="flat"
-              negative
-              onClick={e => window.alert('clicked B')}
-            >
-              B
-            </AtomButton>
-            <AtomButton
-              design="flat"
-              negative
-              onClick={e => window.alert('clicked C')}
-            >
-              C
-            </AtomButton>
-          </MoleculeButtonGroup>
+        <div className="DemoMoleculeButtonGroup-section">
+          <h2>different design dependeding on state</h2>
+          <ButtonDesignByState />
         </div>
-      </div>
-      <div className="DemoMoleculeButtonGroup-section">
-        <h2>
-          As a group of choices (only one can be selected) → 'input radio' like
-        </h2>
-        <SimpleOptionsRadioForm />
-      </div>
-      <div className="DemoMoleculeButtonGroup-section">
-        <h2>
-          As a group of choices (several can be selected) → 'checkbox' like
-        </h2>
-        <SimpleOptionsCheckboxForm />
-      </div>
-      <div style={{width: '500px'}} className="DemoMoleculeButtonGroup-section">
-        <h2>specifying groupPositions</h2>
-        <MoleculeButtonGroup groupPositions={atomButtonGroupPositions}>
-          <AtomButton design="solid">A</AtomButton>
-          <AtomButton design="solid">B</AtomButton>
-          <AtomButton design="solid">C</AtomButton>
-        </MoleculeButtonGroup>
-      </div>
-      <div className="DemoMoleculeButtonGroup-section">
-        <h2>different design dependeding on state</h2>
-        <ButtonDesignByState />
       </div>
     </div>
   )

--- a/demo/molecule/buttonGroupField/demo/index.js
+++ b/demo/molecule/buttonGroupField/demo/index.js
@@ -9,58 +9,60 @@ const BASE_CLASS_DEMO = 'DemoMoleculeButtonGroupField'
 
 const DemoMoleculeButtonGroupField = () => {
   return (
-    <div className={BASE_CLASS_DEMO}>
-      <h1>MoleculeButtonGroupField</h1>
-      <div className={`${BASE_CLASS_DEMO}-section`}>
-        <h2>With Information HelpText</h2>
-        <MoleculeButtonGroupField
-          id="info-help-text"
-          label="Your text here"
-          helpText="Your description here"
-        >
-          <AtomButtom onClick={e => window.alert('clicked A')}>A</AtomButtom>
-          <AtomButtom onClick={e => window.alert('clicked B')}>B</AtomButtom>
-          <AtomButtom onClick={e => window.alert('clicked C')}>C</AtomButtom>
-        </MoleculeButtonGroupField>
-      </div>
+    <div className="sui-StudioPreview">
+      <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+        <h1>Button Group Field</h1>
+        <div className={`${BASE_CLASS_DEMO}-section`}>
+          <h2>With Information HelpText</h2>
+          <MoleculeButtonGroupField
+            id="info-help-text"
+            label="Your text here"
+            helpText="Your description here"
+          >
+            <AtomButtom onClick={e => window.alert('clicked A')}>A</AtomButtom>
+            <AtomButtom onClick={e => window.alert('clicked B')}>B</AtomButtom>
+            <AtomButtom onClick={e => window.alert('clicked C')}>C</AtomButtom>
+          </MoleculeButtonGroupField>
+        </div>
 
-      <div className={`${BASE_CLASS_DEMO}-section`}>
-        <h2>With Success Validation HelpText</h2>
-        <MoleculeButtonGroupField
-          id="success-help-text"
-          label="Your text here"
-          successText="Everything ok!"
-        >
-          <AtomButtom onClick={e => window.alert('clicked A')}>A</AtomButtom>
-          <AtomButtom onClick={e => window.alert('clicked B')}>B</AtomButtom>
-          <AtomButtom onClick={e => window.alert('clicked C')}>C</AtomButtom>
-        </MoleculeButtonGroupField>
-      </div>
+        <div className={`${BASE_CLASS_DEMO}-section`}>
+          <h2>With Success Validation HelpText</h2>
+          <MoleculeButtonGroupField
+            id="success-help-text"
+            label="Your text here"
+            successText="Everything ok!"
+          >
+            <AtomButtom onClick={e => window.alert('clicked A')}>A</AtomButtom>
+            <AtomButtom onClick={e => window.alert('clicked B')}>B</AtomButtom>
+            <AtomButtom onClick={e => window.alert('clicked C')}>C</AtomButtom>
+          </MoleculeButtonGroupField>
+        </div>
 
-      <div className={`${BASE_CLASS_DEMO}-section`}>
-        <h2>With Error validation HelpText</h2>
-        <MoleculeButtonGroupField
-          id="error-help-text"
-          label="Your text here"
-          errorText="All wrong!"
-        >
-          <AtomButtom onClick={e => window.alert('clicked A')}>A</AtomButtom>
-          <AtomButtom onClick={e => window.alert('clicked B')}>B</AtomButtom>
-          <AtomButtom onClick={e => window.alert('clicked C')}>C</AtomButtom>
-        </MoleculeButtonGroupField>
-      </div>
+        <div className={`${BASE_CLASS_DEMO}-section`}>
+          <h2>With Error validation HelpText</h2>
+          <MoleculeButtonGroupField
+            id="error-help-text"
+            label="Your text here"
+            errorText="All wrong!"
+          >
+            <AtomButtom onClick={e => window.alert('clicked A')}>A</AtomButtom>
+            <AtomButtom onClick={e => window.alert('clicked B')}>B</AtomButtom>
+            <AtomButtom onClick={e => window.alert('clicked C')}>C</AtomButtom>
+          </MoleculeButtonGroupField>
+        </div>
 
-      <div className={`${BASE_CLASS_DEMO}-section`}>
-        <h2>With Alert validation HelpText</h2>
-        <MoleculeButtonGroupField
-          id="alert-help-text"
-          label="Your text here"
-          alertText="Something meh..."
-        >
-          <AtomButtom onClick={e => window.alert('clicked A')}>A</AtomButtom>
-          <AtomButtom onClick={e => window.alert('clicked B')}>B</AtomButtom>
-          <AtomButtom onClick={e => window.alert('clicked C')}>C</AtomButtom>
-        </MoleculeButtonGroupField>
+        <div className={`${BASE_CLASS_DEMO}-section`}>
+          <h2>With Alert validation HelpText</h2>
+          <MoleculeButtonGroupField
+            id="alert-help-text"
+            label="Your text here"
+            alertText="Something meh..."
+          >
+            <AtomButtom onClick={e => window.alert('clicked A')}>A</AtomButtom>
+            <AtomButtom onClick={e => window.alert('clicked B')}>B</AtomButtom>
+            <AtomButtom onClick={e => window.alert('clicked C')}>C</AtomButtom>
+          </MoleculeButtonGroupField>
+        </div>
       </div>
     </div>
   )

--- a/demo/molecule/checkboxField/demo/index.js
+++ b/demo/molecule/checkboxField/demo/index.js
@@ -4,8 +4,6 @@ import MoleculeCheckboxField from '../../../../components/molecule/checkboxField
 
 import './index.scss'
 
-const BASE_CLASS_DEMO = `DemoMoleculeCheckboxField`
-
 const styleList = {
   listStyle: 'none'
 }
@@ -16,77 +14,77 @@ const styleListItem = {
 
 const Demo = () => {
   return (
-    <div className={BASE_CLASS_DEMO}>
-      <h1>
-        <code>MoleculeCheckboxField</code>
-      </h1>
-      <ul style={styleList}>
-        <li style={styleListItem}>
-          <h2>With Information HelpText</h2>
-          <MoleculeCheckboxField
-            id="info-help-text"
-            label="Description"
-            helpText="Tu descripción en Latin"
-            onChange={(e, {name, value}) => console.log({[name]: value})}
-          />
-        </li>
-        <li style={styleListItem}>
-          <h2>With Html Label</h2>
-          <MoleculeCheckboxField
-            id="info-help-text"
-            nodeLabel={
-              <>
-                this is the <a href="#">nodeLabel</a>
-              </>
-            }
-            onChange={(e, {name, value}) => console.log({[name]: value})}
-          />
-        </li>
-        <li style={styleListItem}>
-          <h2>With Html Label + fullWidth</h2>
-          <MoleculeCheckboxField
-            id="info-help-text"
-            fullWidth
-            nodeLabel={
-              <div style={{display: 'flex', border: '1px dashed #000'}}>
-                <div style={{flexGrow: 1}}>I'm full width</div>
-                <button>Action</button>
-              </div>
-            }
-            onChange={(e, {name, value}) => console.log({[name]: value})}
-          />
-        </li>
-        <li style={styleListItem}>
-          <h2>With Success Validation HelpText</h2>
-          <MoleculeCheckboxField
-            id="success-help-text"
-            label="Description"
-            value="In some place of La Mancha which name..."
-            successText="Everything ok!"
-            onChange={(e, {name, value}) => console.log({[name]: value})}
-          />
-        </li>
-        <li style={styleListItem}>
-          <h2>With Error validation HelpText</h2>
-          <MoleculeCheckboxField
-            id="error-help-text"
-            label="Notes"
-            errorText="All wrong!"
-            value="In some place of La Mancha which name..."
-            onChange={(e, {name, value}) => console.log({[name]: value})}
-          />
-        </li>
-        <li style={styleListItem}>
-          <h2>With Alert validation HelpText</h2>
-          <MoleculeCheckboxField
-            id="alert-help-text"
-            label="Notes"
-            alertText="Something meh..."
-            value="In some place of La Mancha which name..."
-            onChange={(e, {name, value}) => console.log({[name]: value})}
-          />
-        </li>
-      </ul>
+    <div className="sui-StudioPreview">
+      <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+        <h1>Checkbox Field</h1>
+        <ul style={styleList}>
+          <li style={styleListItem}>
+            <h2>With Information HelpText</h2>
+            <MoleculeCheckboxField
+              id="info-help-text"
+              label="Description"
+              helpText="Tu descripción en Latin"
+              onChange={(e, {name, value}) => console.log({[name]: value})}
+            />
+          </li>
+          <li style={styleListItem}>
+            <h2>With Html Label</h2>
+            <MoleculeCheckboxField
+              id="info-help-text"
+              nodeLabel={
+                <>
+                  this is the <a href="#">nodeLabel</a>
+                </>
+              }
+              onChange={(e, {name, value}) => console.log({[name]: value})}
+            />
+          </li>
+          <li style={styleListItem}>
+            <h2>With Html Label + fullWidth</h2>
+            <MoleculeCheckboxField
+              id="info-help-text"
+              fullWidth
+              nodeLabel={
+                <div style={{display: 'flex', border: '1px dashed #000'}}>
+                  <div style={{flexGrow: 1}}>I'm full width</div>
+                  <button>Action</button>
+                </div>
+              }
+              onChange={(e, {name, value}) => console.log({[name]: value})}
+            />
+          </li>
+          <li style={styleListItem}>
+            <h2>With Success Validation HelpText</h2>
+            <MoleculeCheckboxField
+              id="success-help-text"
+              label="Description"
+              value="In some place of La Mancha which name..."
+              successText="Everything ok!"
+              onChange={(e, {name, value}) => console.log({[name]: value})}
+            />
+          </li>
+          <li style={styleListItem}>
+            <h2>With Error validation HelpText</h2>
+            <MoleculeCheckboxField
+              id="error-help-text"
+              label="Notes"
+              errorText="All wrong!"
+              value="In some place of La Mancha which name..."
+              onChange={(e, {name, value}) => console.log({[name]: value})}
+            />
+          </li>
+          <li style={styleListItem}>
+            <h2>With Alert validation HelpText</h2>
+            <MoleculeCheckboxField
+              id="alert-help-text"
+              label="Notes"
+              alertText="Something meh..."
+              value="In some place of La Mancha which name..."
+              onChange={(e, {name, value}) => console.log({[name]: value})}
+            />
+          </li>
+        </ul>
+      </div>
     </div>
   )
 }

--- a/demo/molecule/dataCounter/playground
+++ b/demo/molecule/dataCounter/playground
@@ -23,7 +23,7 @@ const propsMessages = {
 
 return (
   <div>
-   <h1><pre>MoleculeDataCounter</pre></h1>  
+   <h1>Data Counter</h1>  
     <h2>Basic</h2>
     <div style={stylesSection}>
       <MoleculeDataCounter onChange={consoleValue} label="Label" id="demo1"  {...propsMessages} />

--- a/demo/molecule/dropdownList/demo/index.js
+++ b/demo/molecule/dropdownList/demo/index.js
@@ -27,141 +27,141 @@ const MoleculeDropdownOptionListWithStateMulti = withStateMulti(
 )
 
 const Demo = () => (
-  <div className={BASE_CLASS_DEMO}>
-    <h1>
-      <code>MoleculeDropdownList</code>
-    </h1>
-    <h2>Dynamic</h2>
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>Single selection</h3>
+  <div className="sui-StudioPreview">
+    <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+      <h1>Dropdown List</h1>
+      <h2>Dynamic</h2>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>Single selection</h3>
 
-      <MoleculeDropdownOptionListWithStateSingle visible={isOpen}>
-        {countries.map((option, index) => (
-          <MoleculeDropdownOption value={option} key={index}>
-            {option}
-          </MoleculeDropdownOption>
-        ))}
-      </MoleculeDropdownOptionListWithStateSingle>
-
-      <h3>Multi selection</h3>
-
-      <MoleculeDropdownOptionListWithStateMulti
-        visible={isOpen}
-        checkbox
-        onSelectKey=" "
-      >
-        {countries.map((option, index) => (
-          <MoleculeDropdownOption value={option} key={index}>
-            {option}
-          </MoleculeDropdownOption>
-        ))}
-      </MoleculeDropdownOptionListWithStateMulti>
-    </div>
-
-    <h2>Static</h2>
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>
-        Basic (default <code>size → SMALL</code>)
-      </h3>
-      <div className={CLASS_DEMO_LIST}>
-        <MoleculeDropdownList visible={isOpen}>
+        <MoleculeDropdownOptionListWithStateSingle visible={isOpen}>
           {countries.map((option, index) => (
-            <MoleculeDropdownOption
-              value={option}
-              key={index}
-              selected={option === 'Canary Islands'}
-            >
+            <MoleculeDropdownOption value={option} key={index}>
               {option}
             </MoleculeDropdownOption>
           ))}
-        </MoleculeDropdownList>
-      </div>
-      <h3>
-        Basic (<code>size → MEDIUM</code>)
-      </h3>
-      <div className={CLASS_DEMO_LIST}>
-        <MoleculeDropdownList
+        </MoleculeDropdownOptionListWithStateSingle>
+
+        <h3>Multi selection</h3>
+
+        <MoleculeDropdownOptionListWithStateMulti
           visible={isOpen}
-          size={moleculeDropdownListSizes.MEDIUM}
+          checkbox
+          onSelectKey=" "
         >
           {countries.map((option, index) => (
-            <MoleculeDropdownOption
-              value={option}
-              key={index}
-              selected={option === 'Canary Islands'}
-            >
+            <MoleculeDropdownOption value={option} key={index}>
               {option}
             </MoleculeDropdownOption>
           ))}
-        </MoleculeDropdownList>
+        </MoleculeDropdownOptionListWithStateMulti>
       </div>
-      <h3>
-        Basic (<code>size → LARGE</code>)
-      </h3>
-      <div className={CLASS_DEMO_LIST}>
-        <MoleculeDropdownList
-          visible={isOpen}
-          size={moleculeDropdownListSizes.LARGE}
-        >
-          {countries.map((option, index) => (
-            <MoleculeDropdownOption
-              value={option}
-              key={index}
-              selected={option === 'Canary Islands'}
-            >
-              {option}
-            </MoleculeDropdownOption>
-          ))}
-        </MoleculeDropdownList>
-      </div>
-      <h3>w/ Checkbox</h3>
-      <div className={CLASS_DEMO_LIST}>
-        <MoleculeDropdownList checkbox visible={isOpen}>
-          {countries.map((option, index) => (
-            <MoleculeDropdownOption
-              value={option}
-              key={index}
-              selected={option === 'Canary Islands'}
-            >
-              {option}
-            </MoleculeDropdownOption>
-          ))}
-        </MoleculeDropdownList>
-      </div>
-      <h3>w/ Disabled Options</h3>
-      <div className={CLASS_DEMO_LIST}>
-        <MoleculeDropdownList checkbox visible={isOpen}>
-          {countries.map((option, index) => (
-            <MoleculeDropdownOption
-              value={option}
-              key={index}
-              selected={option === 'Canary Islands'}
-              disabled={['Luxembourg', 'Cameroon', 'Venezuela'].includes(
-                option
-              )}
-            >
-              {option}
-            </MoleculeDropdownOption>
-          ))}
-        </MoleculeDropdownList>
-      </div>
-      <h3>
-        w/ Highlight Query (<code>'an'</code>)
-      </h3>
-      <div className={CLASS_DEMO_LIST}>
-        <MoleculeDropdownList visible={isOpen}>
-          {countries
-            .filter(country => country.toLowerCase().includes('an'))
-            .map((option, index) => (
+
+      <h2>Static</h2>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>
+          Basic (default <code>size → SMALL</code>)
+        </h3>
+        <div className={CLASS_DEMO_LIST}>
+          <MoleculeDropdownList visible={isOpen}>
+            {countries.map((option, index) => (
               <MoleculeDropdownOption
                 value={option}
                 key={index}
-                highlightQuery="an"
+                selected={option === 'Canary Islands'}
               >
                 {option}
               </MoleculeDropdownOption>
             ))}
-        </MoleculeDropdownList>
+          </MoleculeDropdownList>
+        </div>
+        <h3>
+          Basic (<code>size → MEDIUM</code>)
+        </h3>
+        <div className={CLASS_DEMO_LIST}>
+          <MoleculeDropdownList
+            visible={isOpen}
+            size={moleculeDropdownListSizes.MEDIUM}
+          >
+            {countries.map((option, index) => (
+              <MoleculeDropdownOption
+                value={option}
+                key={index}
+                selected={option === 'Canary Islands'}
+              >
+                {option}
+              </MoleculeDropdownOption>
+            ))}
+          </MoleculeDropdownList>
+        </div>
+        <h3>
+          Basic (<code>size → LARGE</code>)
+        </h3>
+        <div className={CLASS_DEMO_LIST}>
+          <MoleculeDropdownList
+            visible={isOpen}
+            size={moleculeDropdownListSizes.LARGE}
+          >
+            {countries.map((option, index) => (
+              <MoleculeDropdownOption
+                value={option}
+                key={index}
+                selected={option === 'Canary Islands'}
+              >
+                {option}
+              </MoleculeDropdownOption>
+            ))}
+          </MoleculeDropdownList>
+        </div>
+        <h3>w/ Checkbox</h3>
+        <div className={CLASS_DEMO_LIST}>
+          <MoleculeDropdownList checkbox visible={isOpen}>
+            {countries.map((option, index) => (
+              <MoleculeDropdownOption
+                value={option}
+                key={index}
+                selected={option === 'Canary Islands'}
+              >
+                {option}
+              </MoleculeDropdownOption>
+            ))}
+          </MoleculeDropdownList>
+        </div>
+        <h3>w/ Disabled Options</h3>
+        <div className={CLASS_DEMO_LIST}>
+          <MoleculeDropdownList checkbox visible={isOpen}>
+            {countries.map((option, index) => (
+              <MoleculeDropdownOption
+                value={option}
+                key={index}
+                selected={option === 'Canary Islands'}
+                disabled={['Luxembourg', 'Cameroon', 'Venezuela'].includes(
+                  option
+                )}
+              >
+                {option}
+              </MoleculeDropdownOption>
+            ))}
+          </MoleculeDropdownList>
+        </div>
+        <h3>
+          w/ Highlight Query (<code>'an'</code>)
+        </h3>
+        <div className={CLASS_DEMO_LIST}>
+          <MoleculeDropdownList visible={isOpen}>
+            {countries
+              .filter(country => country.toLowerCase().includes('an'))
+              .map((option, index) => (
+                <MoleculeDropdownOption
+                  value={option}
+                  key={index}
+                  highlightQuery="an"
+                >
+                  {option}
+                </MoleculeDropdownOption>
+              ))}
+          </MoleculeDropdownList>
+        </div>
       </div>
     </div>
   </div>

--- a/demo/molecule/dropdownOption/demo/index.js
+++ b/demo/molecule/dropdownOption/demo/index.js
@@ -15,140 +15,144 @@ const CLASS_DEMO_SECTION = `${BASE_CLASS_DEMO}-section`
 const CLASS_DEMO_OPTION = `${BASE_CLASS_DEMO}-option`
 
 const Demo = () => (
-  <div className={BASE_CLASS_DEMO}>
-    <h1>
-      <code>MoleculeDropdownOption</code>
-    </h1>
-    <h2>Dynamic</h2>
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>Basic Options & unique selection</h3>
-      <BasicDropdownOptions options={['john', 'paul', 'george', 'ringo']} />
-      <h3>Checkbox Options & multiple selection</h3>
-      <CheckboxDropdownOptions options={['john', 'paul', 'george', 'ringo']} />
-      <h3>Highlight options</h3>
-      <HighlightDropdownOptions options={['john', 'paul', 'george', 'ringo']} />
-    </div>
-    <h2>Static</h2>
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>Basic</h3>
-      <div className={CLASS_DEMO_OPTION}>
-        <MoleculeDropdownOption value="option-basic">
-          basic
-        </MoleculeDropdownOption>
+  <div className="sui-StudioPreview">
+    <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+      <h1>Dropdown Options</h1>
+      <h2>Dynamic</h2>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>Basic Options & unique selection</h3>
+        <BasicDropdownOptions options={['john', 'paul', 'george', 'ringo']} />
+        <h3>Checkbox Options & multiple selection</h3>
+        <CheckboxDropdownOptions
+          options={['john', 'paul', 'george', 'ringo']}
+        />
+        <h3>Highlight options</h3>
+        <HighlightDropdownOptions
+          options={['john', 'paul', 'george', 'ringo']}
+        />
       </div>
-      <h3>Basic selected </h3>
-      <div className={CLASS_DEMO_OPTION}>
-        <MoleculeDropdownOption value="option-selected" selected>
-          selected
-        </MoleculeDropdownOption>
-      </div>
-      <h3>Disabled</h3>
-      <div className={CLASS_DEMO_OPTION}>
-        <MoleculeDropdownOption value="option-disabled" disabled>
-          disabled
-        </MoleculeDropdownOption>
-      </div>
-      <h3>With checkbox</h3>
-      <div className={CLASS_DEMO_OPTION}>
-        <MoleculeDropdownOption value="option-checkbox" checkbox>
-          checkbox
-        </MoleculeDropdownOption>
-      </div>
-      <h3>With checkbox selected</h3>
-      <div className={CLASS_DEMO_OPTION}>
-        <MoleculeDropdownOption value="option-selected" checkbox selected>
-          selected
-        </MoleculeDropdownOption>
-      </div>
-      <h3>With text highlighted</h3>
-      <div className={CLASS_DEMO_OPTION}>
-        <MoleculeDropdownOption value="indiana jones" highlightQuery="indi">
-          Indiana Jones
-        </MoleculeDropdownOption>
-      </div>
+      <h2>Static</h2>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>Basic</h3>
+        <div className={CLASS_DEMO_OPTION}>
+          <MoleculeDropdownOption value="option-basic">
+            basic
+          </MoleculeDropdownOption>
+        </div>
+        <h3>Basic selected </h3>
+        <div className={CLASS_DEMO_OPTION}>
+          <MoleculeDropdownOption value="option-selected" selected>
+            selected
+          </MoleculeDropdownOption>
+        </div>
+        <h3>Disabled</h3>
+        <div className={CLASS_DEMO_OPTION}>
+          <MoleculeDropdownOption value="option-disabled" disabled>
+            disabled
+          </MoleculeDropdownOption>
+        </div>
+        <h3>With checkbox</h3>
+        <div className={CLASS_DEMO_OPTION}>
+          <MoleculeDropdownOption value="option-checkbox" checkbox>
+            checkbox
+          </MoleculeDropdownOption>
+        </div>
+        <h3>With checkbox selected</h3>
+        <div className={CLASS_DEMO_OPTION}>
+          <MoleculeDropdownOption value="option-selected" checkbox selected>
+            selected
+          </MoleculeDropdownOption>
+        </div>
+        <h3>With text highlighted</h3>
+        <div className={CLASS_DEMO_OPTION}>
+          <MoleculeDropdownOption value="indiana jones" highlightQuery="indi">
+            Indiana Jones
+          </MoleculeDropdownOption>
+        </div>
 
-      <h3>With callback (click & enter)</h3>
-      <div className={CLASS_DEMO_OPTION}>
-        <MoleculeDropdownOption
-          value="Indiana Jones"
-          checkbox
-          onClick={(e, {value}) => {
-            window.alert(value)
-          }}
-        >
-          Indiana Jones
-        </MoleculeDropdownOption>
-      </div>
-      <h3>With callback (click & space)</h3>
-      <div className={CLASS_DEMO_OPTION}>
-        <MoleculeDropdownOption
-          value="Indiana Jones"
-          checkbox
-          onSelectKey=" "
-          onClick={(e, {value}) => {
-            window.alert(value)
-          }}
-        >
-          Indiana Jones
-        </MoleculeDropdownOption>
-      </div>
-      <h3>With some HTML as children</h3>
-      <div className={CLASS_DEMO_OPTION}>
-        <MoleculeDropdownOption value="sparta" checkbox selected>
-          <span>
-            this is <em>sparta</em> 😎
-          </span>
-        </MoleculeDropdownOption>
-      </div>
-      <h3>Ellipsis</h3>
-      <div className={CLASS_DEMO_OPTION}>
-        <MoleculeDropdownOption value="option-basic">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua.
-        </MoleculeDropdownOption>
-      </div>
-      <h3>Two lines text clamp (deprecated prop withTwoLinesText)</h3>
-      <div className={CLASS_DEMO_OPTION}>
-        <MoleculeDropdownOption value="option-basic" withTwoLinesText>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua.
-        </MoleculeDropdownOption>
-      </div>
-      <h3>With Two Lines Wrap</h3>
-      <div className={CLASS_DEMO_OPTION}>
-        <MoleculeDropdownOption
-          value="option-basic"
-          textWrap={MoleculeDropdownOptionTextWrapStyles.TWO_LINES}
-        >
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-          aliquip ex ea commodo consequat.
-        </MoleculeDropdownOption>
-      </div>
-      <h3>With Three Lines Wrap</h3>
-      <div className={CLASS_DEMO_OPTION}>
-        <MoleculeDropdownOption
-          value="option-basic"
-          textWrap={MoleculeDropdownOptionTextWrapStyles.THREE_LINES}
-        >
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-          aliquip ex ea commodo consequat.
-        </MoleculeDropdownOption>
-      </div>
-      <h3>With Line Wrap</h3>
-      <div className={CLASS_DEMO_OPTION}>
-        <MoleculeDropdownOption
-          value="option-basic"
-          textWrap={MoleculeDropdownOptionTextWrapStyles.LINE_WRAP}
-        >
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-          aliquip ex ea commodo consequat.
-        </MoleculeDropdownOption>
+        <h3>With callback (click & enter)</h3>
+        <div className={CLASS_DEMO_OPTION}>
+          <MoleculeDropdownOption
+            value="Indiana Jones"
+            checkbox
+            onClick={(e, {value}) => {
+              window.alert(value)
+            }}
+          >
+            Indiana Jones
+          </MoleculeDropdownOption>
+        </div>
+        <h3>With callback (click & space)</h3>
+        <div className={CLASS_DEMO_OPTION}>
+          <MoleculeDropdownOption
+            value="Indiana Jones"
+            checkbox
+            onSelectKey=" "
+            onClick={(e, {value}) => {
+              window.alert(value)
+            }}
+          >
+            Indiana Jones
+          </MoleculeDropdownOption>
+        </div>
+        <h3>With some HTML as children</h3>
+        <div className={CLASS_DEMO_OPTION}>
+          <MoleculeDropdownOption value="sparta" checkbox selected>
+            <span>
+              this is <em>sparta</em> 😎
+            </span>
+          </MoleculeDropdownOption>
+        </div>
+        <h3>Ellipsis</h3>
+        <div className={CLASS_DEMO_OPTION}>
+          <MoleculeDropdownOption value="option-basic">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          </MoleculeDropdownOption>
+        </div>
+        <h3>Two lines text clamp (deprecated prop withTwoLinesText)</h3>
+        <div className={CLASS_DEMO_OPTION}>
+          <MoleculeDropdownOption value="option-basic" withTwoLinesText>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          </MoleculeDropdownOption>
+        </div>
+        <h3>With Two Lines Wrap</h3>
+        <div className={CLASS_DEMO_OPTION}>
+          <MoleculeDropdownOption
+            value="option-basic"
+            textWrap={MoleculeDropdownOptionTextWrapStyles.TWO_LINES}
+          >
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat.
+          </MoleculeDropdownOption>
+        </div>
+        <h3>With Three Lines Wrap</h3>
+        <div className={CLASS_DEMO_OPTION}>
+          <MoleculeDropdownOption
+            value="option-basic"
+            textWrap={MoleculeDropdownOptionTextWrapStyles.THREE_LINES}
+          >
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat.
+          </MoleculeDropdownOption>
+        </div>
+        <h3>With Line Wrap</h3>
+        <div className={CLASS_DEMO_OPTION}>
+          <MoleculeDropdownOption
+            value="option-basic"
+            textWrap={MoleculeDropdownOptionTextWrapStyles.LINE_WRAP}
+          >
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat.
+          </MoleculeDropdownOption>
+        </div>
       </div>
     </div>
   </div>

--- a/demo/molecule/field/playground
+++ b/demo/molecule/field/playground
@@ -1,6 +1,6 @@
 return (
   <div>
-    <h1>MoleculeField</h1>
+    <h1>Field</h1>
     <h2>
       With <code>AtomInput</code>
     </h2>

--- a/demo/molecule/inputField/playground
+++ b/demo/molecule/inputField/playground
@@ -34,9 +34,7 @@ const MoleculeInputFieldWithState = withState(MoleculeInputField)
 
 return (
   <div>
-    <h1>
-      <code>MoleculeInputField</code>
-    </h1>
+    <h1>Input Field</h1>
     <ul style={styleList}>
       <li style={styleListItem}>
         <h2>

--- a/demo/molecule/inputTags/demo/index.js
+++ b/demo/molecule/inputTags/demo/index.js
@@ -17,91 +17,91 @@ const CLASS_DEMO_SECTION = `${BASE_CLASS_DEMO}-section`
 const MoleculeInputTagsWithState = withStateValueTags(MoleculeInputTags)
 
 const Demo = () => (
-  <div className={BASE_CLASS_DEMO}>
-    <h1>
-      <code>MoleculeInputTags</code>
-    </h1>
-    <p>
-      Check the console to verify the <code>onChangeTags</code> on
-      adding/removing tabs
-    </p>
-    <div className={CLASS_DEMO_SECTION}>
-      <h4>Basic</h4>
-      <MoleculeInputTagsWithState
-        name="inputTagsBeatles1"
-        value="George Martin"
-        tagsCloseIcon={<CloseIcon />}
-        tags={beatles}
-        onChangeTags={(_, {tags, name}) => {
-          console.log({[`onChangeTags___${name}`]: tags})
-        }}
-      />
-    </div>
-    <div className={CLASS_DEMO_SECTION}>
-      <h4>Entering tags on "Tab" press</h4>
-      <MoleculeInputTagsWithState
-        name="inputTagsBeatles2"
-        value="George Martin"
-        tagsCloseIcon={<CloseIcon />}
-        tags={beatles}
-        onEnterKey="Tab"
-        onChangeTags={(_, {tags, name}) => {
-          console.log({[`onChangeTags___${name}`]: tags})
-        }}
-      />
-    </div>
-    <div className={CLASS_DEMO_SECTION}>
-      <h4>Entering tags on "comma" press</h4>
-      <MoleculeInputTagsWithState
-        name="inputTagsBeatles3"
-        value="George Martin"
-        tagsCloseIcon={<CloseIcon />}
-        tags={beatles}
-        onEnterKey=","
-        onChangeTags={(_, {tags, name}) => {
-          console.log({[`onChangeTags___${name}`]: tags})
-        }}
-      />
-    </div>
-    <div className={CLASS_DEMO_SECTION}>
-      <h4>With size=SMALL</h4>
-      <MoleculeInputTagsWithState
-        name="inputTagsBeatles4"
-        tagsCloseIcon={<CloseIcon />}
-        tags={ledZeppelin}
-        size={inputSizes.SMALL}
-        onChangeTags={(_, {tags, name}) => {
-          console.log({[`onChangeTags___${name}`]: tags})
-        }}
-      />
-    </div>
-    <div className={CLASS_DEMO_SECTION}>
-      <h4>With error</h4>
-      <MoleculeInputTagsWithState
-        name="inputTagsBeatles5"
-        tagsCloseIcon={<CloseIcon />}
-        tags={queen}
-        errorState
-        onChangeTags={(_, {tags, name}) => {
-          console.log({[`onChangeTags___${name}`]: tags})
-        }}
-      />
-    </div>
-    <div className={CLASS_DEMO_SECTION}>
-      <h4>With onChange handler</h4>
-      <MoleculeInputTagsWithState
-        name="inputTagsBeatles6"
-        tagsCloseIcon={<CloseIcon />}
-        tags={queen}
-        onChange={(_, valuesToPropagate) => {
-          const {name, value} = valuesToPropagate
-          console.log({[`onChange___${name}`]: value})
-        }}
-        onChangeTags={(_, valuesToPropagate) => {
-          const {name, tags} = valuesToPropagate
-          console.log({[`onChangeTags___${name}`]: tags})
-        }}
-      />
+  <div className="sui-StudioPreview">
+    <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+      <h1>Input tags</h1>
+      <p>
+        Check the console to verify the <code>onChangeTags</code> on
+        adding/removing tabs
+      </p>
+      <div className={CLASS_DEMO_SECTION}>
+        <h4>Basic</h4>
+        <MoleculeInputTagsWithState
+          name="inputTagsBeatles1"
+          value="George Martin"
+          tagsCloseIcon={<CloseIcon />}
+          tags={beatles}
+          onChangeTags={(_, {tags, name}) => {
+            console.log({[`onChangeTags___${name}`]: tags})
+          }}
+        />
+      </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h4>Entering tags on "Tab" press</h4>
+        <MoleculeInputTagsWithState
+          name="inputTagsBeatles2"
+          value="George Martin"
+          tagsCloseIcon={<CloseIcon />}
+          tags={beatles}
+          onEnterKey="Tab"
+          onChangeTags={(_, {tags, name}) => {
+            console.log({[`onChangeTags___${name}`]: tags})
+          }}
+        />
+      </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h4>Entering tags on "comma" press</h4>
+        <MoleculeInputTagsWithState
+          name="inputTagsBeatles3"
+          value="George Martin"
+          tagsCloseIcon={<CloseIcon />}
+          tags={beatles}
+          onEnterKey=","
+          onChangeTags={(_, {tags, name}) => {
+            console.log({[`onChangeTags___${name}`]: tags})
+          }}
+        />
+      </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h4>With size=SMALL</h4>
+        <MoleculeInputTagsWithState
+          name="inputTagsBeatles4"
+          tagsCloseIcon={<CloseIcon />}
+          tags={ledZeppelin}
+          size={inputSizes.SMALL}
+          onChangeTags={(_, {tags, name}) => {
+            console.log({[`onChangeTags___${name}`]: tags})
+          }}
+        />
+      </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h4>With error</h4>
+        <MoleculeInputTagsWithState
+          name="inputTagsBeatles5"
+          tagsCloseIcon={<CloseIcon />}
+          tags={queen}
+          errorState
+          onChangeTags={(_, {tags, name}) => {
+            console.log({[`onChangeTags___${name}`]: tags})
+          }}
+        />
+      </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h4>With onChange handler</h4>
+        <MoleculeInputTagsWithState
+          name="inputTagsBeatles6"
+          tagsCloseIcon={<CloseIcon />}
+          tags={queen}
+          onChange={(_, valuesToPropagate) => {
+            const {name, value} = valuesToPropagate
+            console.log({[`onChange___${name}`]: value})
+          }}
+          onChangeTags={(_, valuesToPropagate) => {
+            const {name, tags} = valuesToPropagate
+            console.log({[`onChangeTags___${name}`]: tags})
+          }}
+        />
+      </div>
     </div>
   </div>
 )

--- a/demo/molecule/modal/demo/index.js
+++ b/demo/molecule/modal/demo/index.js
@@ -19,16 +19,11 @@ const fieldStyle = {
   padding: '10px',
   maxWidth: '600px'
 }
-const containerStyle = {
-  padding: '20px'
-}
 
 const Demo = () => (
-  <>
-    <div style={containerStyle}>
-      <h1>
-        <code>MoleculeModal</code>
-      </h1>
+  <div className="sui-StudioPreview">
+    <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+      <h1>Modal</h1>
       <h2>Scroll Modal</h2>
       <div style={fieldStyle}>
         <ScrollModal />
@@ -74,7 +69,7 @@ const Demo = () => (
         <WithUrlStateModal />
       </div>
     </div>
-  </>
+  </div>
 )
 
 export default Demo

--- a/demo/molecule/notification/playground
+++ b/demo/molecule/notification/playground
@@ -71,7 +71,7 @@ const TYPES = ['info', 'success', 'warning', 'error', 'system']
 const VARIATIONS = ['positive', 'negative']
 
 return (
-  <div style={{margin: '32px'}}>
+  <div>
     <h1>Notification</h1>
     <h2>Types and variations</h2>
     {TYPES.map(type =>

--- a/demo/molecule/pagination/demo/index.js
+++ b/demo/molecule/pagination/demo/index.js
@@ -38,271 +38,276 @@ const linkFactory = ({children, ...props}) => {
 
 const Demo = () => {
   return (
-    <div className={BASE_CLASS_DEMO}>
-      <h1>
-        <code>MoleculePagination</code>
-      </h1>
-      <h2>
-        Responsive <code>w/ LayoutMediaQuery</code>
-      </h2>
-      <div className={CLASS_DEMO_SECTION_RESPONSIVE}>
-        <LayoutMediaQuery>
-          {({S, M}) =>
-            S ? (
-              <DynamicMoleculePagination
-                totalPages={25}
-                page={17}
-                showPages={M ? 10 : 5}
-              />
-            ) : (
-              <DynamicMoleculePagination
-                totalPages={25}
-                page={17}
-                compressed={!S}
-              />
-            )
-          }
-        </LayoutMediaQuery>
-      </div>
-      <h2>Dynamic</h2>
-      <div className={CLASS_DEMO_SECTION}>
+    <div className="sui-StudioPreview">
+      <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+        <h1>Pagination</h1>
+        <h2>
+          Responsive <code>w/ LayoutMediaQuery</code>
+        </h2>
+        <div className={CLASS_DEMO_SECTION_RESPONSIVE}>
+          <LayoutMediaQuery>
+            {({S, M}) =>
+              S ? (
+                <DynamicMoleculePagination
+                  totalPages={25}
+                  page={17}
+                  showPages={M ? 10 : 5}
+                />
+              ) : (
+                <DynamicMoleculePagination
+                  totalPages={25}
+                  page={17}
+                  compressed={!S}
+                />
+              )
+            }
+          </LayoutMediaQuery>
+        </div>
+        <h2>Dynamic</h2>
+        <div className={CLASS_DEMO_SECTION}>
+          <h3>Extended Version</h3>
+          <DynamicMoleculePagination totalPages={25} page={17} />
+          <h3>Extended Version (hide Disabled)</h3>
+          <DynamicMoleculePagination totalPages={25} page={17} hideDisabled />
+          <h3>
+            Extended Version <code>showPages=7</code>
+          </h3>
+          <DynamicMoleculePagination totalPages={25} page={17} showPages={7} />
+        </div>
+        <div className={CLASS_DEMO_SECTION}>
+          <h3>Compressed Version</h3>
+          <DynamicMoleculePagination totalPages={25} page={17} compressed />
+        </div>
+        {/* ------------------------------------------------------------------------------------------------------------- */}
+        <h2>Static</h2>
         <h3>Extended Version</h3>
-        <DynamicMoleculePagination totalPages={25} page={17} />
-        <h3>Extended Version (hide Disabled)</h3>
-        <DynamicMoleculePagination totalPages={25} page={17} hideDisabled />
-        <h3>
-          Extended Version <code>showPages=7</code>
-        </h3>
-        <DynamicMoleculePagination totalPages={25} page={17} showPages={7} />
-      </div>
-      <div className={CLASS_DEMO_SECTION}>
+        <div className={CLASS_DEMO_SECTION}>
+          <h4>Basic</h4>
+          <p>
+            <code>totalPages=25 page=7</code>
+          </p>
+          <MoleculePagination totalPages={25} page={7} />
+        </div>
+        <div className={CLASS_DEMO_SECTION}>
+          <h4>Basic with links and linkFactory</h4>
+          <p>
+            <code>
+              totalPages=25 page=7 linkFactory urlPattern="
+              {`/?page=%{pageNumber}`}" renderLinks
+            </code>
+          </p>
+          <MoleculePagination
+            totalPages={25}
+            page={7}
+            linkFactory={linkFactory}
+            urlPattern={PAGINATION_URL}
+            renderLinks
+          />
+        </div>
+        <div className={CLASS_DEMO_SECTION}>
+          <h4>w/ Next</h4>
+          <p>
+            <code>totalPages=25 page=7</code>
+          </p>
+          <MoleculePagination
+            totalPages={25}
+            page={7}
+            {...Icons}
+            {...OnClicks}
+          />
+        </div>
+        <div className={CLASS_DEMO_SECTION}>
+          <h4>w/ Prev & Next</h4>
+          <p>
+            <code>totalPages=25 page=17</code>
+          </p>
+          <MoleculePagination
+            totalPages={25}
+            page={17}
+            {...Icons}
+            {...OnClicks}
+          />
+        </div>
+        <div className={CLASS_DEMO_SECTION}>
+          <h4>w/ Prev</h4>
+          <p>
+            <code>totalPages=25 page=27</code>
+          </p>
+          <MoleculePagination
+            totalPages={25}
+            page={27}
+            {...Icons}
+            {...OnClicks}
+          />
+        </div>
+        <div className={CLASS_DEMO_SECTION}>
+          <h4>No Arrows</h4>
+          <p>
+            <code>totalPages=25 page=7</code>
+          </p>
+          <MoleculePagination totalPages={25} page={17} {...OnClicks} />
+        </div>
+        <div className={CLASS_DEMO_SECTION}>
+          <h4>Different Texts</h4>
+          <p>
+            <code>totalPages=25 page=7</code>
+          </p>
+          <MoleculePagination
+            totalPages={25}
+            page={17}
+            {...Icons}
+            {...Texts}
+            {...OnClicks}
+          />
+        </div>
+        <div className={CLASS_DEMO_SECTION}>
+          <h4>Out of range current page</h4>
+          <p>
+            <code>totalPages=25 page=-2</code>
+          </p>
+          <MoleculePagination
+            totalPages={25}
+            page={-2}
+            {...Icons}
+            {...Texts}
+            {...OnClicks}
+          />
+        </div>
+        <div className={CLASS_DEMO_SECTION}>
+          <h4>Hide Disabled</h4>
+          <p>
+            <code>totalPages=25 page=2</code>
+          </p>
+          <MoleculePagination
+            totalPages={25}
+            page={2}
+            hideDisabled
+            {...Icons}
+            {...Texts}
+            {...OnClicks}
+          />
+        </div>
+        {/* ------------------------------------------------------------------------------------------------------------- */}
         <h3>Compressed Version</h3>
-        <DynamicMoleculePagination totalPages={25} page={17} compressed />
-      </div>
-      {/* ------------------------------------------------------------------------------------------------------------- */}
-      <h2>Static</h2>
-      <h3>Extended Version</h3>
-      <div className={CLASS_DEMO_SECTION}>
-        <h4>Basic</h4>
-        <p>
-          <code>totalPages=25 page=7</code>
-        </p>
-        <MoleculePagination totalPages={25} page={7} />
-      </div>
-      <div className={CLASS_DEMO_SECTION}>
-        <h4>Basic with links and linkFactory</h4>
-        <p>
-          <code>
-            totalPages=25 page=7 linkFactory urlPattern="
-            {`/?page=%{pageNumber}`}" renderLinks
-          </code>
-        </p>
-        <MoleculePagination
-          totalPages={25}
-          page={7}
-          linkFactory={linkFactory}
-          urlPattern={PAGINATION_URL}
-          renderLinks
-        />
-      </div>
-      <div className={CLASS_DEMO_SECTION}>
-        <h4>w/ Next</h4>
-        <p>
-          <code>totalPages=25 page=7</code>
-        </p>
-        <MoleculePagination totalPages={25} page={7} {...Icons} {...OnClicks} />
-      </div>
-      <div className={CLASS_DEMO_SECTION}>
-        <h4>w/ Prev & Next</h4>
-        <p>
-          <code>totalPages=25 page=17</code>
-        </p>
-        <MoleculePagination
-          totalPages={25}
-          page={17}
-          {...Icons}
-          {...OnClicks}
-        />
-      </div>
-      <div className={CLASS_DEMO_SECTION}>
-        <h4>w/ Prev</h4>
-        <p>
-          <code>totalPages=25 page=27</code>
-        </p>
-        <MoleculePagination
-          totalPages={25}
-          page={27}
-          {...Icons}
-          {...OnClicks}
-        />
-      </div>
-      <div className={CLASS_DEMO_SECTION}>
-        <h4>No Arrows</h4>
-        <p>
-          <code>totalPages=25 page=7</code>
-        </p>
-        <MoleculePagination totalPages={25} page={17} {...OnClicks} />
-      </div>
-      <div className={CLASS_DEMO_SECTION}>
-        <h4>Different Texts</h4>
-        <p>
-          <code>totalPages=25 page=7</code>
-        </p>
-        <MoleculePagination
-          totalPages={25}
-          page={17}
-          {...Icons}
-          {...Texts}
-          {...OnClicks}
-        />
-      </div>
-      <div className={CLASS_DEMO_SECTION}>
-        <h4>Out of range current page</h4>
-        <p>
-          <code>totalPages=25 page=-2</code>
-        </p>
-        <MoleculePagination
-          totalPages={25}
-          page={-2}
-          {...Icons}
-          {...Texts}
-          {...OnClicks}
-        />
-      </div>
-      <div className={CLASS_DEMO_SECTION}>
-        <h4>Hide Disabled</h4>
-        <p>
-          <code>totalPages=25 page=2</code>
-        </p>
-        <MoleculePagination
-          totalPages={25}
-          page={2}
-          hideDisabled
-          {...Icons}
-          {...Texts}
-          {...OnClicks}
-        />
-      </div>
-      {/* ------------------------------------------------------------------------------------------------------------- */}
-      <h3>Compressed Version</h3>
-      <div className={CLASS_DEMO_SECTION}>
-        <h4>First Page (only next)</h4>
-        <p>
-          <code>totalPages=25 page=1</code>
-        </p>
-        <MoleculePagination
-          totalPages={25}
-          page={1}
-          {...Icons}
-          {...OnClicks}
-          compressed
-        />
-      </div>
-      <div className={CLASS_DEMO_SECTION}>
-        <h4>w/ Prev & Next</h4>
-        <p>
-          <code>totalPages=25 page=17</code>
-        </p>
-        <MoleculePagination
-          totalPages={25}
-          page={17}
-          {...Icons}
-          {...OnClicks}
-          compressed
-        />
-      </div>
-      <div className={CLASS_DEMO_SECTION}>
-        <h4>Out of range current page</h4>
-        <p>
-          <code>totalPages=25 page=27</code>
-        </p>
-        <MoleculePagination
-          totalPages={25}
-          page={27}
-          {...Icons}
-          {...OnClicks}
-          compressed
-        />
-      </div>
-      <div className={CLASS_DEMO_SECTION}>
-        <h4>No Arrows</h4>
-        <p>
-          <code>totalPages=25 page=17</code>
-        </p>
-        <MoleculePagination
-          totalPages={25}
-          page={17}
-          {...OnClicks}
-          compressed
-        />
-      </div>
-      <div className={CLASS_DEMO_SECTION}>
-        <h4>Different Texts</h4>
-        <p>
-          <code>totalPages=25 page=17</code>
-        </p>
-        <MoleculePagination
-          totalPages={25}
-          page={17}
-          {...Icons}
-          {...Texts}
-          {...OnClicks}
-          compressed
-        />
-      </div>
-      <div className={CLASS_DEMO_SECTION}>
-        <h4>Hide Disabled</h4>
-        <p>
-          <code>totalPages=25 page=1</code>
-        </p>
-        <MoleculePagination
-          totalPages={25}
-          page={1}
-          {...Icons}
-          {...Texts}
-          {...OnClicks}
-          compressed
-          hideDisabled
-        />
-      </div>
-      <div className={CLASS_DEMO_SECTION}>
-        <h4>Change Navigation Buttons</h4>
-        <p>
-          <code>totalPages=25 page=1</code>
-        </p>
-        <DynamicMoleculePagination
-          totalPages={25}
-          page={1}
-          {...Icons}
-          {...Texts}
-          {...OnClicks}
-          hideDisabled
-          prevButtonDesign="flat"
-          nextButtonDesign="solid"
-          showPages={5}
-          nonSelectedPageButtonDesign="outline"
-        />
+        <div className={CLASS_DEMO_SECTION}>
+          <h4>First Page (only next)</h4>
+          <p>
+            <code>totalPages=25 page=1</code>
+          </p>
+          <MoleculePagination
+            totalPages={25}
+            page={1}
+            {...Icons}
+            {...OnClicks}
+            compressed
+          />
+        </div>
+        <div className={CLASS_DEMO_SECTION}>
+          <h4>w/ Prev & Next</h4>
+          <p>
+            <code>totalPages=25 page=17</code>
+          </p>
+          <MoleculePagination
+            totalPages={25}
+            page={17}
+            {...Icons}
+            {...OnClicks}
+            compressed
+          />
+        </div>
+        <div className={CLASS_DEMO_SECTION}>
+          <h4>Out of range current page</h4>
+          <p>
+            <code>totalPages=25 page=27</code>
+          </p>
+          <MoleculePagination
+            totalPages={25}
+            page={27}
+            {...Icons}
+            {...OnClicks}
+            compressed
+          />
+        </div>
+        <div className={CLASS_DEMO_SECTION}>
+          <h4>No Arrows</h4>
+          <p>
+            <code>totalPages=25 page=17</code>
+          </p>
+          <MoleculePagination
+            totalPages={25}
+            page={17}
+            {...OnClicks}
+            compressed
+          />
+        </div>
+        <div className={CLASS_DEMO_SECTION}>
+          <h4>Different Texts</h4>
+          <p>
+            <code>totalPages=25 page=17</code>
+          </p>
+          <MoleculePagination
+            totalPages={25}
+            page={17}
+            {...Icons}
+            {...Texts}
+            {...OnClicks}
+            compressed
+          />
+        </div>
+        <div className={CLASS_DEMO_SECTION}>
+          <h4>Hide Disabled</h4>
+          <p>
+            <code>totalPages=25 page=1</code>
+          </p>
+          <MoleculePagination
+            totalPages={25}
+            page={1}
+            {...Icons}
+            {...Texts}
+            {...OnClicks}
+            compressed
+            hideDisabled
+          />
+        </div>
+        <div className={CLASS_DEMO_SECTION}>
+          <h4>Change Navigation Buttons</h4>
+          <p>
+            <code>totalPages=25 page=1</code>
+          </p>
+          <DynamicMoleculePagination
+            totalPages={25}
+            page={1}
+            {...Icons}
+            {...Texts}
+            {...OnClicks}
+            hideDisabled
+            prevButtonDesign="flat"
+            nextButtonDesign="solid"
+            showPages={5}
+            nonSelectedPageButtonDesign="outline"
+          />
 
-        <p>
-          <code>totalPages=25 page=3</code>
-        </p>
-        <DynamicMoleculePagination
-          totalPages={25}
-          page={3}
-          {...Icons}
-          {...Texts}
-          {...OnClicks}
-          hideDisabled
-          prevButtonDesign="flat"
-          nextButtonDesign="flat"
-          showPages={5}
-          selectedPageButtonDesign="outline"
-          nonSelectedPageButtonDesign="flat"
-          selectedPageButtonColor="accent"
-          nonSelectedPageButtonColor="accent"
-          prevButtonColor="accent"
-          nextButtonColor="accent"
-        />
+          <p>
+            <code>totalPages=25 page=3</code>
+          </p>
+          <DynamicMoleculePagination
+            totalPages={25}
+            page={3}
+            {...Icons}
+            {...Texts}
+            {...OnClicks}
+            hideDisabled
+            prevButtonDesign="flat"
+            nextButtonDesign="flat"
+            showPages={5}
+            selectedPageButtonDesign="outline"
+            nonSelectedPageButtonDesign="flat"
+            selectedPageButtonColor="accent"
+            nonSelectedPageButtonColor="accent"
+            prevButtonColor="accent"
+            nextButtonColor="accent"
+          />
+        </div>
       </div>
     </div>
   )

--- a/demo/molecule/photoUploader/playground
+++ b/demo/molecule/photoUploader/playground
@@ -92,8 +92,8 @@ const Demo = () => {
   )
 
   return (
-    <div style={demoStyles}>
-      <h1 style={lineStyles}>Molecule PhotoUploader</h1>
+    <div>
+      <h1>Photo Uploader</h1>
 
       <MoleculePhotoUploader
         addMorePhotosIcon={_addMorePhotosIcon}

--- a/demo/molecule/progressSteps/demo/index.js
+++ b/demo/molecule/progressSteps/demo/index.js
@@ -22,112 +22,114 @@ const CLASS_DEMO_CONTENT_STEP = `${BASE_CLASS_DEMO}-contentStep`
 
 const Demo = () => {
   return (
-    <div className={BASE_CLASS_DEMO}>
-      <h1>
-        <code>MoleculeProgressSteps</code>
-      </h1>
-      <h2>Dynamic</h2>
+    <div className="sui-StudioPreview">
+      <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+        <h1>Progress Steps</h1>
+        <h2>Dynamic</h2>
+        <h3>Basic (Responsive)</h3>
+        <div className={CLASS_DEMO_SECTION_RESPONSIVE}>
+          <LayoutMediaQuery>
+            {({S}) => {
+              return (
+                <DynamicProgressSteps
+                  config={configBasic6Steps}
+                  compressed={!S}
+                />
+              )
+            }}
+          </LayoutMediaQuery>
+        </div>
 
-      <h3>Basic (Responsive)</h3>
-      <div className={CLASS_DEMO_SECTION_RESPONSIVE}>
-        <LayoutMediaQuery>
-          {({S}) => {
-            return (
-              <DynamicProgressSteps
-                config={configBasic6Steps}
-                compressed={!S}
-              />
-            )
-          }}
-        </LayoutMediaQuery>
-      </div>
+        <h3>w/ Icons (Responsive)</h3>
+        <div className={CLASS_DEMO_SECTION_RESPONSIVE}>
+          <LayoutMediaQuery>
+            {({S}) => {
+              return (
+                <DynamicProgressSteps
+                  config={configWithIcons}
+                  compressed={!S}
+                />
+              )
+            }}
+          </LayoutMediaQuery>
+        </div>
 
-      <h3>w/ Icons (Responsive)</h3>
-      <div className={CLASS_DEMO_SECTION_RESPONSIVE}>
-        <LayoutMediaQuery>
-          {({S}) => {
-            return (
-              <DynamicProgressSteps config={configWithIcons} compressed={!S} />
-            )
-          }}
-        </LayoutMediaQuery>
-      </div>
+        <h2>Static</h2>
 
-      <h2>Static</h2>
+        <h3>Basic</h3>
+        <div className={CLASS_DEMO_SECTION}>
+          <MoleculeProgressSteps iconStepDone={<IconFillCheck />}>
+            {Object.values(configBasic).map(
+              ({status, label, content, icon}, index) => (
+                <MoleculeProgressStep
+                  key={index}
+                  label={label}
+                  status={status}
+                  icon={icon}
+                >
+                  {content}
+                </MoleculeProgressStep>
+              )
+            )}
+          </MoleculeProgressSteps>
+        </div>
 
-      <h3>Basic</h3>
-      <div className={CLASS_DEMO_SECTION}>
-        <MoleculeProgressSteps iconStepDone={<IconFillCheck />}>
-          {Object.values(configBasic).map(
-            ({status, label, content, icon}, index) => (
-              <MoleculeProgressStep
-                key={index}
-                label={label}
-                status={status}
-                icon={icon}
-              >
-                {content}
-              </MoleculeProgressStep>
-            )
-          )}
-        </MoleculeProgressSteps>
-      </div>
+        <h3>Compressed</h3>
+        <div className={CLASS_DEMO_SECTION}>
+          <MoleculeProgressSteps iconStepDone={<IconFillCheck />} compressed>
+            {Object.values(configBasic).map(
+              ({status, label, content, icon}, index) => (
+                <MoleculeProgressStep
+                  key={index}
+                  label={label}
+                  status={status}
+                  icon={icon}
+                >
+                  {content}
+                </MoleculeProgressStep>
+              )
+            )}
+          </MoleculeProgressSteps>
+        </div>
 
-      <h3>Compressed</h3>
-      <div className={CLASS_DEMO_SECTION}>
-        <MoleculeProgressSteps iconStepDone={<IconFillCheck />} compressed>
-          {Object.values(configBasic).map(
-            ({status, label, content, icon}, index) => (
-              <MoleculeProgressStep
-                key={index}
-                label={label}
-                status={status}
-                icon={icon}
-              >
-                {content}
-              </MoleculeProgressStep>
-            )
-          )}
-        </MoleculeProgressSteps>
-      </div>
+        <h3>Vertical</h3>
 
-      <h3>Vertical</h3>
+        <div className={cx(CLASS_DEMO_SECTION, CLASS_DEMO_SECTION_VERTICAL)}>
+          <MoleculeProgressSteps iconStepDone={<IconFillCheck />} vertical>
+            {Object.values(configBasic6Steps).map(
+              ({status, label, content, icon}, index) => (
+                <MoleculeProgressStep
+                  key={index}
+                  label={label}
+                  status={status}
+                  icon={icon}
+                >
+                  {content}
+                </MoleculeProgressStep>
+              )
+            )}
+          </MoleculeProgressSteps>
+        </div>
 
-      <div className={cx(CLASS_DEMO_SECTION, CLASS_DEMO_SECTION_VERTICAL)}>
-        <MoleculeProgressSteps iconStepDone={<IconFillCheck />} vertical>
-          {Object.values(configBasic6Steps).map(
-            ({status, label, content, icon}, index) => (
-              <MoleculeProgressStep
-                key={index}
-                label={label}
-                status={status}
-                icon={icon}
-              >
-                {content}
-              </MoleculeProgressStep>
-            )
-          )}
-        </MoleculeProgressSteps>
-      </div>
+        <h3>Vertical w/ Icons</h3>
 
-      <h3>Vertical w/ Icons</h3>
-
-      <div className={cx(CLASS_DEMO_SECTION, CLASS_DEMO_SECTION_VERTICAL)}>
-        <MoleculeProgressSteps iconStepDone={<IconFillCheck />} vertical>
-          {Object.values(configWithIcons).map(
-            ({status, label, content, icon, iconActive}, index) => (
-              <MoleculeProgressStep
-                key={index}
-                label={label}
-                status={status}
-                icon={icon}
-                iconActive={iconActive}
-              >
-                {content}
-              </MoleculeProgressStep>
-            )
-          )}
-        </MoleculeProgressSteps>
+        <div className={cx(CLASS_DEMO_SECTION, CLASS_DEMO_SECTION_VERTICAL)}>
+          <MoleculeProgressSteps iconStepDone={<IconFillCheck />} vertical>
+            {Object.values(configWithIcons).map(
+              ({status, label, content, icon, iconActive}, index) => (
+                <MoleculeProgressStep
+                  key={index}
+                  label={label}
+                  status={status}
+                  icon={icon}
+                  iconActive={iconActive}
+                >
+                  {content}
+                </MoleculeProgressStep>
+              )
+            )}
+          </MoleculeProgressSteps>
+        </div>
       </div>
     </div>
   )

--- a/demo/molecule/quickAction/playground
+++ b/demo/molecule/quickAction/playground
@@ -18,13 +18,9 @@ function handleOnClick() {
   alert('clicked')
 }
 
-const stylesSection = {
-  margin: '15px',
-  maxWidth: '300px'
-}
-
 return (
-  <div style={stylesSection}>
+  <div>
+    <h1>Quick Action</h1>
     <p>Default</p>
     <MoleculeQuickAction
       onClick={handleOnClick}

--- a/demo/molecule/radioButtonField/playground
+++ b/demo/molecule/radioButtonField/playground
@@ -8,9 +8,7 @@ const styleListItem = {
 
 return (
   <div>
-    <h1>
-      <code>MoleculeRadioButtonField</code>
-    </h1>
+    <h1>Radio-button Field</h1>
     <ul style={styleList}>
       <li style={styleListItem}>
         <h2>With Information HelpText</h2>

--- a/demo/molecule/radioButtonGroup/demo/index.js
+++ b/demo/molecule/radioButtonGroup/demo/index.js
@@ -76,71 +76,73 @@ const RadioButtonGroupStateWrapper = () => {
 
 const Demo = () => {
   return (
-    <div className={BASE_CLASS_DEMO}>
-      <h1>MoleculeRadioButtonGroup</h1>
-      <h2>Use Cases</h2>
-      <div className={CLASS_SECTION}>
-        <h3>with AtomRadioButton</h3>
+    <div className="sui-StudioPreview">
+      <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+        <h1>Radio-button Group</h1>
+        <h2>Use Cases</h2>
+        <div className={CLASS_SECTION}>
+          <h3>with AtomRadioButton</h3>
 
-        <MoleculeRadioButtonGroup
-          onChange={(ev, {name, value}) => {
-            console.log({[name]: value})
-          }}
-          name="favorite-beatle"
-          value="john"
-        >
-          <AtomRadioButton value="john" />
-          <AtomRadioButton value="paul" />
-          <AtomRadioButton value="george" />
-          <AtomRadioButton value="ringo" />
-          <AtomRadioButton value="martin" disabled />
-        </MoleculeRadioButtonGroup>
-      </div>
-
-      <div className={CLASS_SECTION}>
-        <h3>with MoleculeRadioButtonField</h3>
-
-        <MoleculeRadioButtonGroup
-          onChange={(ev, {name, value}) => {
-            console.log({[name]: value})
-          }}
-          name="field-favorite-beatle"
-          value="john"
-        >
-          <MoleculeRadioButtonField
-            id="john"
+          <MoleculeRadioButtonGroup
+            onChange={(ev, {name, value}) => {
+              console.log({[name]: value})
+            }}
+            name="favorite-beatle"
             value="john"
-            nodeLabel={<CustomLabel text="John" />}
-            helpText="John Lennon"
-          />
-          <MoleculeRadioButtonField
-            id="paul"
-            value="paul"
-            label="Paul"
-            helpText="Paul McCartney"
-          />
-          <MoleculeRadioButtonField
-            id="george"
-            value="george"
-            label="George"
-            helpText="George Harrison"
-          />
-          <MoleculeRadioButtonField
-            id="ringo"
-            value="ringo"
-            label="Ringo"
-            helpText="Ringo Star"
-            disabled
-          />
-        </MoleculeRadioButtonGroup>
-      </div>
-      <div className={CLASS_SECTION}>
-        <h3>with Icons</h3>
-        <RadioButtonGroupIcons />
-      </div>
-      <div className={CLASS_SECTION}>
-        <h3>Change props from parent</h3>
-        <RadioButtonGroupStateWrapper />
+          >
+            <AtomRadioButton value="john" />
+            <AtomRadioButton value="paul" />
+            <AtomRadioButton value="george" />
+            <AtomRadioButton value="ringo" />
+            <AtomRadioButton value="martin" disabled />
+          </MoleculeRadioButtonGroup>
+        </div>
+
+        <div className={CLASS_SECTION}>
+          <h3>with MoleculeRadioButtonField</h3>
+
+          <MoleculeRadioButtonGroup
+            onChange={(ev, {name, value}) => {
+              console.log({[name]: value})
+            }}
+            name="field-favorite-beatle"
+            value="john"
+          >
+            <MoleculeRadioButtonField
+              id="john"
+              value="john"
+              nodeLabel={<CustomLabel text="John" />}
+              helpText="John Lennon"
+            />
+            <MoleculeRadioButtonField
+              id="paul"
+              value="paul"
+              label="Paul"
+              helpText="Paul McCartney"
+            />
+            <MoleculeRadioButtonField
+              id="george"
+              value="george"
+              label="George"
+              helpText="George Harrison"
+            />
+            <MoleculeRadioButtonField
+              id="ringo"
+              value="ringo"
+              label="Ringo"
+              helpText="Ringo Star"
+              disabled
+            />
+          </MoleculeRadioButtonGroup>
+        </div>
+        <div className={CLASS_SECTION}>
+          <h3>with Icons</h3>
+          <RadioButtonGroupIcons />
+        </div>
+        <div className={CLASS_SECTION}>
+          <h3>Change props from parent</h3>
+          <RadioButtonGroupStateWrapper />
+        </div>
       </div>
     </div>
   )

--- a/demo/molecule/rating/demo/index.js
+++ b/demo/molecule/rating/demo/index.js
@@ -21,76 +21,79 @@ const customPropsStar = {
 }
 
 const Demo = () => (
-  <div className={BASE_CLASS_DEMO}>
-    <h2>Size SMALL</h2>
-    <div className={CLASS_DEMO_SECTION}>
-      <MoleculeRating value={0} label="25 opiniones" />
-      <MoleculeRating value={2.5} label="25 opiniones" />
-    </div>
-    <h3>With Link</h3>
-    <div className={CLASS_DEMO_SECTION}>
-      <MoleculeRating
-        value={4}
-        label="25 opiniones"
-        link
-        href="https://www.adevinta.com/"
-      />
-    </div>
-    <h2>Size MEDIUM</h2>
-    <div className={CLASS_DEMO_SECTION}>
-      <MoleculeRating
-        value={0}
-        size={MoleculeRatingSizes.MEDIUM}
-        label="25 opiniones"
-      />
-      <MoleculeRating
-        value={2.5}
-        size={MoleculeRatingSizes.MEDIUM}
-        label="25 opiniones"
-      />
-    </div>
-    <h3>With Link</h3>
-    <div className={CLASS_DEMO_SECTION}>
-      <MoleculeRating
-        value={4}
-        size={MoleculeRatingSizes.MEDIUM}
-        label="25 opiniones"
-        href="https://www.adevinta.com/"
-      />
-    </div>
+  <div className="sui-StudioPreview">
+    <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+      <h1>Rating</h1>
+      <h2>Size SMALL</h2>
+      <div className={CLASS_DEMO_SECTION}>
+        <MoleculeRating value={0} label="25 opiniones" />
+        <MoleculeRating value={2.5} label="25 opiniones" />
+      </div>
+      <h3>With Link</h3>
+      <div className={CLASS_DEMO_SECTION}>
+        <MoleculeRating
+          value={4}
+          label="25 opiniones"
+          link
+          href="https://www.adevinta.com/"
+        />
+      </div>
+      <h2>Size MEDIUM</h2>
+      <div className={CLASS_DEMO_SECTION}>
+        <MoleculeRating
+          value={0}
+          size={MoleculeRatingSizes.MEDIUM}
+          label="25 opiniones"
+        />
+        <MoleculeRating
+          value={2.5}
+          size={MoleculeRatingSizes.MEDIUM}
+          label="25 opiniones"
+        />
+      </div>
+      <h3>With Link</h3>
+      <div className={CLASS_DEMO_SECTION}>
+        <MoleculeRating
+          value={4}
+          size={MoleculeRatingSizes.MEDIUM}
+          label="25 opiniones"
+          href="https://www.adevinta.com/"
+        />
+      </div>
 
-    <h2>Size LARGE</h2>
-    <div className={CLASS_DEMO_SECTION}>
-      <MoleculeRating
-        value={0}
-        size={MoleculeRatingSizes.LARGE}
-        label="25 opiniones"
-      />
-      <MoleculeRating
-        value={2.5}
-        size={MoleculeRatingSizes.LARGE}
-        label="25 opiniones"
-      />
-    </div>
-    <h3>With Link</h3>
-    <div className={CLASS_DEMO_SECTION}>
-      <MoleculeRating
-        value={4}
-        size={MoleculeRatingSizes.LARGE}
-        label="25 opiniones"
-        href="https://www.adevinta.com/"
-      />
-    </div>
+      <h2>Size LARGE</h2>
+      <div className={CLASS_DEMO_SECTION}>
+        <MoleculeRating
+          value={0}
+          size={MoleculeRatingSizes.LARGE}
+          label="25 opiniones"
+        />
+        <MoleculeRating
+          value={2.5}
+          size={MoleculeRatingSizes.LARGE}
+          label="25 opiniones"
+        />
+      </div>
+      <h3>With Link</h3>
+      <div className={CLASS_DEMO_SECTION}>
+        <MoleculeRating
+          value={4}
+          size={MoleculeRatingSizes.LARGE}
+          label="25 opiniones"
+          href="https://www.adevinta.com/"
+        />
+      </div>
 
-    <h3>Custom Star</h3>
-    <div className={cx(CLASS_DEMO_SECTION, CLASS_DEMO_SECTION_ICONS)}>
-      <MoleculeRating
-        value={3.5}
-        size={MoleculeRatingSizes.LARGE}
-        label="25 opiniones"
-        href="https://www.adevinta.com/"
-        {...customPropsStar}
-      />
+      <h3>Custom Star</h3>
+      <div className={cx(CLASS_DEMO_SECTION, CLASS_DEMO_SECTION_ICONS)}>
+        <MoleculeRating
+          value={3.5}
+          size={MoleculeRatingSizes.LARGE}
+          label="25 opiniones"
+          href="https://www.adevinta.com/"
+          {...customPropsStar}
+        />
+      </div>
     </div>
   </div>
 )

--- a/demo/molecule/select/demo/index.js
+++ b/demo/molecule/select/demo/index.js
@@ -25,217 +25,217 @@ const BASE_CLASS_DEMO = 'DemoMoleculeSelect'
 const CLASS_DEMO_SECTION = `${BASE_CLASS_DEMO}-section`
 
 const Demo = () => (
-  <div className={BASE_CLASS_DEMO}>
-    <h1>
-      <code>MoleculeSelect</code>
-    </h1>
-    <p>
-      El componente <code>select</code> sólo se usará para seleccionar opciones
-      de un listado cerrado. Utiliza <code>Autosuggest</code> si necesitas
-      añadir opciones fuera del listado cerrado
-    </p>
-    <p>
-      En esta demo sólo se utiliza el tamaño por defecto del{' '}
-      <code>DropdownList</code> y las opciones básicas de{' '}
-      <code>DropdownOption</code>. Recuerda que en dichos componentes existen
-      más posibilidades si son necesarias
-    </p>
-
-    <h2>Single Selection</h2>
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With Placeholder</h3>
-      <MoleculeSelectWithState
-        placeholder="Select a Country..."
-        onChange={(_, {value}) => console.log(value)}
-        iconArrowDown={<IconArrowDown />}
-      >
-        {countriesList.map((country, i) => (
-          <MoleculeSelectOption key={i} value={country}>
-            {country}
-          </MoleculeSelectOption>
-        ))}
-      </MoleculeSelectWithState>
-    </div>
-
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With leftIcon</h3>
-      <MoleculeSelectWithState
-        placeholder="Select a Country..."
-        onChange={(_, {value}) => console.log(value)}
-        leftIcon={<IconClock />}
-        iconArrowDown={<IconArrowDown />}
-      >
-        {countriesList.map((country, i) => (
-          <MoleculeSelectOption key={i} value={country}>
-            {country}
-          </MoleculeSelectOption>
-        ))}
-      </MoleculeSelectWithState>
-    </div>
-
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With useEffect and preselected Value</h3>
-      <MoleculeSelectUseEffect value="EFTA" />
-    </div>
-
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With preselected Value</h3>
-      <MoleculeSelectWithState
-        value="Luxembourg"
-        onChange={(_, {value}) => console.log(value)}
-        iconArrowDown={<IconArrowDown />}
-      >
-        {countriesList.map((country, i) => (
-          <MoleculeSelectOption key={i} value={country}>
-            {country}
-          </MoleculeSelectOption>
-        ))}
-      </MoleculeSelectWithState>
-    </div>
-
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With disabled state</h3>
-      <MoleculeSelectWithState
-        disabled
-        placeholder="Select a Country..."
-        onChange={(_, {value}) => console.log(value)}
-        iconArrowDown={<IconArrowDown />}
-      >
-        {countriesList.map((country, i) => (
-          <MoleculeSelectOption key={i} value={country}>
-            {country}
-          </MoleculeSelectOption>
-        ))}
-      </MoleculeSelectWithState>
-    </div>
-
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With different value and displayed text</h3>
-      <MoleculeSelectWithState
-        placeholder="Select some countries..."
-        onChange={(_, {value}) => console.log(value)}
-        iconCloseTag={<IconCloseTag />}
-        iconArrowDown={<IconArrowDown />}
-      >
-        {countriesData.map(({name, code}, i) => (
-          <MoleculeSelectOption key={i} value={code}>
-            {name}
-          </MoleculeSelectOption>
-        ))}
-      </MoleculeSelectWithState>
-    </div>
-
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>Small size</h3>
-      <MoleculeSelect
-        placeholder="Select a Country..."
-        onChange={(_, {value}) => console.log(value)}
-        iconArrowDown={<IconArrowDown />}
-        selectSize={moleculeSelectSizes.SMALL}
-      >
-        {countriesData.map(({name, code}, i) => (
-          <MoleculeSelectOption key={i} value={code}>
-            {name}
-          </MoleculeSelectOption>
-        ))}
-      </MoleculeSelect>
-    </div>
-
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With state</h3>
+  <div className="sui-StudioPreview">
+    <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+      <h1>Select</h1>
       <p>
-        State to highlight that can be <code>success</code>, <code>error</code>{' '}
-        or <code>alert</code>
+        El componente <code>select</code> sólo se usará para seleccionar
+        opciones de un listado cerrado. Utiliza <code>Autosuggest</code> si
+        necesitas añadir opciones fuera del listado cerrado
       </p>
-      <MoleculeSelect
-        placeholder="Select a Country..."
-        onChange={(_, {value}) => console.log(value)}
-        iconArrowDown={<IconArrowDown />}
-        state={moleculeSelectStates.ALERT}
-      >
-        {countriesData.map(({name, code}, i) => (
-          <MoleculeSelectOption key={i} value={code}>
-            {name}
-          </MoleculeSelectOption>
-        ))}
-      </MoleculeSelect>
-    </div>
+      <p>
+        En esta demo sólo se utiliza el tamaño por defecto del{' '}
+        <code>DropdownList</code> y las opciones básicas de{' '}
+        <code>DropdownOption</code>. Recuerda que en dichos componentes existen
+        más posibilidades si son necesarias
+      </p>
 
-    <h2>Multiple Selection</h2>
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With Placeholder</h3>
-      <MoleculeSelectWithState
-        placeholder="Select some countries..."
-        onChange={(_, {value}) => console.log(value)}
-        iconCloseTag={<IconCloseTag />}
-        iconArrowDown={<IconArrowDown />}
-        multiselection
-      >
-        {countriesList.map((country, i) => (
-          <MoleculeSelectOption key={i} value={country}>
-            {country}
-          </MoleculeSelectOption>
-        ))}
-      </MoleculeSelectWithState>
-    </div>
+      <h2>Single Selection</h2>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With Placeholder</h3>
+        <MoleculeSelectWithState
+          placeholder="Select a Country..."
+          onChange={(_, {value}) => console.log(value)}
+          iconArrowDown={<IconArrowDown />}
+        >
+          {countriesList.map((country, i) => (
+            <MoleculeSelectOption key={i} value={country}>
+              {country}
+            </MoleculeSelectOption>
+          ))}
+        </MoleculeSelectWithState>
+      </div>
 
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With preselected Value</h3>
-      <MoleculeSelectWithState
-        placeholder="Select some countries..."
-        value={['India', 'Luxembourg']}
-        onChange={(_, {value}) => console.log(value)}
-        iconCloseTag={<IconCloseTag />}
-        iconArrowDown={<IconArrowDown />}
-        multiselection
-      >
-        {countriesList.map((country, i) => (
-          <MoleculeSelectOption key={i} value={country}>
-            {country}
-          </MoleculeSelectOption>
-        ))}
-      </MoleculeSelectWithState>
-    </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With leftIcon</h3>
+        <MoleculeSelectWithState
+          placeholder="Select a Country..."
+          onChange={(_, {value}) => console.log(value)}
+          leftIcon={<IconClock />}
+          iconArrowDown={<IconArrowDown />}
+        >
+          {countriesList.map((country, i) => (
+            <MoleculeSelectOption key={i} value={country}>
+              {country}
+            </MoleculeSelectOption>
+          ))}
+        </MoleculeSelectWithState>
+      </div>
 
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With different value and displayed text</h3>
-      <MoleculeSelectWithState
-        placeholder="Select some countries..."
-        onChange={(_, {value}) => console.log(value)}
-        iconCloseTag={<IconCloseTag />}
-        iconArrowDown={<IconArrowDown />}
-        multiselection
-      >
-        {countriesData.map(({name, code}, i) => (
-          <MoleculeSelectOption key={i} value={code}>
-            {name}
-          </MoleculeSelectOption>
-        ))}
-      </MoleculeSelectWithState>
-    </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With useEffect and preselected Value</h3>
+        <MoleculeSelectUseEffect value="EFTA" />
+      </div>
 
-    <h2>Dependant Selection</h2>
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With Placeholder</h3>
-      <ComboCountries />
-    </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With preselected Value</h3>
+        <MoleculeSelectWithState
+          value="Luxembourg"
+          onChange={(_, {value}) => console.log(value)}
+          iconArrowDown={<IconArrowDown />}
+        >
+          {countriesList.map((country, i) => (
+            <MoleculeSelectOption key={i} value={country}>
+              {country}
+            </MoleculeSelectOption>
+          ))}
+        </MoleculeSelectWithState>
+      </div>
 
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>Small size</h3>
-      <MoleculeSelectWithState
-        placeholder="Select some countries..."
-        onChange={(_, {value}) => console.log(value)}
-        iconCloseTag={<IconCloseTag />}
-        iconArrowDown={<IconArrowDown />}
-        multiselection
-        selectSize={moleculeSelectSizes.SMALL}
-      >
-        {countriesData.map(({name, code}, i) => (
-          <MoleculeSelectOption key={i} value={code}>
-            {name}
-          </MoleculeSelectOption>
-        ))}
-      </MoleculeSelectWithState>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With disabled state</h3>
+        <MoleculeSelectWithState
+          disabled
+          placeholder="Select a Country..."
+          onChange={(_, {value}) => console.log(value)}
+          iconArrowDown={<IconArrowDown />}
+        >
+          {countriesList.map((country, i) => (
+            <MoleculeSelectOption key={i} value={country}>
+              {country}
+            </MoleculeSelectOption>
+          ))}
+        </MoleculeSelectWithState>
+      </div>
+
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With different value and displayed text</h3>
+        <MoleculeSelectWithState
+          placeholder="Select some countries..."
+          onChange={(_, {value}) => console.log(value)}
+          iconCloseTag={<IconCloseTag />}
+          iconArrowDown={<IconArrowDown />}
+        >
+          {countriesData.map(({name, code}, i) => (
+            <MoleculeSelectOption key={i} value={code}>
+              {name}
+            </MoleculeSelectOption>
+          ))}
+        </MoleculeSelectWithState>
+      </div>
+
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>Small size</h3>
+        <MoleculeSelect
+          placeholder="Select a Country..."
+          onChange={(_, {value}) => console.log(value)}
+          iconArrowDown={<IconArrowDown />}
+          selectSize={moleculeSelectSizes.SMALL}
+        >
+          {countriesData.map(({name, code}, i) => (
+            <MoleculeSelectOption key={i} value={code}>
+              {name}
+            </MoleculeSelectOption>
+          ))}
+        </MoleculeSelect>
+      </div>
+
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With state</h3>
+        <p>
+          State to highlight that can be <code>success</code>,{' '}
+          <code>error</code> or <code>alert</code>
+        </p>
+        <MoleculeSelect
+          placeholder="Select a Country..."
+          onChange={(_, {value}) => console.log(value)}
+          iconArrowDown={<IconArrowDown />}
+          state={moleculeSelectStates.ALERT}
+        >
+          {countriesData.map(({name, code}, i) => (
+            <MoleculeSelectOption key={i} value={code}>
+              {name}
+            </MoleculeSelectOption>
+          ))}
+        </MoleculeSelect>
+      </div>
+
+      <h2>Multiple Selection</h2>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With Placeholder</h3>
+        <MoleculeSelectWithState
+          placeholder="Select some countries..."
+          onChange={(_, {value}) => console.log(value)}
+          iconCloseTag={<IconCloseTag />}
+          iconArrowDown={<IconArrowDown />}
+          multiselection
+        >
+          {countriesList.map((country, i) => (
+            <MoleculeSelectOption key={i} value={country}>
+              {country}
+            </MoleculeSelectOption>
+          ))}
+        </MoleculeSelectWithState>
+      </div>
+
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With preselected Value</h3>
+        <MoleculeSelectWithState
+          placeholder="Select some countries..."
+          value={['India', 'Luxembourg']}
+          onChange={(_, {value}) => console.log(value)}
+          iconCloseTag={<IconCloseTag />}
+          iconArrowDown={<IconArrowDown />}
+          multiselection
+        >
+          {countriesList.map((country, i) => (
+            <MoleculeSelectOption key={i} value={country}>
+              {country}
+            </MoleculeSelectOption>
+          ))}
+        </MoleculeSelectWithState>
+      </div>
+
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With different value and displayed text</h3>
+        <MoleculeSelectWithState
+          placeholder="Select some countries..."
+          onChange={(_, {value}) => console.log(value)}
+          iconCloseTag={<IconCloseTag />}
+          iconArrowDown={<IconArrowDown />}
+          multiselection
+        >
+          {countriesData.map(({name, code}, i) => (
+            <MoleculeSelectOption key={i} value={code}>
+              {name}
+            </MoleculeSelectOption>
+          ))}
+        </MoleculeSelectWithState>
+      </div>
+
+      <h2>Dependant Selection</h2>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With Placeholder</h3>
+        <ComboCountries />
+      </div>
+
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>Small size</h3>
+        <MoleculeSelectWithState
+          placeholder="Select some countries..."
+          onChange={(_, {value}) => console.log(value)}
+          iconCloseTag={<IconCloseTag />}
+          iconArrowDown={<IconArrowDown />}
+          multiselection
+          selectSize={moleculeSelectSizes.SMALL}
+        >
+          {countriesData.map(({name, code}, i) => (
+            <MoleculeSelectOption key={i} value={code}>
+              {name}
+            </MoleculeSelectOption>
+          ))}
+        </MoleculeSelectWithState>
+      </div>
     </div>
   </div>
 )

--- a/demo/molecule/selectField/demo/index.js
+++ b/demo/molecule/selectField/demo/index.js
@@ -17,126 +17,126 @@ const BASE_CLASS_DEMO = 'DemoMoleculeSelect'
 const CLASS_DEMO_SECTION = `${BASE_CLASS_DEMO}-section`
 
 const Demo = () => (
-  <div className={BASE_CLASS_DEMO}>
-    <h1>
-      <code>MoleculeSelectField</code>
-    </h1>
-    <h2>Single Selection</h2>
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With Placeholder</h3>
-      <MoleculeSelectFieldWithState
-        id="with-placeholder"
-        label="Country"
-        placeholder="Select a Country..."
-        onChange={(_, {value}) => console.log(value)}
-        iconCloseTag={<IconCloseTag />}
-        iconArrowDown={<IconArrowDown />}
-      >
-        {countries.map((country, i) => (
-          <MoleculeSelectOption key={i} value={country}>
-            {country}
-          </MoleculeSelectOption>
-        ))}
-      </MoleculeSelectFieldWithState>
-    </div>
+  <div className="sui-StudioPreview">
+    <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+      <h1>Select Field</h1>
+      <h2>Single Selection</h2>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With Placeholder</h3>
+        <MoleculeSelectFieldWithState
+          id="with-placeholder"
+          label="Country"
+          placeholder="Select a Country..."
+          onChange={(_, {value}) => console.log(value)}
+          iconCloseTag={<IconCloseTag />}
+          iconArrowDown={<IconArrowDown />}
+        >
+          {countries.map((country, i) => (
+            <MoleculeSelectOption key={i} value={country}>
+              {country}
+            </MoleculeSelectOption>
+          ))}
+        </MoleculeSelectFieldWithState>
+      </div>
 
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With Information HelpText</h3>
-      <MoleculeSelectFieldWithState
-        id="with-information-help-text"
-        label="Country"
-        placeholder="Select a Country..."
-        helpText="The country selected will be added to your profile"
-        onChange={(_, {value}) => console.log(value)}
-        iconCloseTag={<IconCloseTag />}
-        iconArrowDown={<IconArrowDown />}
-      >
-        {countries.map((country, i) => (
-          <MoleculeSelectOption key={i} value={country}>
-            {country}
-          </MoleculeSelectOption>
-        ))}
-      </MoleculeSelectFieldWithState>
-    </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With Information HelpText</h3>
+        <MoleculeSelectFieldWithState
+          id="with-information-help-text"
+          label="Country"
+          placeholder="Select a Country..."
+          helpText="The country selected will be added to your profile"
+          onChange={(_, {value}) => console.log(value)}
+          iconCloseTag={<IconCloseTag />}
+          iconArrowDown={<IconArrowDown />}
+        >
+          {countries.map((country, i) => (
+            <MoleculeSelectOption key={i} value={country}>
+              {country}
+            </MoleculeSelectOption>
+          ))}
+        </MoleculeSelectFieldWithState>
+      </div>
 
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With Success Validation HelpText</h3>
-      <MoleculeSelectFieldWithState
-        id="with-success-validation-help-text"
-        label="Country"
-        placeholder="Select a Country..."
-        successText="Everything ok!"
-        onChange={(_, {value}) => console.log(value)}
-        iconCloseTag={<IconCloseTag />}
-        iconArrowDown={<IconArrowDown />}
-      >
-        {countries.map((country, i) => (
-          <MoleculeSelectOption key={i} value={country}>
-            {country}
-          </MoleculeSelectOption>
-        ))}
-      </MoleculeSelectFieldWithState>
-    </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With Success Validation HelpText</h3>
+        <MoleculeSelectFieldWithState
+          id="with-success-validation-help-text"
+          label="Country"
+          placeholder="Select a Country..."
+          successText="Everything ok!"
+          onChange={(_, {value}) => console.log(value)}
+          iconCloseTag={<IconCloseTag />}
+          iconArrowDown={<IconArrowDown />}
+        >
+          {countries.map((country, i) => (
+            <MoleculeSelectOption key={i} value={country}>
+              {country}
+            </MoleculeSelectOption>
+          ))}
+        </MoleculeSelectFieldWithState>
+      </div>
 
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With Error validation HelpText</h3>
-      <MoleculeSelectFieldWithState
-        id="with-error-validation-help-text"
-        label="Country"
-        placeholder="Select a Country..."
-        errorText="All wrong!"
-        onChange={(_, {value}) => console.log(value)}
-        iconCloseTag={<IconCloseTag />}
-        iconArrowDown={<IconArrowDown />}
-      >
-        {countries.map((country, i) => (
-          <MoleculeSelectOption key={i} value={country}>
-            {country}
-          </MoleculeSelectOption>
-        ))}
-      </MoleculeSelectFieldWithState>
-    </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With Error validation HelpText</h3>
+        <MoleculeSelectFieldWithState
+          id="with-error-validation-help-text"
+          label="Country"
+          placeholder="Select a Country..."
+          errorText="All wrong!"
+          onChange={(_, {value}) => console.log(value)}
+          iconCloseTag={<IconCloseTag />}
+          iconArrowDown={<IconArrowDown />}
+        >
+          {countries.map((country, i) => (
+            <MoleculeSelectOption key={i} value={country}>
+              {country}
+            </MoleculeSelectOption>
+          ))}
+        </MoleculeSelectFieldWithState>
+      </div>
 
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With Alert validation HelpText</h3>
-      <MoleculeSelectFieldWithState
-        id="with-alert-validation-help-text"
-        label="Country"
-        placeholder="Select a Country..."
-        alertText="Ok, but something needs your attention..."
-        onChange={(_, {value}) => console.log(value)}
-        iconCloseTag={<IconCloseTag />}
-        iconArrowDown={<IconArrowDown />}
-      >
-        {countries.map((country, i) => (
-          <MoleculeSelectOption key={i} value={country}>
-            {country}
-          </MoleculeSelectOption>
-        ))}
-      </MoleculeSelectFieldWithState>
-    </div>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With Alert validation HelpText</h3>
+        <MoleculeSelectFieldWithState
+          id="with-alert-validation-help-text"
+          label="Country"
+          placeholder="Select a Country..."
+          alertText="Ok, but something needs your attention..."
+          onChange={(_, {value}) => console.log(value)}
+          iconCloseTag={<IconCloseTag />}
+          iconArrowDown={<IconArrowDown />}
+        >
+          {countries.map((country, i) => (
+            <MoleculeSelectOption key={i} value={country}>
+              {country}
+            </MoleculeSelectOption>
+          ))}
+        </MoleculeSelectFieldWithState>
+      </div>
 
-    <h2>Multiple Selection</h2>
+      <h2>Multiple Selection</h2>
 
-    <div className={CLASS_DEMO_SECTION}>
-      <h3>With Alert validation HelpText</h3>
-      <MoleculeSelectFieldWithState
-        id="multiple-selection-with-alert-validation-help-text"
-        label="Country"
-        placeholder="Select some countries..."
-        value={['India', 'Luxembourg']}
-        onChange={(_, {value}) => console.log(value)}
-        iconCloseTag={<IconCloseTag />}
-        iconArrowDown={<IconArrowDown />}
-        multiselection
-        alertText="All wrong!"
-      >
-        {countries.map((country, i) => (
-          <MoleculeSelectOption key={i} value={country}>
-            {country}
-          </MoleculeSelectOption>
-        ))}
-      </MoleculeSelectFieldWithState>
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With Alert validation HelpText</h3>
+        <MoleculeSelectFieldWithState
+          id="multiple-selection-with-alert-validation-help-text"
+          label="Country"
+          placeholder="Select some countries..."
+          value={['India', 'Luxembourg']}
+          onChange={(_, {value}) => console.log(value)}
+          iconCloseTag={<IconCloseTag />}
+          iconArrowDown={<IconArrowDown />}
+          multiselection
+          alertText="All wrong!"
+        >
+          {countries.map((country, i) => (
+            <MoleculeSelectOption key={i} value={country}>
+              {country}
+            </MoleculeSelectOption>
+          ))}
+        </MoleculeSelectFieldWithState>
+      </div>
     </div>
   </div>
 )

--- a/demo/molecule/selectPopover/demo/index.js
+++ b/demo/molecule/selectPopover/demo/index.js
@@ -49,94 +49,99 @@ const Demo = () => {
   const selectText = isSelected ? itemsText : 'Todas las operaciones'
 
   return (
-    <div className="demo-container">
-      <h1>Atom Popover</h1>
-      <h3>Props</h3>
-      <label>Size</label>
-      <MoleculeSelect
-        value={size}
-        onChange={(ev, {value}) => setSize(value)}
-        placeholder="Select a size..."
-        iconArrowDown={<IconArrowDown />}
-      >
-        {Object.keys(selectPopoverSizes).map(key => (
-          <MoleculeSelectOption key={key} value={selectPopoverSizes[key]}>
-            {key}
-          </MoleculeSelectOption>
-        ))}
-      </MoleculeSelect>
-      <br />
-      <label>Placements</label>
-      <MoleculeSelect
-        value={placement}
-        onChange={(ev, {value}) => setPlacement(value)}
-        placeholder="Select a size..."
-        iconArrowDown={<IconArrowDown />}
-      >
-        {Object.keys(selectPopoverPlacements).map(key => (
-          <MoleculeSelectOption key={key} value={selectPopoverPlacements[key]}>
-            {key}
-          </MoleculeSelectOption>
-        ))}
-      </MoleculeSelect>
-      <br />
-      <div>
-        <label>
-          <input
-            type="checkbox"
-            checked={hasEvents}
-            onChange={ev => setHasEvents(ev.target.checked)}
-          />
-          With events (onOpen & onClose)
-        </label>
-      </div>
-      <div>
-        <label>
-          <input
-            type="checkbox"
-            checked={actionsAreHidden}
-            onChange={ev => setActionsAreHidden(ev.target.checked)}
-          />
-          Actions are hidden
-        </label>
-      </div>
-
-      <h3>Component</h3>
-      <MoleculeSelectPopover
-        acceptButtonText="Aceptar"
-        cancelButtonText="Cancelar"
-        hideActions={actionsAreHidden}
-        iconArrowDown={IconArrowDown}
-        isSelected={isSelected}
-        onAccept={() => setItems(unconfirmedItems)}
-        onCancel={() => setUnconfirmedItems(items)}
-        onClose={handleClose}
-        onOpen={handleOpen}
-        placement={placement}
-        selectText={selectText}
-        size={size}
-      >
-        <div className="demo-content">
-          <h3>Tipo de operación</h3>
-          <div className="demo-content-options">
-            {unconfirmedItems.map(item => {
-              const {id: childId, checked} = item
-
-              return (
-                <MoleculeCheckboxField
-                  key={childId}
-                  id={childId}
-                  checked={checked}
-                  checkedIcon={IconCheck}
-                  intermediateIcon={IconHalfCheck}
-                  onChange={handleChangeItem}
-                  {...item}
-                />
-              )
-            })}
-          </div>
+    <div className="sui-StudioPreview">
+      <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+        <h1>Select Popover</h1>
+        <h3>Props</h3>
+        <label>Size</label>
+        <MoleculeSelect
+          value={size}
+          onChange={(ev, {value}) => setSize(value)}
+          placeholder="Select a size..."
+          iconArrowDown={<IconArrowDown />}
+        >
+          {Object.keys(selectPopoverSizes).map(key => (
+            <MoleculeSelectOption key={key} value={selectPopoverSizes[key]}>
+              {key}
+            </MoleculeSelectOption>
+          ))}
+        </MoleculeSelect>
+        <br />
+        <label>Placements</label>
+        <MoleculeSelect
+          value={placement}
+          onChange={(ev, {value}) => setPlacement(value)}
+          placeholder="Select a size..."
+          iconArrowDown={<IconArrowDown />}
+        >
+          {Object.keys(selectPopoverPlacements).map(key => (
+            <MoleculeSelectOption
+              key={key}
+              value={selectPopoverPlacements[key]}
+            >
+              {key}
+            </MoleculeSelectOption>
+          ))}
+        </MoleculeSelect>
+        <br />
+        <div>
+          <label>
+            <input
+              type="checkbox"
+              checked={hasEvents}
+              onChange={ev => setHasEvents(ev.target.checked)}
+            />
+            With events (onOpen & onClose)
+          </label>
         </div>
-      </MoleculeSelectPopover>
+        <div>
+          <label>
+            <input
+              type="checkbox"
+              checked={actionsAreHidden}
+              onChange={ev => setActionsAreHidden(ev.target.checked)}
+            />
+            Actions are hidden
+          </label>
+        </div>
+
+        <h3>Component</h3>
+        <MoleculeSelectPopover
+          acceptButtonText="Aceptar"
+          cancelButtonText="Cancelar"
+          hideActions={actionsAreHidden}
+          iconArrowDown={IconArrowDown}
+          isSelected={isSelected}
+          onAccept={() => setItems(unconfirmedItems)}
+          onCancel={() => setUnconfirmedItems(items)}
+          onClose={handleClose}
+          onOpen={handleOpen}
+          placement={placement}
+          selectText={selectText}
+          size={size}
+        >
+          <div className="demo-content">
+            <h3>Tipo de operación</h3>
+            <div className="demo-content-options">
+              {unconfirmedItems.map(item => {
+                const {id: childId, checked} = item
+
+                return (
+                  <MoleculeCheckboxField
+                    key={childId}
+                    id={childId}
+                    checked={checked}
+                    checkedIcon={IconCheck}
+                    intermediateIcon={IconHalfCheck}
+                    onChange={handleChangeItem}
+                    {...item}
+                  />
+                )
+              })}
+            </div>
+          </div>
+        </MoleculeSelectPopover>
+      </div>
     </div>
   )
 }

--- a/demo/molecule/tabs/demo/index.js
+++ b/demo/molecule/tabs/demo/index.js
@@ -29,215 +29,225 @@ const CLASS_DEMO_CONTENT_STEP = `${BASE_CLASS_DEMO}-contentStep`
 
 const Demo = () => {
   return (
-    <div className={BASE_CLASS_DEMO}>
-      <h1>
-        <code>MoleculeTabs</code>
-      </h1>
-      <h2>Dynamic</h2>
+    <div className="sui-StudioPreview">
+      <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+        <h1>Tabs</h1>
+        <h2>Dynamic</h2>
 
-      <h3>Basic</h3>
-      <div className={CLASS_DEMO_SECTION}>
-        <MoleculeTabs>
-          {Object.values(configBasic).map(({content, ...props}, index) => (
-            <MoleculeTab key={index} numTab={index + 1} {...props}>
-              {content}
-            </MoleculeTab>
-          ))}
-        </MoleculeTabs>
-      </div>
+        <h3>Basic</h3>
+        <div className={CLASS_DEMO_SECTION}>
+          <MoleculeTabs>
+            {Object.values(configBasic).map(({content, ...props}, index) => (
+              <MoleculeTab key={index} numTab={index + 1} {...props}>
+                {content}
+              </MoleculeTab>
+            ))}
+          </MoleculeTabs>
+        </div>
 
-      <h3>Variant → HIGHLIGHTED</h3>
-      <div className={CLASS_DEMO_SECTION}>
-        <MoleculeTabs variant={moleculeTabsVariants.HIGHLIGHTED}>
-          {Object.values(configBasic).map(({content, ...props}, index) => (
-            <MoleculeTab key={index} numTab={index + 1} {...props}>
-              {content}
-            </MoleculeTab>
-          ))}
-        </MoleculeTabs>
-      </div>
+        <h3>Variant → HIGHLIGHTED</h3>
+        <div className={CLASS_DEMO_SECTION}>
+          <MoleculeTabs variant={moleculeTabsVariants.HIGHLIGHTED}>
+            {Object.values(configBasic).map(({content, ...props}, index) => (
+              <MoleculeTab key={index} numTab={index + 1} {...props}>
+                {content}
+              </MoleculeTab>
+            ))}
+          </MoleculeTabs>
+        </div>
 
-      <h3>Variant → HIGHLIGHTED & Type → VERTICAL</h3>
-      <div className={CLASS_DEMO_SECTION}>
-        <MoleculeTabs
-          variant={moleculeTabsVariants.HIGHLIGHTED}
-          type={moleculeTabsTypes.VERTICAL}
-        >
-          {Object.values(configBasic).map(({content, ...props}, index) => (
-            <MoleculeTab key={index} numTab={index + 1} {...props}>
-              {content}
-            </MoleculeTab>
-          ))}
-        </MoleculeTabs>
-      </div>
-
-      <h3>w/ Icons</h3>
-      <div className={CLASS_DEMO_SECTION}>
-        <MoleculeTabs>
-          {Object.values(configWithIcons).map(({content, ...props}, index) => (
-            <MoleculeTab key={index} numTab={index + 1} {...props}>
-              {content}
-            </MoleculeTab>
-          ))}
-        </MoleculeTabs>
-      </div>
-
-      <h3>w/ Icons (Type → FULLWIDTH)</h3>
-      <div className={CLASS_DEMO_SECTION}>
-        <MoleculeTabs type={moleculeTabsTypes.FULLWIDTH}>
-          {Object.values(configWithIcons).map(({content, ...props}, index) => (
-            <MoleculeTab key={index} numTab={index + 1} {...props}>
-              {content}
-            </MoleculeTab>
-          ))}
-        </MoleculeTabs>
-      </div>
-
-      <h3>w/ Icons (Type → VERTICAL)</h3>
-      <div className={CLASS_DEMO_SECTION}>
-        <MoleculeTabs type={moleculeTabsTypes.VERTICAL}>
-          {Object.values(configWithIcons).map(({content, ...props}, index) => (
-            <MoleculeTab key={index} numTab={index + 1} {...props}>
-              {content}
-            </MoleculeTab>
-          ))}
-        </MoleculeTabs>
-      </div>
-
-      <h3>w/ Icons (Type → VERTICAL & Variant → HIGHLIGHTED)</h3>
-      <div className={CLASS_DEMO_SECTION}>
-        <MoleculeTabs
-          type={moleculeTabsTypes.VERTICAL}
-          variant={moleculeTabsVariants.HIGHLIGHTED}
-        >
-          {Object.values(configWithIcons).map(({content, ...props}, index) => (
-            <MoleculeTab key={index} numTab={index + 1} {...props}>
-              {content}
-            </MoleculeTab>
-          ))}
-        </MoleculeTabs>
-      </div>
-
-      <h3>w/ Counter</h3>
-      <div className={CLASS_DEMO_SECTION}>
-        <MoleculeTabs
-          variant={moleculeTabsVariants.HIGHLIGHTED}
-          type={moleculeTabsTypes.FULLWIDTH}
-        >
-          {Object.values(configWhitCount).map(({content, ...props}, index) => (
-            <MoleculeTab key={index} numTab={index + 1} {...props}>
-              {content}
-            </MoleculeTab>
-          ))}
-        </MoleculeTabs>
-      </div>
-
-      <h2>Static</h2>
-
-      <h3>Basic</h3>
-      <div className={CLASS_DEMO_SECTION}>
-        <StaticMoleculeTabs>
-          <MoleculeTab numTab="1" label="Tab 1">
-            <div>
-              <h1>Content Tab 1</h1>
-              <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
-            </div>
-          </MoleculeTab>
-          <MoleculeTab numTab="2" label="Tab 2" active>
-            <div>
-              <h1>Content Tab 2</h1>
-              <p>
-                Cumque ad corrupti id neque aperiam deleniti voluptate iusto
-                excepturi rem officia qui nihil natus, quos doloribus numquam
-                laboriosam veritatis?
-              </p>
-            </div>
-          </MoleculeTab>
-          <MoleculeTab numTab="3" label="Tab 3">
-            <div>
-              <h1>Content Tab 3</h1>
-              <p>
-                Deleniti voluptate iusto excepturi rem officia qui nihil natus,
-                quos doloribus numquam
-              </p>
-            </div>
-          </MoleculeTab>
-        </StaticMoleculeTabs>
-      </div>
-
-      <h3>w/ Icons</h3>
-      <div className={CLASS_DEMO_SECTION}>
-        <StaticMoleculeTabs>
-          <MoleculeTab
-            numTab="1"
-            label="Tab 1"
-            icon={<IconLineBackup />}
-            active
+        <h3>Variant → HIGHLIGHTED & Type → VERTICAL</h3>
+        <div className={CLASS_DEMO_SECTION}>
+          <MoleculeTabs
+            variant={moleculeTabsVariants.HIGHLIGHTED}
+            type={moleculeTabsTypes.VERTICAL}
           >
-            <div>
-              <h1>Content Tab 1</h1>
-              <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
-            </div>
-          </MoleculeTab>
-          <MoleculeTab numTab="2" label="Tab 2" icon={<IconLineDashboard />}>
-            <div>
-              <h1>Content Tab 2</h1>
-              <p>
-                Cumque ad corrupti id neque aperiam deleniti voluptate iusto
-                excepturi rem officia qui nihil natus, quos doloribus numquam
-                laboriosam veritatis?
-              </p>
-            </div>
-          </MoleculeTab>
-          <MoleculeTab
-            numTab="3"
-            label="Tab 3"
-            icon={<IconLineExtension />}
-            disabled
-          >
-            <div>
-              <h1>Content Tab 3</h1>
-              <p>
-                Deleniti voluptate iusto excepturi rem officia qui nihil natus,
-                quos doloribus numquam
-              </p>
-            </div>
-          </MoleculeTab>
-        </StaticMoleculeTabs>
-      </div>
+            {Object.values(configBasic).map(({content, ...props}, index) => (
+              <MoleculeTab key={index} numTab={index + 1} {...props}>
+                {content}
+              </MoleculeTab>
+            ))}
+          </MoleculeTabs>
+        </div>
 
-      <h3>w/ Counter</h3>
-      <div className={CLASS_DEMO_SECTION}>
-        <StaticMoleculeTabs
-          type={moleculeTabsTypes.FULLWIDTH}
-          variant={moleculeTabsVariants.HIGHLIGHTED}
-        >
-          <MoleculeTab numTab="1" label="Tab 1" count={17} active>
-            <div>
-              <h1>Content Tab 1</h1>
-              <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
-            </div>
-          </MoleculeTab>
-          <MoleculeTab numTab="2" label="Tab 2" count={173}>
-            <div>
-              <h1>Content Tab 2</h1>
-              <p>
-                Cumque ad corrupti id neque aperiam deleniti voluptate iusto
-                excepturi rem officia qui nihil natus, quos doloribus numquam
-                laboriosam veritatis?
-              </p>
-            </div>
-          </MoleculeTab>
-          <MoleculeTab numTab="3" label="Tab 3" count={0} disabled>
-            <div>
-              <h1>Content Tab 3</h1>
-              <p>
-                Deleniti voluptate iusto excepturi rem officia qui nihil natus,
-                quos doloribus numquam
-              </p>
-            </div>
-          </MoleculeTab>
-        </StaticMoleculeTabs>
+        <h3>w/ Icons</h3>
+        <div className={CLASS_DEMO_SECTION}>
+          <MoleculeTabs>
+            {Object.values(configWithIcons).map(
+              ({content, ...props}, index) => (
+                <MoleculeTab key={index} numTab={index + 1} {...props}>
+                  {content}
+                </MoleculeTab>
+              )
+            )}
+          </MoleculeTabs>
+        </div>
+
+        <h3>w/ Icons (Type → FULLWIDTH)</h3>
+        <div className={CLASS_DEMO_SECTION}>
+          <MoleculeTabs type={moleculeTabsTypes.FULLWIDTH}>
+            {Object.values(configWithIcons).map(
+              ({content, ...props}, index) => (
+                <MoleculeTab key={index} numTab={index + 1} {...props}>
+                  {content}
+                </MoleculeTab>
+              )
+            )}
+          </MoleculeTabs>
+        </div>
+
+        <h3>w/ Icons (Type → VERTICAL)</h3>
+        <div className={CLASS_DEMO_SECTION}>
+          <MoleculeTabs type={moleculeTabsTypes.VERTICAL}>
+            {Object.values(configWithIcons).map(
+              ({content, ...props}, index) => (
+                <MoleculeTab key={index} numTab={index + 1} {...props}>
+                  {content}
+                </MoleculeTab>
+              )
+            )}
+          </MoleculeTabs>
+        </div>
+
+        <h3>w/ Icons (Type → VERTICAL & Variant → HIGHLIGHTED)</h3>
+        <div className={CLASS_DEMO_SECTION}>
+          <MoleculeTabs
+            type={moleculeTabsTypes.VERTICAL}
+            variant={moleculeTabsVariants.HIGHLIGHTED}
+          >
+            {Object.values(configWithIcons).map(
+              ({content, ...props}, index) => (
+                <MoleculeTab key={index} numTab={index + 1} {...props}>
+                  {content}
+                </MoleculeTab>
+              )
+            )}
+          </MoleculeTabs>
+        </div>
+
+        <h3>w/ Counter</h3>
+        <div className={CLASS_DEMO_SECTION}>
+          <MoleculeTabs
+            variant={moleculeTabsVariants.HIGHLIGHTED}
+            type={moleculeTabsTypes.FULLWIDTH}
+          >
+            {Object.values(configWhitCount).map(
+              ({content, ...props}, index) => (
+                <MoleculeTab key={index} numTab={index + 1} {...props}>
+                  {content}
+                </MoleculeTab>
+              )
+            )}
+          </MoleculeTabs>
+        </div>
+
+        <h2>Static</h2>
+
+        <h3>Basic</h3>
+        <div className={CLASS_DEMO_SECTION}>
+          <StaticMoleculeTabs>
+            <MoleculeTab numTab="1" label="Tab 1">
+              <div>
+                <h1>Content Tab 1</h1>
+                <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+              </div>
+            </MoleculeTab>
+            <MoleculeTab numTab="2" label="Tab 2" active>
+              <div>
+                <h1>Content Tab 2</h1>
+                <p>
+                  Cumque ad corrupti id neque aperiam deleniti voluptate iusto
+                  excepturi rem officia qui nihil natus, quos doloribus numquam
+                  laboriosam veritatis?
+                </p>
+              </div>
+            </MoleculeTab>
+            <MoleculeTab numTab="3" label="Tab 3">
+              <div>
+                <h1>Content Tab 3</h1>
+                <p>
+                  Deleniti voluptate iusto excepturi rem officia qui nihil
+                  natus, quos doloribus numquam
+                </p>
+              </div>
+            </MoleculeTab>
+          </StaticMoleculeTabs>
+        </div>
+
+        <h3>w/ Icons</h3>
+        <div className={CLASS_DEMO_SECTION}>
+          <StaticMoleculeTabs>
+            <MoleculeTab
+              numTab="1"
+              label="Tab 1"
+              icon={<IconLineBackup />}
+              active
+            >
+              <div>
+                <h1>Content Tab 1</h1>
+                <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+              </div>
+            </MoleculeTab>
+            <MoleculeTab numTab="2" label="Tab 2" icon={<IconLineDashboard />}>
+              <div>
+                <h1>Content Tab 2</h1>
+                <p>
+                  Cumque ad corrupti id neque aperiam deleniti voluptate iusto
+                  excepturi rem officia qui nihil natus, quos doloribus numquam
+                  laboriosam veritatis?
+                </p>
+              </div>
+            </MoleculeTab>
+            <MoleculeTab
+              numTab="3"
+              label="Tab 3"
+              icon={<IconLineExtension />}
+              disabled
+            >
+              <div>
+                <h1>Content Tab 3</h1>
+                <p>
+                  Deleniti voluptate iusto excepturi rem officia qui nihil
+                  natus, quos doloribus numquam
+                </p>
+              </div>
+            </MoleculeTab>
+          </StaticMoleculeTabs>
+        </div>
+
+        <h3>w/ Counter</h3>
+        <div className={CLASS_DEMO_SECTION}>
+          <StaticMoleculeTabs
+            type={moleculeTabsTypes.FULLWIDTH}
+            variant={moleculeTabsVariants.HIGHLIGHTED}
+          >
+            <MoleculeTab numTab="1" label="Tab 1" count={17} active>
+              <div>
+                <h1>Content Tab 1</h1>
+                <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+              </div>
+            </MoleculeTab>
+            <MoleculeTab numTab="2" label="Tab 2" count={173}>
+              <div>
+                <h1>Content Tab 2</h1>
+                <p>
+                  Cumque ad corrupti id neque aperiam deleniti voluptate iusto
+                  excepturi rem officia qui nihil natus, quos doloribus numquam
+                  laboriosam veritatis?
+                </p>
+              </div>
+            </MoleculeTab>
+            <MoleculeTab numTab="3" label="Tab 3" count={0} disabled>
+              <div>
+                <h1>Content Tab 3</h1>
+                <p>
+                  Deleniti voluptate iusto excepturi rem officia qui nihil
+                  natus, quos doloribus numquam
+                </p>
+              </div>
+            </MoleculeTab>
+          </StaticMoleculeTabs>
+        </div>
       </div>
     </div>
   )

--- a/demo/molecule/textareaField/demo/index.js
+++ b/demo/molecule/textareaField/demo/index.js
@@ -11,85 +11,85 @@ const MoleculeTextareaFieldWithState = withState(MoleculeTextareaField)
 
 const Demo = () => {
   return (
-    <div>
-      <h1>
-        <code>MoleculeTextareaField</code>
-      </h1>
-      <ul style={styleList}>
-        <li>
-          <h2>
-            With <code>placeholder</code>
-          </h2>
-          <MoleculeTextareaFieldWithState
-            id="commentd"
-            label="Comments"
-            maxChars={100}
-            placeholder="Please, write something cool..."
-          />
-        </li>
-        <li>
-          <h2>
-            With <code>placeholder</code> and autohide HelpText
-          </h2>
-          <MoleculeTextareaFieldWithState
-            id="commentd"
-            label="Comments"
-            maxChars={100}
-            placeholder="Please, write something cool..."
-            autoHideHelpText
-          />
-        </li>
-        <li>
-          <h2>
-            With Information HelpText and custom <code>textCharacters</code>
-          </h2>
-          <MoleculeTextareaField
-            id="description-inline"
-            label="Description"
-            helpText="Tu descripción en Latin"
-            textCharacters="caracteres"
-          />
-        </li>
-        <li>
-          <h2>With Success Validation HelpText</h2>
-          <MoleculeTextareaField
-            id="description"
-            label="Description"
-            value="In some place of La Mancha which name..."
-            successText="Everything ok!"
-          />
-        </li>
-        <li>
-          <h2>
-            With Error validation HelpText and custom <code>maxChars</code>
-          </h2>
-          <MoleculeTextareaField
-            id="notes"
-            label="Notes"
-            errorText="All wrong!"
-            value="In some place of La Mancha which name..."
-            maxChars={60}
-          />
-        </li>
-        <li>
-          <h2>
-            With Alert validation HelpText and custom <code>maxChars</code>
-          </h2>
-          <MoleculeTextareaField
-            id="notes"
-            label="Notes"
-            alertText="Ok, but's something needs your attention..."
-            value="In some place of La Mancha which name..."
-            maxChars={60}
-          />
-        </li>
-        <li>
-          <h2>
-            With <code>updateInternalValue</code> from outside
-          </h2>
-          <TextareaUpdatingValue />
-        </li>
-      </ul>
+    <div className="sui-StudioPreview">
+      <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+        <h1>Text-area Field</h1>
+        <ul style={styleList}>
+          <li>
+            <h2>
+              With <code>placeholder</code>
+            </h2>
+            <MoleculeTextareaFieldWithState
+              id="commentd"
+              label="Comments"
+              maxChars={100}
+              placeholder="Please, write something cool..."
+            />
+          </li>
+          <li>
+            <h2>
+              With <code>placeholder</code> and autohide HelpText
+            </h2>
+            <MoleculeTextareaFieldWithState
+              id="commentd"
+              label="Comments"
+              maxChars={100}
+              placeholder="Please, write something cool..."
+              autoHideHelpText
+            />
+          </li>
+          <li>
+            <h2>
+              With Information HelpText and custom <code>textCharacters</code>
+            </h2>
+            <MoleculeTextareaField
+              id="description-inline"
+              label="Description"
+              helpText="Tu descripción en Latin"
+              textCharacters="caracteres"
+            />
+          </li>
+          <li>
+            <h2>With Success Validation HelpText</h2>
+            <MoleculeTextareaField
+              id="description"
+              label="Description"
+              value="In some place of La Mancha which name..."
+              successText="Everything ok!"
+            />
+          </li>
+          <li>
+            <h2>
+              With Error validation HelpText and custom <code>maxChars</code>
+            </h2>
+            <MoleculeTextareaField
+              id="notes"
+              label="Notes"
+              errorText="All wrong!"
+              value="In some place of La Mancha which name..."
+              maxChars={60}
+            />
+          </li>
+          <li>
+            <h2>
+              With Alert validation HelpText and custom <code>maxChars</code>
+            </h2>
+            <MoleculeTextareaField
+              id="notes"
+              label="Notes"
+              alertText="Ok, but's something needs your attention..."
+              value="In some place of La Mancha which name..."
+              maxChars={60}
+            />
+          </li>
+          <li>
+            <h2>
+              With <code>updateInternalValue</code> from outside
+            </h2>
+            <TextareaUpdatingValue />
+          </li>
+        </ul>
+      </div>
     </div>
   )
 }

--- a/demo/molecule/thumbnail/demo/index.js
+++ b/demo/molecule/thumbnail/demo/index.js
@@ -36,327 +36,330 @@ const CLASS_DEMO_CELL = `${BASE_CLASS_DEMO}-cell`
 
 const Demo = () => {
   return (
-    <div className={BASE_CLASS_DEMO}>
-      <h2>Basic examples</h2>
-      <table className={CLASS_DEMO_TABLE}>
-        <tbody>
-          <tr>
-            <td className={CLASS_DEMO_CELL}>
-              <h3>Link</h3>
-              <MoleculeThumbnail
-                src={IMAGES.FINAL}
-                alt="Some alt"
-                href="https://someLink"
-                target="_blank"
-                spinner={<Spinner noBackground />}
-                placeholder={IMAGES.PLACEHOLDER}
-                size={moleculeThumbnailSize.MEDIUM}
-              />
-            </td>
-            <td className={CLASS_DEMO_CELL}>
-              <h3>No link</h3>
-              <MoleculeThumbnail
-                src={IMAGES.FINAL}
-                alt="Some alt"
-                target="_blank"
-                spinner={<Spinner noBackground />}
-                placeholder={IMAGES.PLACEHOLDER}
-                size={moleculeThumbnailSize.MEDIUM}
-              />
-            </td>
-            <td className={CLASS_DEMO_CELL}>
-              <h3>Caption</h3>
-              <MoleculeThumbnail
-                src={IMAGES.FINAL}
-                alt="Some alt"
-                captionText="Show!"
-                spinner={<Spinner noBackground />}
-                placeholder={IMAGES.PLACEHOLDER}
-                size={moleculeThumbnailSize.MEDIUM}
-              />
-            </td>
-            <td className={CLASS_DEMO_CELL}>
-              <h3>Circled</h3>
-              <MoleculeThumbnail
-                src={IMAGES.FINAL}
-                alt="Some alt"
-                href="https://someLink"
-                target="_blank"
-                captionText="Show!"
-                spinner={<Spinner noBackground />}
-                placeholder={IMAGES.PLACEHOLDER}
-                shape={moleculeThumbnailShape.CIRCLED}
-                size={moleculeThumbnailSize.MEDIUM}
-              />
-            </td>
-          </tr>
-        </tbody>
-      </table>
+    <div className="sui-StudioPreview">
+      <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+        <h1>Thumbnail</h1>
+        <h2>Basic examples</h2>
+        <table className={CLASS_DEMO_TABLE}>
+          <tbody>
+            <tr>
+              <td className={CLASS_DEMO_CELL}>
+                <h3>Link</h3>
+                <MoleculeThumbnail
+                  src={IMAGES.FINAL}
+                  alt="Some alt"
+                  href="https://someLink"
+                  target="_blank"
+                  spinner={<Spinner noBackground />}
+                  placeholder={IMAGES.PLACEHOLDER}
+                  size={moleculeThumbnailSize.MEDIUM}
+                />
+              </td>
+              <td className={CLASS_DEMO_CELL}>
+                <h3>No link</h3>
+                <MoleculeThumbnail
+                  src={IMAGES.FINAL}
+                  alt="Some alt"
+                  target="_blank"
+                  spinner={<Spinner noBackground />}
+                  placeholder={IMAGES.PLACEHOLDER}
+                  size={moleculeThumbnailSize.MEDIUM}
+                />
+              </td>
+              <td className={CLASS_DEMO_CELL}>
+                <h3>Caption</h3>
+                <MoleculeThumbnail
+                  src={IMAGES.FINAL}
+                  alt="Some alt"
+                  captionText="Show!"
+                  spinner={<Spinner noBackground />}
+                  placeholder={IMAGES.PLACEHOLDER}
+                  size={moleculeThumbnailSize.MEDIUM}
+                />
+              </td>
+              <td className={CLASS_DEMO_CELL}>
+                <h3>Circled</h3>
+                <MoleculeThumbnail
+                  src={IMAGES.FINAL}
+                  alt="Some alt"
+                  href="https://someLink"
+                  target="_blank"
+                  captionText="Show!"
+                  spinner={<Spinner noBackground />}
+                  placeholder={IMAGES.PLACEHOLDER}
+                  shape={moleculeThumbnailShape.CIRCLED}
+                  size={moleculeThumbnailSize.MEDIUM}
+                />
+              </td>
+            </tr>
+          </tbody>
+        </table>
 
-      <h2>Squared & Ratio 1:1</h2>
-      <table className={CLASS_DEMO_TABLE}>
-        <tbody>
-          <tr>
-            <td className={CLASS_DEMO_CELL}>
-              <h3>Large</h3>
-              <MoleculeThumbnail
-                src={IMAGES.FINAL}
-                alt="Some alt"
-                href="https://someLink"
-                target="_blank"
-                captionText="Show!"
-                spinner={<Spinner noBackground />}
-                placeholder={IMAGES.PLACEHOLDER}
-                size={moleculeThumbnailSize.LARGE}
-              />
-            </td>
-            <td className={CLASS_DEMO_CELL}>
-              <h3>Medium</h3>
-              <MoleculeThumbnail
-                src={IMAGES.FINAL}
-                alt="Some alt"
-                href="https://someLink"
-                target="_blank"
-                captionText="Show!"
-                spinner={<Spinner noBackground />}
-                placeholder={IMAGES.PLACEHOLDER}
-                size={moleculeThumbnailSize.MEDIUM}
-              />
-            </td>
-            <td className={CLASS_DEMO_CELL}>
-              <h3>Small</h3>
-              <MoleculeThumbnail
-                src={IMAGES.FINAL}
-                alt="Some alt"
-                href="https://someLink"
-                target="_blank"
-                captionText="Show!"
-                spinner={<Spinner noBackground />}
-                placeholder={IMAGES.PLACEHOLDER}
-                size={moleculeThumbnailSize.SMALL}
-              />
-            </td>
-            <td className={CLASS_DEMO_CELL}>
-              <h3>Xsmall</h3>
-              <MoleculeThumbnail
-                src={IMAGES.FINAL}
-                alt="Some alt"
-                href="https://someLink"
-                target="_blank"
-                captionText="Show!"
-                spinner={<Spinner noBackground />}
-                placeholder={IMAGES.PLACEHOLDER}
-                size={moleculeThumbnailSize.XSMALL}
-              />
-            </td>
-          </tr>
-        </tbody>
-      </table>
+        <h2>Squared & Ratio 1:1</h2>
+        <table className={CLASS_DEMO_TABLE}>
+          <tbody>
+            <tr>
+              <td className={CLASS_DEMO_CELL}>
+                <h3>Large</h3>
+                <MoleculeThumbnail
+                  src={IMAGES.FINAL}
+                  alt="Some alt"
+                  href="https://someLink"
+                  target="_blank"
+                  captionText="Show!"
+                  spinner={<Spinner noBackground />}
+                  placeholder={IMAGES.PLACEHOLDER}
+                  size={moleculeThumbnailSize.LARGE}
+                />
+              </td>
+              <td className={CLASS_DEMO_CELL}>
+                <h3>Medium</h3>
+                <MoleculeThumbnail
+                  src={IMAGES.FINAL}
+                  alt="Some alt"
+                  href="https://someLink"
+                  target="_blank"
+                  captionText="Show!"
+                  spinner={<Spinner noBackground />}
+                  placeholder={IMAGES.PLACEHOLDER}
+                  size={moleculeThumbnailSize.MEDIUM}
+                />
+              </td>
+              <td className={CLASS_DEMO_CELL}>
+                <h3>Small</h3>
+                <MoleculeThumbnail
+                  src={IMAGES.FINAL}
+                  alt="Some alt"
+                  href="https://someLink"
+                  target="_blank"
+                  captionText="Show!"
+                  spinner={<Spinner noBackground />}
+                  placeholder={IMAGES.PLACEHOLDER}
+                  size={moleculeThumbnailSize.SMALL}
+                />
+              </td>
+              <td className={CLASS_DEMO_CELL}>
+                <h3>Xsmall</h3>
+                <MoleculeThumbnail
+                  src={IMAGES.FINAL}
+                  alt="Some alt"
+                  href="https://someLink"
+                  target="_blank"
+                  captionText="Show!"
+                  spinner={<Spinner noBackground />}
+                  placeholder={IMAGES.PLACEHOLDER}
+                  size={moleculeThumbnailSize.XSMALL}
+                />
+              </td>
+            </tr>
+          </tbody>
+        </table>
 
-      <h2>Squared & Ratio 4:3</h2>
-      <table className={CLASS_DEMO_TABLE}>
-        <tbody>
-          <tr>
-            <td className={CLASS_DEMO_CELL}>
-              <h3>Large</h3>
-              <MoleculeThumbnail
-                src={IMAGES.FINAL}
-                alt="Some alt"
-                href="https://someLink"
-                target="_blank"
-                captionText="Show!"
-                spinner={<Spinner noBackground />}
-                placeholder={IMAGES.PLACEHOLDER}
-                size={moleculeThumbnailSize.LARGE}
-                ratio={moleculeThumbnailRatio['4:3']}
-              />
-            </td>
-            <td className={CLASS_DEMO_CELL}>
-              <h3>Medium</h3>
-              <MoleculeThumbnail
-                src={IMAGES.FINAL}
-                alt="Some alt"
-                href="https://someLink"
-                target="_blank"
-                captionText="Show!"
-                spinner={<Spinner noBackground />}
-                placeholder={IMAGES.PLACEHOLDER}
-                size={moleculeThumbnailSize.MEDIUM}
-                ratio={moleculeThumbnailRatio['4:3']}
-              />
-            </td>
-            <td className={CLASS_DEMO_CELL}>
-              <h3>Small</h3>
-              <MoleculeThumbnail
-                src={IMAGES.FINAL}
-                alt="Some alt"
-                href="https://someLink"
-                target="_blank"
-                captionText="Show!"
-                spinner={<Spinner noBackground />}
-                placeholder={IMAGES.PLACEHOLDER}
-                size={moleculeThumbnailSize.SMALL}
-                ratio={moleculeThumbnailRatio['4:3']}
-              />
-            </td>
-            <td className={CLASS_DEMO_CELL}>
-              <h3>Xsmall</h3>
-              <MoleculeThumbnail
-                src={IMAGES.FINAL}
-                alt="Some alt"
-                href="https://someLink"
-                target="_blank"
-                captionText="Show!"
-                spinner={<Spinner noBackground />}
-                placeholder={IMAGES.PLACEHOLDER}
-                size={moleculeThumbnailSize.XSMALL}
-                ratio={moleculeThumbnailRatio['4:3']}
-              />
-            </td>
-          </tr>
-        </tbody>
-      </table>
+        <h2>Squared & Ratio 4:3</h2>
+        <table className={CLASS_DEMO_TABLE}>
+          <tbody>
+            <tr>
+              <td className={CLASS_DEMO_CELL}>
+                <h3>Large</h3>
+                <MoleculeThumbnail
+                  src={IMAGES.FINAL}
+                  alt="Some alt"
+                  href="https://someLink"
+                  target="_blank"
+                  captionText="Show!"
+                  spinner={<Spinner noBackground />}
+                  placeholder={IMAGES.PLACEHOLDER}
+                  size={moleculeThumbnailSize.LARGE}
+                  ratio={moleculeThumbnailRatio['4:3']}
+                />
+              </td>
+              <td className={CLASS_DEMO_CELL}>
+                <h3>Medium</h3>
+                <MoleculeThumbnail
+                  src={IMAGES.FINAL}
+                  alt="Some alt"
+                  href="https://someLink"
+                  target="_blank"
+                  captionText="Show!"
+                  spinner={<Spinner noBackground />}
+                  placeholder={IMAGES.PLACEHOLDER}
+                  size={moleculeThumbnailSize.MEDIUM}
+                  ratio={moleculeThumbnailRatio['4:3']}
+                />
+              </td>
+              <td className={CLASS_DEMO_CELL}>
+                <h3>Small</h3>
+                <MoleculeThumbnail
+                  src={IMAGES.FINAL}
+                  alt="Some alt"
+                  href="https://someLink"
+                  target="_blank"
+                  captionText="Show!"
+                  spinner={<Spinner noBackground />}
+                  placeholder={IMAGES.PLACEHOLDER}
+                  size={moleculeThumbnailSize.SMALL}
+                  ratio={moleculeThumbnailRatio['4:3']}
+                />
+              </td>
+              <td className={CLASS_DEMO_CELL}>
+                <h3>Xsmall</h3>
+                <MoleculeThumbnail
+                  src={IMAGES.FINAL}
+                  alt="Some alt"
+                  href="https://someLink"
+                  target="_blank"
+                  captionText="Show!"
+                  spinner={<Spinner noBackground />}
+                  placeholder={IMAGES.PLACEHOLDER}
+                  size={moleculeThumbnailSize.XSMALL}
+                  ratio={moleculeThumbnailRatio['4:3']}
+                />
+              </td>
+            </tr>
+          </tbody>
+        </table>
 
-      <h2>Squared & Ratio 16:9</h2>
-      <table className={CLASS_DEMO_TABLE}>
-        <tbody>
-          <tr>
-            <td className={CLASS_DEMO_CELL}>
-              <h3>Large</h3>
-              <MoleculeThumbnail
-                src={IMAGES.FINAL}
-                alt="Some alt"
-                href="https://someLink"
-                target="_blank"
-                captionText="Show!"
-                spinner={<Spinner noBackground />}
-                placeholder={IMAGES.PLACEHOLDER}
-                size={moleculeThumbnailSize.LARGE}
-                ratio={moleculeThumbnailRatio['16:9']}
-              />
-            </td>
-            <td className={CLASS_DEMO_CELL}>
-              <h3>Medium</h3>
-              <MoleculeThumbnail
-                src={IMAGES.FINAL}
-                alt="Some alt"
-                href="https://someLink"
-                target="_blank"
-                captionText="Show!"
-                spinner={<Spinner noBackground />}
-                placeholder={IMAGES.PLACEHOLDER}
-                size={moleculeThumbnailSize.MEDIUM}
-                ratio={moleculeThumbnailRatio['16:9']}
-              />
-            </td>
-            <td className={CLASS_DEMO_CELL}>
-              <h3>Small</h3>
-              <MoleculeThumbnail
-                src={IMAGES.FINAL}
-                alt="Some alt"
-                href="https://someLink"
-                target="_blank"
-                captionText="Show!"
-                spinner={<Spinner noBackground />}
-                placeholder={IMAGES.PLACEHOLDER}
-                size={moleculeThumbnailSize.SMALL}
-                ratio={moleculeThumbnailRatio['16:9']}
-              />
-            </td>
-            <td className={CLASS_DEMO_CELL}>
-              <h3>Xsmall</h3>
-              <MoleculeThumbnail
-                src={IMAGES.FINAL}
-                alt="Some alt"
-                href="https://someLink"
-                target="_blank"
-                captionText="Show!"
-                spinner={<Spinner noBackground />}
-                placeholder={IMAGES.PLACEHOLDER}
-                size={moleculeThumbnailSize.XSMALL}
-                ratio={moleculeThumbnailRatio['16:9']}
-              />
-            </td>
-          </tr>
-        </tbody>
-      </table>
+        <h2>Squared & Ratio 16:9</h2>
+        <table className={CLASS_DEMO_TABLE}>
+          <tbody>
+            <tr>
+              <td className={CLASS_DEMO_CELL}>
+                <h3>Large</h3>
+                <MoleculeThumbnail
+                  src={IMAGES.FINAL}
+                  alt="Some alt"
+                  href="https://someLink"
+                  target="_blank"
+                  captionText="Show!"
+                  spinner={<Spinner noBackground />}
+                  placeholder={IMAGES.PLACEHOLDER}
+                  size={moleculeThumbnailSize.LARGE}
+                  ratio={moleculeThumbnailRatio['16:9']}
+                />
+              </td>
+              <td className={CLASS_DEMO_CELL}>
+                <h3>Medium</h3>
+                <MoleculeThumbnail
+                  src={IMAGES.FINAL}
+                  alt="Some alt"
+                  href="https://someLink"
+                  target="_blank"
+                  captionText="Show!"
+                  spinner={<Spinner noBackground />}
+                  placeholder={IMAGES.PLACEHOLDER}
+                  size={moleculeThumbnailSize.MEDIUM}
+                  ratio={moleculeThumbnailRatio['16:9']}
+                />
+              </td>
+              <td className={CLASS_DEMO_CELL}>
+                <h3>Small</h3>
+                <MoleculeThumbnail
+                  src={IMAGES.FINAL}
+                  alt="Some alt"
+                  href="https://someLink"
+                  target="_blank"
+                  captionText="Show!"
+                  spinner={<Spinner noBackground />}
+                  placeholder={IMAGES.PLACEHOLDER}
+                  size={moleculeThumbnailSize.SMALL}
+                  ratio={moleculeThumbnailRatio['16:9']}
+                />
+              </td>
+              <td className={CLASS_DEMO_CELL}>
+                <h3>Xsmall</h3>
+                <MoleculeThumbnail
+                  src={IMAGES.FINAL}
+                  alt="Some alt"
+                  href="https://someLink"
+                  target="_blank"
+                  captionText="Show!"
+                  spinner={<Spinner noBackground />}
+                  placeholder={IMAGES.PLACEHOLDER}
+                  size={moleculeThumbnailSize.XSMALL}
+                  ratio={moleculeThumbnailRatio['16:9']}
+                />
+              </td>
+            </tr>
+          </tbody>
+        </table>
 
-      <h2>Circled & ratio 1:1</h2>
-      <table className={CLASS_DEMO_TABLE}>
-        <tbody>
-          <tr>
-            <td className={CLASS_DEMO_CELL}>
-              <h3>Large</h3>
-              <MoleculeThumbnail
-                src={IMAGES.FINAL}
-                alt="Some alt"
-                href="https://someLink"
-                target="_blank"
-                captionText="Show!"
-                spinner={<Spinner noBackground />}
-                placeholder={IMAGES.PLACEHOLDER}
-                shape={moleculeThumbnailShape.CIRCLED}
-                size={moleculeThumbnailSize.LARGE}
-              />
-            </td>
-            <td className={CLASS_DEMO_CELL}>
-              <h3>Medium</h3>
-              <MoleculeThumbnail
-                src={IMAGES.FINAL}
-                alt="Some alt"
-                href="https://someLink"
-                target="_blank"
-                captionText="Show!"
-                spinner={<Spinner noBackground />}
-                placeholder={IMAGES.PLACEHOLDER}
-                shape={moleculeThumbnailShape.CIRCLED}
-                size={moleculeThumbnailSize.MEDIUM}
-              />
-            </td>
-            <td className={CLASS_DEMO_CELL}>
-              <h3>Small</h3>
-              <MoleculeThumbnail
-                src={IMAGES.FINAL}
-                alt="Some alt"
-                href="https://someLink"
-                target="_blank"
-                captionText="Show!"
-                spinner={<Spinner noBackground />}
-                placeholder={IMAGES.PLACEHOLDER}
-                shape={moleculeThumbnailShape.CIRCLED}
-                size={moleculeThumbnailSize.SMALL}
-              />
-            </td>
-            <td className={CLASS_DEMO_CELL}>
-              <h3>Xsmall</h3>
-              <MoleculeThumbnail
-                src={IMAGES.FINAL}
-                alt="Some alt"
-                href="https://someLink"
-                target="_blank"
-                captionText="Show!"
-                spinner={<Spinner noBackground />}
-                placeholder={IMAGES.PLACEHOLDER}
-                shape={moleculeThumbnailShape.CIRCLED}
-                size={moleculeThumbnailSize.XSMALL}
-              />
-            </td>
-          </tr>
-        </tbody>
-      </table>
+        <h2>Circled & ratio 1:1</h2>
+        <table className={CLASS_DEMO_TABLE}>
+          <tbody>
+            <tr>
+              <td className={CLASS_DEMO_CELL}>
+                <h3>Large</h3>
+                <MoleculeThumbnail
+                  src={IMAGES.FINAL}
+                  alt="Some alt"
+                  href="https://someLink"
+                  target="_blank"
+                  captionText="Show!"
+                  spinner={<Spinner noBackground />}
+                  placeholder={IMAGES.PLACEHOLDER}
+                  shape={moleculeThumbnailShape.CIRCLED}
+                  size={moleculeThumbnailSize.LARGE}
+                />
+              </td>
+              <td className={CLASS_DEMO_CELL}>
+                <h3>Medium</h3>
+                <MoleculeThumbnail
+                  src={IMAGES.FINAL}
+                  alt="Some alt"
+                  href="https://someLink"
+                  target="_blank"
+                  captionText="Show!"
+                  spinner={<Spinner noBackground />}
+                  placeholder={IMAGES.PLACEHOLDER}
+                  shape={moleculeThumbnailShape.CIRCLED}
+                  size={moleculeThumbnailSize.MEDIUM}
+                />
+              </td>
+              <td className={CLASS_DEMO_CELL}>
+                <h3>Small</h3>
+                <MoleculeThumbnail
+                  src={IMAGES.FINAL}
+                  alt="Some alt"
+                  href="https://someLink"
+                  target="_blank"
+                  captionText="Show!"
+                  spinner={<Spinner noBackground />}
+                  placeholder={IMAGES.PLACEHOLDER}
+                  shape={moleculeThumbnailShape.CIRCLED}
+                  size={moleculeThumbnailSize.SMALL}
+                />
+              </td>
+              <td className={CLASS_DEMO_CELL}>
+                <h3>Xsmall</h3>
+                <MoleculeThumbnail
+                  src={IMAGES.FINAL}
+                  alt="Some alt"
+                  href="https://someLink"
+                  target="_blank"
+                  captionText="Show!"
+                  spinner={<Spinner noBackground />}
+                  placeholder={IMAGES.PLACEHOLDER}
+                  shape={moleculeThumbnailShape.CIRCLED}
+                  size={moleculeThumbnailSize.XSMALL}
+                />
+              </td>
+            </tr>
+          </tbody>
+        </table>
 
-      <h2>Fallback example</h2>
-      <div style={{width: '20%'}}>
-        <MoleculeThumbnail
-          src={IMAGES.BAD}
-          alt="Some alt"
-          captionText="Show!"
-          spinner={<Spinner noBackground />}
-          placeholder={IMAGES.PLACEHOLDER}
-          errorIcon={<ImageNotFoundIcon />}
-          errorText={defaultErrorText}
-          size={moleculeThumbnailSize.LARGE}
-        />
+        <h2>Fallback example</h2>
+        <div style={{width: '20%'}}>
+          <MoleculeThumbnail
+            src={IMAGES.BAD}
+            alt="Some alt"
+            captionText="Show!"
+            spinner={<Spinner noBackground />}
+            placeholder={IMAGES.PLACEHOLDER}
+            errorIcon={<ImageNotFoundIcon />}
+            errorText={defaultErrorText}
+            size={moleculeThumbnailSize.LARGE}
+          />
+        </div>
       </div>
     </div>
   )

--- a/demo/organism/nestedCheckboxes/demo/index.js
+++ b/demo/organism/nestedCheckboxes/demo/index.js
@@ -88,48 +88,50 @@ const Demo = () => {
     })
 
   return (
-    <div className="DemoOrganismNestedCheckboxes">
-      <h1>Organism NestedCheckboxes</h1>
-      <OrganismNestedCheckboxes
-        checkedIcon={IconCheck}
-        intermediateIcon={IconHalfCheck}
-        id="nested-1"
-        labelParent="Nested checkboxes"
-        onChangeParent={handleChangeParent}
-      >
-        {renderItems()}
-      </OrganismNestedCheckboxes>
+    <div className="sui-StudioPreview">
+      <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+        <h1>Nested Checkboxes</h1>
+        <OrganismNestedCheckboxes
+          checkedIcon={IconCheck}
+          intermediateIcon={IconHalfCheck}
+          id="nested-1"
+          labelParent="Nested checkboxes"
+          onChangeParent={handleChangeParent}
+        >
+          {renderItems()}
+        </OrganismNestedCheckboxes>
 
-      <h2>
-        With Join prop | <small>Remove left padding on items</small>
-      </h2>
-      <OrganismNestedCheckboxes
-        checkedIcon={IconCheck}
-        intermediateIcon={IconHalfCheck}
-        id="nested-2"
-        join
-        labelParent="Nested checkboxes"
-        onChangeParent={handleChangeParent}
-      >
-        {renderItems()}
-      </OrganismNestedCheckboxes>
+        <h2>
+          With Join prop | <small>Remove left padding on items</small>
+        </h2>
+        <OrganismNestedCheckboxes
+          checkedIcon={IconCheck}
+          intermediateIcon={IconHalfCheck}
+          id="nested-2"
+          join
+          labelParent="Nested checkboxes"
+          onChangeParent={handleChangeParent}
+        >
+          {renderItems()}
+        </OrganismNestedCheckboxes>
 
-      <h2>
-        With Show/hide items feature | <small>Toggle items visibility</small>
-      </h2>
-      <OrganismNestedCheckboxes
-        checkedIcon={IconCheck}
-        intermediateIcon={IconHalfCheck}
-        id="nested-3"
-        labelParent="Nested checkboxes"
-        onChangeParent={handleChangeParent}
-        onClickParent={() => setShowItems(prevState => !prevState)}
-        showItems={showItems}
-        showItemsIcon={IconArrowDown}
-        hideItemsIcon={IconArrowUp}
-      >
-        {renderItems()}
-      </OrganismNestedCheckboxes>
+        <h2>
+          With Show/hide items feature | <small>Toggle items visibility</small>
+        </h2>
+        <OrganismNestedCheckboxes
+          checkedIcon={IconCheck}
+          intermediateIcon={IconHalfCheck}
+          id="nested-3"
+          labelParent="Nested checkboxes"
+          onChangeParent={handleChangeParent}
+          onClickParent={() => setShowItems(prevState => !prevState)}
+          showItems={showItems}
+          showItemsIcon={IconArrowDown}
+          hideItemsIcon={IconArrowUp}
+        >
+          {renderItems()}
+        </OrganismNestedCheckboxes>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
**What does this PR do?**
- Ensures all demos have a Heading with the title of the component (h1)
- Standardises the look and feel of the Heading (plain H1)
- Standardises the wrapper for all demos, so that everything has this structure:
```
<div class="sui-StudioDemo">
    <div class="sui-StudioPreview">
        <div class="sui-StudioPreview-content sui-StudioDemo-preview">
            <div>
                    <h1>Back To Top</h1>
```

**Extra information:**
I tried to make the very minimum code changes, just 2 or 3 lines in every file.
I've run `sui-lint js --fix`, which unfortunately makes it look way more complicated than what it actually is.

This is just the 1st step to standardise all the base demo styling.

**This is how it loos like after the changes:**
![all H1 and  Wrappers standardised](https://user-images.githubusercontent.com/23620759/89920642-ef39b700-dbfc-11ea-9134-144d17b94310.gif)

