### PR TITLE
feat(atom/table): add new tokens

### DIFF
--- a/components/atom/table/src/index.js
+++ b/components/atom/table/src/index.js
@@ -23,7 +23,7 @@ const AtomTable = ({
   cellPadding,
   borderBottom,
   onRowClick,
-  isZebra
+  zebraStriped
 }) => {
   const hasHead = Boolean(head?.length)
   const hasFoot = Boolean(foot?.length)
@@ -37,7 +37,7 @@ const AtomTable = ({
   })
   const rowClass = cx(`${baseClass}-row`, {
     [`${baseClass}-row--actionable`]: isRowActionable,
-    [`${baseClass}-row--zebra`]: isZebra
+    [`${baseClass}-row--zebraStriped`]: zebraStriped
   })
 
   const handleOnRowClick = index => onRowClick(index)
@@ -153,7 +153,7 @@ AtomTable.propTypes = {
   /**
    * Add interspersed stripes to rows
    */
-  isZebra: PropTypes.bool
+  zebraStriped: PropTypes.bool
 }
 
 export {CELL_TYPE as atomTableCellTypes, CELL_PADDING as atomTableCellPadding}

--- a/components/atom/table/src/index.js
+++ b/components/atom/table/src/index.js
@@ -22,7 +22,8 @@ const AtomTable = ({
   fullWidth,
   cellPadding,
   borderBottom,
-  onRowClick
+  onRowClick,
+  isZebra
 }) => {
   const hasHead = Boolean(head?.length)
   const hasFoot = Boolean(foot?.length)
@@ -35,7 +36,8 @@ const AtomTable = ({
     [`${baseClass}-cell--${cellPadding}`]: Boolean(cellPadding)
   })
   const rowClass = cx(`${baseClass}-row`, {
-    [`${baseClass}-row--actionable`]: isRowActionable
+    [`${baseClass}-row--actionable`]: isRowActionable,
+    [`${baseClass}-row--zebra`]: isZebra
   })
 
   const handleOnRowClick = index => onRowClick(index)
@@ -147,7 +149,11 @@ AtomTable.propTypes = {
   /**
    * Trigger callback with row index clicked
    */
-  onRowClick: PropTypes.func
+  onRowClick: PropTypes.func,
+  /**
+   * Add interspersed stripes to rows
+   */
+  isZebra: PropTypes.bool
 }
 
 export {CELL_TYPE as atomTableCellTypes, CELL_PADDING as atomTableCellPadding}

--- a/components/atom/table/src/index.scss
+++ b/components/atom/table/src/index.scss
@@ -25,7 +25,7 @@ $bgc-atom-table-row-actionable--active: $c-gray-light-3 !default;
   }
 
   &-row {
-    &:nth-child(2n + 2) {
+    &:nth-child(2n) {
       background-color: $bgc-atom-table-row;
     }
     &--actionable {

--- a/components/atom/table/src/index.scss
+++ b/components/atom/table/src/index.scss
@@ -1,7 +1,7 @@
 @import '~@s-ui/theme/lib/index';
 
 $bgc-atom-table-header-cell: transparent !default;
-$bgc-atom-table-row: $c-gray-light-3 !default;
+$bgc-atom-table-row: $c-gray-light-4 !default;
 $bdrs-atom-table: $bdrs-none !default;
 $bgc-atom-table-row-actionable--hover: $c-gray-light-4 !default;
 $bgc-atom-table-row-actionable--active: $c-gray-light-3 !default;

--- a/components/atom/table/src/index.scss
+++ b/components/atom/table/src/index.scss
@@ -1,7 +1,7 @@
 @import '~@s-ui/theme/lib/index';
 
 $bgc-atom-table-header-cell: transparent !default;
-$bgc-atom-table-row: transparent !default;
+$bgc-atom-table-row: $c-gray-light-4 !default;
 $bdrs-atom-table: $bdrs-none !default;
 $bgc-atom-table-row-actionable--hover: $c-gray-light-4 !default;
 $bgc-atom-table-row-actionable--active: $c-gray-light-3 !default;
@@ -25,9 +25,12 @@ $bgc-atom-table-row-actionable--active: $c-gray-light-3 !default;
   }
 
   &-row {
-    &:nth-child(2n + 2) {
-      background-color: $bgc-atom-table-row;
+    &--zebra {
+      &:nth-child(2n + 2) {
+        background-color: $bgc-atom-table-row;
+      }
     }
+
     &--actionable {
       cursor: pointer;
 

--- a/components/atom/table/src/index.scss
+++ b/components/atom/table/src/index.scss
@@ -2,7 +2,7 @@
 
 $bgc-atom-table-header-cell: transparent !default;
 $bgc-atom-table-row: transparent !default;
-$bdrs-atom-table: 0px !default;
+$bdrs-atom-table: $bdrs-none !default;
 $bgc-atom-table-row-actionable--hover: $c-gray-light-4 !default;
 $bgc-atom-table-row-actionable--active: $c-gray-light-3 !default;
 

--- a/components/atom/table/src/index.scss
+++ b/components/atom/table/src/index.scss
@@ -9,10 +9,10 @@ $bgc-atom-table-row-actionable--active: $c-gray-light-3 !default;
 .react-AtomTable {
   border-collapse: collapse;
   border-radius: $bdrs-atom-table;
-  overflow: hidden;
   color: $c-gray-dark;
   font-size: $fz-s;
   padding: 0;
+  overflow: hidden;
 
   &--fullWidth {
     width: 100%;

--- a/components/atom/table/src/index.scss
+++ b/components/atom/table/src/index.scss
@@ -1,7 +1,7 @@
 @import '~@s-ui/theme/lib/index';
 
 $bgc-atom-table-header-cell: transparent !default;
-$bgc-atom-table-row: $c-gray-light-4 !default;
+$bgc-atom-table-row: $c-gray-light-3 !default;
 $bdrs-atom-table: $bdrs-none !default;
 $bgc-atom-table-row-actionable--hover: $c-gray-light-4 !default;
 $bgc-atom-table-row-actionable--active: $c-gray-light-3 !default;

--- a/components/atom/table/src/index.scss
+++ b/components/atom/table/src/index.scss
@@ -25,7 +25,7 @@ $bgc-atom-table-row-actionable--active: $c-gray-light-3 !default;
   }
 
   &-row {
-    &:nth-child(2n) {
+    &:nth-child(2n + 2) {
       background-color: $bgc-atom-table-row;
     }
     &--actionable {

--- a/components/atom/table/src/index.scss
+++ b/components/atom/table/src/index.scss
@@ -25,7 +25,7 @@ $bgc-atom-table-row-actionable--active: $c-gray-light-3 !default;
   }
 
   &-row {
-    &--zebra {
+    &--zebraStriped {
       &:nth-child(2n + 2) {
         background-color: $bgc-atom-table-row;
       }

--- a/components/atom/table/src/index.scss
+++ b/components/atom/table/src/index.scss
@@ -1,10 +1,15 @@
 @import '~@s-ui/theme/lib/index';
 
+$bgc-atom-table-header-cell: transparent !default;
+$bgc-atom-table-row: transparent !default;
+$bdrs-atom-table: 0px !default;
 $bgc-atom-table-row-actionable--hover: $c-gray-light-4 !default;
 $bgc-atom-table-row-actionable--active: $c-gray-light-3 !default;
 
 .react-AtomTable {
   border-collapse: collapse;
+  border-radius: $bdrs-atom-table;
+  overflow: hidden;
   color: $c-gray-dark;
   font-size: $fz-s;
   padding: 0;
@@ -14,11 +19,15 @@ $bgc-atom-table-row-actionable--active: $c-gray-light-3 !default;
   }
 
   &-headerCell {
+    background-color: $bgc-atom-table-header-cell;
     font-weight: $fw-regular;
     text-align: left;
   }
 
   &-row {
+    &:nth-child(2n + 2) {
+      background-color: $bgc-atom-table-row;
+    }
     &--actionable {
       cursor: pointer;
 

--- a/components/molecule/modal/src/index.js
+++ b/components/molecule/modal/src/index.js
@@ -48,7 +48,7 @@ const MoleculeModal = ({
 
   const closeModal = useCallback(
     ev => {
-      ev.stopPropagation()
+      ev && ev.stopPropagation()
       toggleWindowScroll(false)
       onClose()
     },

--- a/components/molecule/modal/src/index.js
+++ b/components/molecule/modal/src/index.js
@@ -48,7 +48,7 @@ const MoleculeModal = ({
 
   const closeModal = useCallback(
     ev => {
-      ev?.stopPropagation()
+      ev.stopPropagation()
       toggleWindowScroll(false)
       onClose()
     },

--- a/demo/atom/table/playground
+++ b/demo/atom/table/playground
@@ -145,5 +145,15 @@ return (
       onRowClick={handleClick}
     />
     <br/>
+        <h2>Version with thead, tbody and tfoot and the props cellPadding and isZebra </h2>
+    <AtomTable 
+      head={contentHeadMook}
+      body={contentBodyMook}
+      foot={contentFootMook}
+      cellPadding={CELL_PADDING.l}
+      isZebra
+    />
+    <br/>
+
   </div>
 )

--- a/demo/atom/table/playground
+++ b/demo/atom/table/playground
@@ -145,13 +145,13 @@ return (
       onRowClick={handleClick}
     />
     <br/>
-        <h2>Version with thead, tbody and tfoot and the props cellPadding and isZebra </h2>
+        <h2>Version with thead, tbody and tfoot and the props cellPadding and zebraStriped </h2>
     <AtomTable 
       head={contentHeadMook}
       body={contentBodyMook}
       foot={contentFootMook}
       cellPadding={CELL_PADDING.l}
-      isZebra
+      zebraStriped
     />
     <br/>
 


### PR DESCRIPTION
Add new tokens and properties to style the component:

*Background-color to header cell
*Background-color to alternate rows
*Border-radius to table

**Why is this PR needed?**
At this moment, the table won't allow Pijama Stripes, and custom background for the header.
Both features are needed for a MA user story, and we agree this is good for SUI to have as options (as opposed to have this implemented at brand level only)

**This is how the desired design looks like:**
<img width="992" alt="table options" src="https://user-images.githubusercontent.com/23620759/92106789-29a20880-ede5-11ea-843c-efe7bb9c0619.png">

