### PR TITLE
feat(atom/skeleton): add skeleton component 

### DIFF
--- a/components/atom/skeleton/.gitignore
+++ b/components/atom/skeleton/.gitignore
@@ -1,0 +1,2 @@
+lib
+node_modules

--- a/components/atom/skeleton/.npmignore
+++ b/components/atom/skeleton/.npmignore
@@ -1,0 +1,2 @@
+src
+assets

--- a/components/atom/skeleton/README.md
+++ b/components/atom/skeleton/README.md
@@ -69,7 +69,7 @@ Use `animation` prop to choose between `wave` and `pulse` animation, if the prop
 ```jsx
 import AtomSkeleton, {ATOM_SKELETON_ANIMATIONS} from '@s-ui/react-atom-skeleton'
 
-const VariantStory = () => (
+const AnimationStory = () => (
   <>
     <AtomSkeleton animation={ATOM_SKELETON_ANIMATIONS.wave} />
     <AtomSkeleton animation={ATOM_SKELETON_ANIMATIONS.pulse} />
@@ -83,7 +83,7 @@ const VariantStory = () => (
 Use `count` prop to display several skeletons
 
 ```jsx
-const VariantStory = () => (
+const CountStory = () => (
   <>
     <AtomSkeleton count={4} />
   </>

--- a/components/atom/skeleton/README.md
+++ b/components/atom/skeleton/README.md
@@ -1,0 +1,91 @@
+# AtomSkeleton
+
+> Skeleton is used to display the loading state of a component while avoding layout shift.
+
+<!-- ![](./assets/preview.png) -->
+
+## Installation
+
+```sh
+$ npm install @s-ui/react-atom-skeleton
+```
+
+## Usage
+
+### Basic usage
+
+#### Import package and use the component
+
+```js
+import AtomSkeleton from '@s-ui/react-atom-skeleton'
+
+return (<AtomSkeleton />)
+```
+
+#### Import the styles (Sass)
+
+```css
+@import '~@s-ui/theme/lib/index';
+@import '~@s-ui/react-atom-skeleton/lib/index';
+```
+
+### Variant
+
+Use `variant` prop to shape the skeleton and make it look like the final user interface. Choose between `round`, `square` and `circle`.
+
+```jsx
+import AtomSkeleton, {ATOM_SKELETON_VARIANTS} from '@s-ui/react-atom-skeleton'
+
+const VariantStory = () => (
+  <>
+    <AtomSkeleton variant={ATOM_SKELETON_VARIANTS.circle} />
+    <AtomSkeleton variant={ATOM_SKELETON_VARIANTS.round} />
+    <AtomSkeleton variant={ATOM_SKELETON_VARIANTS.square} />
+  </>
+);
+```
+
+### Size
+
+While the `width` and `height` props could be set, it was made to be used directly in your components.
+
+```jsx
+import AtomSkeleton from '@s-ui/react-atom-skeleton'
+
+const SizeStory = () => (
+  <>
+    <AtomSkeleton height="16px" />
+    <h2>
+      <AtomSkeleton />
+    </h2>
+  </>
+);
+```
+
+### Animation
+
+Use `animation` prop to choose between `wave` and `pulse` animation, if the prop is set to `false` the component won't have any.
+
+```jsx
+import AtomSkeleton, {ATOM_SKELETON_ANIMATIONS} from '@s-ui/react-atom-skeleton'
+
+const VariantStory = () => (
+  <>
+    <AtomSkeleton animation={ATOM_SKELETON_ANIMATIONS.wave} />
+    <AtomSkeleton animation={ATOM_SKELETON_ANIMATIONS.pulse} />
+    <AtomSkeleton animation={false} />
+  </>
+);
+```
+
+### Count
+
+```jsx
+const VariantStory = () => (
+  <>
+    <AtomSkeleton count={4} />
+  </>
+);
+```
+
+> **Find full description and more examples in the [demo page](#).**

--- a/components/atom/skeleton/README.md
+++ b/components/atom/skeleton/README.md
@@ -1,6 +1,6 @@
 # AtomSkeleton
 
-> Skeleton is used to display the loading state of a component while avoding layout shift.
+> Skeleton is used to display the loading state of a component while avoiding layout shift.
 
 <!-- ![](./assets/preview.png) -->
 
@@ -79,6 +79,8 @@ const VariantStory = () => (
 ```
 
 ### Count
+
+Use `count` prop to display several skeletons
 
 ```jsx
 const VariantStory = () => (

--- a/components/atom/skeleton/package.json
+++ b/components/atom/skeleton/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@s-ui/react-atom-skeleton",
+  "version": "1.0.0",
+  "description": "Display the loading state of a component while avoding layout shift",
+  "main": "lib/index.js",
+  "scripts": {
+    "build": "npx rimraf ./lib && npm run build:js && npm run build:styles",
+    "build:js": "../../../node_modules/.bin/babel --presets sui ./src --out-dir ./lib",
+    "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
+  },
+  "dependencies": {
+    "@s-ui/component-dependencies": "1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT"
+}

--- a/components/atom/skeleton/src/index.js
+++ b/components/atom/skeleton/src/index.js
@@ -1,0 +1,57 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import cx from 'classnames'
+
+export const ATOM_SKELETON_ANIMATIONS = {
+  wave: 'wave',
+  pulse: 'pulse'
+}
+
+export const ATOM_SKELETON_VARIANTS = {
+  round: 'round',
+  circle: 'circle',
+  square: 'square'
+}
+
+export default function AtomSkeleton({
+  count = 1,
+  variant = ATOM_SKELETON_VARIANTS.round,
+  animation = ATOM_SKELETON_ANIMATIONS.pulse,
+  style,
+  width,
+  height,
+  ...others
+}) {
+  const baseClass = 'react-AtomSkeleton'
+  const className = cx(`${baseClass}`, {
+    [`${baseClass}--pulse`]: animation === ATOM_SKELETON_ANIMATIONS.pulse,
+    [`${baseClass}--wave`]: animation === ATOM_SKELETON_ANIMATIONS.wave,
+    [`${baseClass}--round`]: variant === ATOM_SKELETON_VARIANTS.round,
+    [`${baseClass}--circle`]: variant === ATOM_SKELETON_VARIANTS.circle
+  })
+
+  return (
+    <>
+      {Array.from(Array(count).keys()).map(index => (
+        <span
+          key={index}
+          className={className}
+          style={{...style, width, height}}
+          {...others}
+        >
+          &zwnj;
+        </span>
+      ))}
+    </>
+  )
+}
+
+AtomSkeleton.displayName = 'AtomSkeleton'
+AtomSkeleton.propTypes = {
+  count: PropTypes.number,
+  width: PropTypes.string,
+  height: PropTypes.height,
+  style: PropTypes.object,
+  animation: PropTypes.oneOf(Object.values(ATOM_SKELETON_ANIMATIONS)),
+  variant: PropTypes.oneOf(Object.values(ATOM_SKELETON_VARIANTS))
+}

--- a/components/atom/skeleton/src/index.js
+++ b/components/atom/skeleton/src/index.js
@@ -48,10 +48,28 @@ export default function AtomSkeleton({
 
 AtomSkeleton.displayName = 'AtomSkeleton'
 AtomSkeleton.propTypes = {
+  /**
+   * Display count number of skeletons
+   */
   count: PropTypes.number,
+  /**
+   * Set a specific width
+   */
   width: PropTypes.string,
+  /**
+   * Set a specific height
+   */
   height: PropTypes.height,
+  /**
+   * Set custom styles
+   */
   style: PropTypes.object,
+  /**
+   * Choose between wave and pulse animation, if falsy no animation will be shown
+   */
   animation: PropTypes.oneOf(Object.values(ATOM_SKELETON_ANIMATIONS)),
+  /**
+   * Shape the skeleton and make it look like the final user interface
+   */
   variant: PropTypes.oneOf(Object.values(ATOM_SKELETON_VARIANTS))
 }

--- a/components/atom/skeleton/src/index.scss
+++ b/components/atom/skeleton/src/index.scss
@@ -1,0 +1,59 @@
+@import '~@s-ui/theme/lib/index';
+
+$bg-skeleton: $c-gray-light-3 !default;
+$bg-skeleton-highlight: $c-gray-light-4 !default;
+$bdrs-skeleton: 8px !default;
+$delay-skeleton-wave: 1.2s !default;
+$delay-skeleton-pulse: 1.5s !default;
+
+@keyframes wave {
+  0% {
+    background-position: -200px 0;
+  }
+  100% {
+    background-position: calc(200px + 100%) 0;
+  }
+}
+
+@keyframes pulse {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+.react-AtomSkeleton {
+  background-color: $bg-skeleton;
+  background-repeat: no-repeat;
+  display: inline-block;
+  line-height: 1;
+  width: 100%;
+
+  &--wave {
+    background-image: linear-gradient(
+      90deg,
+      $bg-skeleton,
+      $bg-skeleton-highlight,
+      $bg-skeleton
+    );
+    background-size: 200px 100%;
+    animation: wave $delay-skeleton-wave ease-in-out infinite;
+  }
+
+  &--pulse {
+    animation: pulse $delay-skeleton-pulse ease-in-out infinite;
+  }
+
+  &--round {
+    border-radius: $bdrs-skeleton;
+  }
+
+  &--circle {
+    border-radius: 50%;
+  }
+}

--- a/components/atom/skeleton/src/index.scss
+++ b/components/atom/skeleton/src/index.scss
@@ -1,8 +1,8 @@
 @import '~@s-ui/theme/lib/index';
 
-$bg-skeleton: $c-gray-light-3 !default;
-$bg-skeleton-highlight: $c-gray-light-4 !default;
-$bdrs-skeleton: 8px !default;
+$bgc-skeleton: $c-gray-light-3 !default;
+$bgc-skeleton-highlight: $c-gray-light-4 !default;
+$bdrs-skeleton: $bdrs-base !default;
 $delay-skeleton-wave: 1.2s !default;
 $delay-skeleton-pulse: 1.5s !default;
 
@@ -28,7 +28,7 @@ $delay-skeleton-pulse: 1.5s !default;
 }
 
 .react-AtomSkeleton {
-  background-color: $bg-skeleton;
+  background-color: $bgc-skeleton;
   background-repeat: no-repeat;
   display: inline-block;
   line-height: 1;
@@ -37,9 +37,9 @@ $delay-skeleton-pulse: 1.5s !default;
   &--wave {
     background-image: linear-gradient(
       90deg,
-      $bg-skeleton,
-      $bg-skeleton-highlight,
-      $bg-skeleton
+      $bgc-skeleton,
+      $bgc-skeleton-highlight,
+      $bgc-skeleton
     );
     background-size: 200px 100%;
     animation: wave $delay-skeleton-wave ease-in-out infinite;

--- a/demo/atom/skeleton/playground
+++ b/demo/atom/skeleton/playground
@@ -1,0 +1,67 @@
+return (
+  <div
+    style={{
+      maxWidth: '1280px',
+      width: '100%',
+      margin: '0 auto',
+      padding: '12px'
+    }}
+  >
+    <h1>Skeleton ☠️</h1>
+
+    <h2>Variant</h2>
+    <div style={{display: 'flex'}}>
+      <AtomSkeleton height="62px" width="62px" variant="circle" />
+      <div style={{flex: 1, marginLeft: '12px'}}>
+        <AtomSkeleton height="16px" variant="round" />
+        <AtomSkeleton height="16px" variant="round" />
+        <AtomSkeleton height="14px" width="50%" variant="square" />
+      </div>
+    </div>
+
+    <h2>Size</h2>
+    <div style={{display: 'flex'}}>
+      <AtomSkeleton height="62px" width="62px" variant="circle" />
+      <div style={{flex: 1, marginLeft: '12px'}}>
+        <h2 style={{margin: 0}}>
+          <AtomSkeleton variant="round" />
+        </h2>
+        <p style={{margin: 0}}>
+          <AtomSkeleton variant="round" />
+        </p>
+      </div>
+    </div>
+
+    <h2>Animation</h2>
+    <div style={{display: 'flex', justifyContent: 'space-around'}}>
+      <AtomSkeleton
+        height="62px"
+        width="62px"
+        variant="circle"
+        animation="wave"
+      />
+      <AtomSkeleton
+        height="62px"
+        width="62px"
+        variant="circle"
+        animation="pulse"
+      />
+      <AtomSkeleton
+        height="62px"
+        width="62px"
+        variant="circle"
+        animation={false}
+      />
+    </div>
+
+    <h2>Count</h2>
+    <div>
+      <AtomSkeleton
+        style={{margin: '4px 0'}}
+        height="18px"
+        count={3}
+        animation="pulse"
+      />
+    </div>
+  </div>
+)

--- a/test/atom/skeleton/index.js
+++ b/test/atom/skeleton/index.js
@@ -47,6 +47,7 @@ describe('AtomSkeleton', () => {
       count
     }
 
+    // When
     const {getAllByTestId} = setup(props)
 
     // Then

--- a/test/atom/skeleton/index.js
+++ b/test/atom/skeleton/index.js
@@ -1,0 +1,57 @@
+/* eslint react/jsx-no-undef:0 */
+/* eslint no-undef:0 */
+
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+import chai, {expect} from 'chai'
+import chaiDOM from 'chai-dom'
+
+chai.use(chaiDOM)
+
+describe('AtomSkeleton', () => {
+  const Component = AtomSkeleton
+  const setup = setupEnvironment(Component)
+
+  it('should render without crashing', () => {
+    // Given
+    const props = {}
+
+    // When
+    const component = <Component {...props} />
+
+    // Then
+    const div = document.createElement('div')
+    ReactDOM.render(component, div)
+    ReactDOM.unmountComponentAtNode(div)
+  })
+
+  it('should not render null', () => {
+    // Given
+    const props = {}
+
+    // When
+    const {container} = setup(props)
+
+    // Then
+    expect(container.innerHTML).to.be.a('string')
+    expect(container.innerHTML).to.not.have.lengthOf(0)
+  })
+
+  it('should render a set of skeletons', () => {
+    // Given
+    const count = 3
+    const testid = 'skeleton'
+    const props = {
+      'data-testid': testid,
+      count
+    }
+
+    const {getAllByTestId} = setup(props)
+
+    // Then
+    expect(getAllByTestId(testid))
+      .to.be.an('array')
+      .to.have.lengthOf(count)
+  })
+})


### PR DESCRIPTION
**Is your component proposal related to a problem? Please describe.**
There are cases where spinners are not good enough to show a loading state properly, skeletons are used to display a placeholder preview of your content while avoiding layout shift and reducing frustration. 

**Describe the solution you'd like**
I'd like a component that I could use to create complex placeholders of a user interface.

**Screenshots**
<p align="center">
<img src="https://user-images.githubusercontent.com/6877967/92689716-d0cff400-f33f-11ea-8758-5f799465da1f.png" />
</p>

**Preview**
https://sui-components.schibstedspain.vercel.app/workbench/atom/skeleton/demo