### PR TITLE
fix(atom/tag): AtomTag type hover

### DIFF
--- a/components/atom/tag/src/index.scss
+++ b/components/atom/tag/src/index.scss
@@ -174,16 +174,20 @@ $c-atom-tag-closable-icon--hover: $c-gray !default;
   @each $name, $type in $atom-tag-types {
     $bgc: map-get($type, bgc);
     $c: map-get($type, c);
-    $bgc-atom-tag-type--hover: color-variation($bgc, 2) !default;
-    $c-atom-tag-type--hover: color-variation($c, 2) !default;
+    $bgc-hover: map-get($type, bgc-hover);
+    $c-hover: map-get($type, c-hover);
 
     &--#{$name} {
       background-color: $bgc;
       color: $c;
 
-      &:hover {
-        background-color: $bgc-atom-tag-type--hover;
-        color: $c-atom-tag-type--hover;
+      @if $bgc-hover or $c-hover {
+        @media (hover: hover) {
+          &:hover {
+            background-color: $bgc-hover;
+            color: $c-hover;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
**ISSUE**
When created a type declaring `$atom-tag-types`, tag automatically defines a hover with an "uncontrolled" values.
See how AtomTag behaves in this "gray" type:
![image](https://user-images.githubusercontent.com/5390428/92467958-ae6c9800-f1d2-11ea-8872-dc96ca68ea53.png)

**SOLUTION**
Get hover variables values from `$atom-tag-types` variable instead hardcoded one.
Doing that we can define a different hover for all types