### PR TITLE
feat(atom/button): use defualt border value

### DIFF
--- a/components/atom/button/src/index.scss
+++ b/components/atom/button/src/index.scss
@@ -92,7 +92,7 @@ $icon-sz-atom-button-large: $sz-icon-m !default;
 $icon-m-atom-button-large: $m-m !default;
 $p-atom-button-large: $p-l !default;
 
-$bd-atom-button-group-focused: none !default;
+$bd-atom-button-group-focused: 1px solid !default;
 $bdrs-atom-button-first: $bdrs-m 0 0 $bdrs-m !default;
 $bdrs-atom-button-last: 0 $bdrs-m $bdrs-m 0 !default;
 


### PR DESCRIPTION
Change the default value for the new border variable to avoid this if not defined in the vertical theme

![image](https://user-images.githubusercontent.com/8220448/92725738-dabc1c00-f36c-11ea-8e3c-8771de47da16.png)


