### PR TITLE
Feat/tag actionable

### DIFF
--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -34,23 +34,24 @@ const getIsTypeableKey = key => {
   return key.length === 1 || keysEdit.includes(key)
 }
 
-const MoleculeAutosuggest = ({multiselection, ...props}) => {
-  const {
-    refMoleculeAutosuggest: refMoleculeAutosuggestFromProps,
-    children,
-    onToggle,
-    onChange,
-    onBlur,
-    onEnter,
-    onFocus,
-    isOpen,
-    keysCloseList,
-    keysSelection,
-    disabled,
-    errorState,
-    state
-  } = props
-
+const MoleculeAutosuggest = ({
+  multiselection,
+  refMoleculeAutosuggest: refMoleculeAutosuggestFromProps,
+  children,
+  onToggle,
+  onChange,
+  onBlur,
+  onEnter,
+  onFocus,
+  isOpen,
+  keysCloseList,
+  keysSelection,
+  disabled,
+  errorState,
+  state,
+  id = '',
+  ...restProps
+}) => {
   const refMoleculeAutosuggest = useRef(
     refMoleculeAutosuggestFromProps?.current
   )
@@ -163,6 +164,31 @@ const MoleculeAutosuggest = ({multiselection, ...props}) => {
     }
   }
 
+  const autosuggestSelectionProps = {
+    refMoleculeAutosuggestFromProps,
+    onToggle,
+    onChange,
+    onBlur,
+    onEnter,
+    onFocus,
+    isOpen,
+    keysCloseList,
+    keysSelection,
+    disabled,
+    errorState,
+    state,
+    id,
+    onInputKeyDown: handleInputKeyDown,
+    refMoleculeAutosuggest: refMoleculeAutosuggest,
+    innerRefInput: refMoleculeAutosuggestInput,
+    children: extendedChildren,
+    ...restProps
+  }
+
+  const AutosuggestSelection = multiselection
+    ? MoleculeAutosuggestMultipleSelection
+    : MoleculeAutosuggestSingleSelection
+
   return (
     <div
       ref={refMoleculeAutosuggest}
@@ -171,26 +197,11 @@ const MoleculeAutosuggest = ({multiselection, ...props}) => {
       onKeyDown={handleKeyDown}
       onFocus={handleFocusIn}
       onBlur={handleFocusOut}
+      role="combobox"
+      aria-controls={id}
+      aria-expanded={isOpen}
     >
-      {multiselection ? (
-        <MoleculeAutosuggestMultipleSelection
-          {...props}
-          onInputKeyDown={handleInputKeyDown}
-          refMoleculeAutosuggest={refMoleculeAutosuggest}
-          innerRefInput={refMoleculeAutosuggestInput}
-        >
-          {extendedChildren}
-        </MoleculeAutosuggestMultipleSelection>
-      ) : (
-        <MoleculeAutosuggestSingleSelection
-          {...props}
-          onInputKeyDown={handleInputKeyDown}
-          refMoleculeAutosuggest={refMoleculeAutosuggest}
-          innerRefInput={refMoleculeAutosuggestInput}
-        >
-          {extendedChildren}
-        </MoleculeAutosuggestSingleSelection>
-      )}
+      <AutosuggestSelection {...autosuggestSelectionProps} />
     </div>
   )
 }

--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -164,6 +164,11 @@ const MoleculeAutosuggest = ({
     }
   }
 
+  const handleClick = () => {
+    refMoleculeAutosuggestInput?.current &&
+      refMoleculeAutosuggestInput.current.focus()
+  }
+
   const autosuggestSelectionProps = {
     refMoleculeAutosuggestFromProps,
     onToggle,
@@ -197,6 +202,7 @@ const MoleculeAutosuggest = ({
       onKeyDown={handleKeyDown}
       onFocus={handleFocusIn}
       onBlur={handleFocusOut}
+      onClick={handleClick}
       role="combobox"
       aria-controls={id}
       aria-expanded={isOpen}

--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -35,21 +35,21 @@ const getIsTypeableKey = key => {
 }
 
 const MoleculeAutosuggest = ({
-  multiselection,
-  refMoleculeAutosuggest: refMoleculeAutosuggestFromProps,
   children,
-  onToggle,
-  onChange,
-  onBlur,
-  onEnter,
-  onFocus,
+  disabled,
+  errorState,
+  id = '',
   isOpen,
   keysCloseList,
   keysSelection,
-  disabled,
-  errorState,
+  multiselection,
+  onBlur,
+  onChange,
+  onEnter,
+  onFocus,
+  onToggle,
+  refMoleculeAutosuggest: refMoleculeAutosuggestFromProps,
   state,
-  id = '',
   ...restProps
 }) => {
   const refMoleculeAutosuggest = useRef(

--- a/components/molecule/autosuggestField/src/index.js
+++ b/components/molecule/autosuggestField/src/index.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react'
+import React, {useRef} from 'react'
 import PropTypes from 'prop-types'
 
 import MoleculeField from '@s-ui/react-molecule-field'
@@ -17,57 +17,53 @@ const getState = ({successText, errorState, alertText}) => {
   if (alertText) return MoleculeAutosuggestStates.ALERT
 }
 
-class MoleculeAutosuggestField extends Component {
-  refAutosuggest = React.createRef()
+function MoleculeAutosuggestField({
+  alertText,
+  errorText,
+  helpText,
+  id,
+  inline,
+  label,
+  onChange,
+  successText,
+  useContrastLabel,
+  children,
+  ...restProps
+}) {
+  const refAutosuggest = useRef()
 
-  handleClick = () => {
-    const {current: domAutosuggest} = this.refAutosuggest
+  const handleClick = () => {
+    const {current: domAutosuggest} = refAutosuggest
     if (domAutosuggest) domAutosuggest.focus()
   }
 
-  render() {
-    const {refAutosuggest, handleClick} = this
-    const {
-      label,
-      useContrastLabel,
-      id,
-      successText,
-      errorText,
-      alertText,
-      helpText,
-      inline,
-      children, // eslint-disable-line
-      onChange,
-      ...props
-    } = this.props
-    const errorState = getErrorState({successText, errorText})
-    const autosuggestState = getState({successText, errorState, alertText})
+  const errorState = getErrorState({successText, errorText})
+  const autosuggestState = getState({successText, errorState, alertText})
 
-    return (
-      <MoleculeField
-        name={id}
-        label={label}
-        successText={successText}
-        errorText={errorText}
-        alertText={alertText}
-        helpText={helpText}
-        inline={inline}
-        onClickLabel={handleClick}
-        onChange={onChange}
-        useContrastLabel={useContrastLabel}
+  return (
+    <MoleculeField
+      name={id}
+      label={label}
+      successText={successText}
+      errorText={errorText}
+      alertText={alertText}
+      helpText={helpText}
+      inline={inline}
+      onClickLabel={handleClick}
+      onChange={onChange}
+      useContrastLabel={useContrastLabel}
+    >
+      <MoleculeAutosuggest
+        id={id}
+        refMoleculeAutosuggest={refAutosuggest}
+        errorState={errorState}
+        state={autosuggestState}
+        {...restProps}
       >
-        <MoleculeAutosuggest
-          id={id}
-          refMoleculeAutosuggest={refAutosuggest}
-          errorState={errorState}
-          state={autosuggestState}
-          {...props}
-        >
-          {children}
-        </MoleculeAutosuggest>
-      </MoleculeField>
-    )
-  }
+        {children}
+      </MoleculeAutosuggest>
+    </MoleculeField>
+  )
 }
 
 MoleculeAutosuggestField.displayName = 'MoleculeAutosuggestField'
@@ -98,7 +94,10 @@ MoleculeAutosuggestField.propTypes = {
   inline: PropTypes.bool,
 
   /** Boolean, if true it will use contrast label */
-  useContrastLabel: PropTypes.string
+  useContrastLabel: PropTypes.string,
+
+  /** A React element */
+  children: PropTypes.element
 }
 
 export default MoleculeAutosuggestField

--- a/components/molecule/autosuggestField/src/index.js
+++ b/components/molecule/autosuggestField/src/index.js
@@ -19,6 +19,7 @@ const getState = ({successText, errorState, alertText}) => {
 
 function MoleculeAutosuggestField({
   alertText,
+  children,
   errorText,
   helpText,
   id,
@@ -27,7 +28,6 @@ function MoleculeAutosuggestField({
   onChange,
   successText,
   useContrastLabel,
-  children,
   ...restProps
 }) {
   const refAutosuggest = useRef()

--- a/components/molecule/inputTags/src/index.js
+++ b/components/molecule/inputTags/src/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 import React, {useState} from 'react'
 import PropTypes from 'prop-types'
 import AtomTag, {atomTagSizes} from '@s-ui/react-atom-tag'
@@ -11,10 +13,10 @@ const CLASS_TAGS_ERROR = `${CLASS_TAGS}--error`
 const CLASS_TAGS_SUCCESS = `${CLASS_TAGS}--success`
 
 // eslint-disable-next-line react/prop-types
-const AtomTagItem = ({onClose: onCloseFromProps = () => {}, id, ...props}) => {
-  const onClose = e => onCloseFromProps(e, {id})
+const AtomTagItem = ({onClose = () => {}, id, ...restProps}) => {
+  const handleClose = e => onClose(e, {id})
 
-  return <AtomTag onClose={onClose} {...props} />
+  return <AtomTag onClose={handleClose} {...restProps} />
 }
 
 const MoleculeInputTags = ({
@@ -22,16 +24,16 @@ const MoleculeInputTags = ({
   value,
   optionsData,
   onChangeTags,
-  onChange: onChangeFromProps,
+  onChange: onInputChange,
   innerRefInput,
   tagsCloseIcon,
   tags: tagsFromProps,
-  ...props
+  size,
+  ...restProps
 }) => {
-  const {size} = props
   const [focus, setFocus] = useState(false)
 
-  const classNames = cx(CLASS_TAGS, {
+  const className = cx(CLASS_TAGS, {
     [CLASS_TAGS_FOCUS]: focus === true,
     [CLASS_TAGS_ERROR]: errorState === true,
     [CLASS_TAGS_SUCCESS]: errorState === false,
@@ -57,16 +59,20 @@ const MoleculeInputTags = ({
     }
   }
 
-  const onChange = (ev, valuesToPropagate) => {
-    onChangeFromProps(ev, valuesToPropagate)
+  const handleInputChange = (ev, valuesToPropagate) => {
+    onInputChange(ev, valuesToPropagate)
   }
 
   const handleFocusIn = () => setFocus(true)
 
   const handleFocusOut = () => setFocus(false)
 
+  const handleWrapperClick = () => {
+    innerRefInput?.current && innerRefInput.current.focus()
+  }
+
   return (
-    <div className={classNames}>
+    <div className={className} onClick={handleWrapperClick}>
       {tagsFromProps.map((label, index) => (
         <AtomTagItem
           key={index}
@@ -79,9 +85,9 @@ const MoleculeInputTags = ({
         />
       ))}
       <AtomInput
-        {...props}
+        {...restProps}
         value={value}
-        onChange={onChange}
+        onChange={handleInputChange}
         onEnter={addTag}
         onFocus={handleFocusIn}
         onBlur={handleFocusOut}

--- a/components/molecule/inputTags/src/index.js
+++ b/components/molecule/inputTags/src/index.js
@@ -19,14 +19,14 @@ const AtomTagItem = ({onClose = () => {}, id, ...restProps}) => {
 
 const MoleculeInputTags = ({
   errorState,
-  value,
-  optionsData,
-  onChangeTags,
-  onChange: onInputChange,
   innerRefInput,
-  tagsCloseIcon,
-  tags: tagsFromProps,
+  onChange: onInputChange,
+  onChangeTags,
+  optionsData,
   size,
+  tags: tagsFromProps,
+  tagsCloseIcon,
+  value,
   ...restProps
 }) => {
   const [focus, setFocus] = useState(false)

--- a/components/molecule/inputTags/src/index.js
+++ b/components/molecule/inputTags/src/index.js
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
 import React, {useState} from 'react'
 import PropTypes from 'prop-types'
 import AtomTag, {atomTagSizes} from '@s-ui/react-atom-tag'
@@ -67,12 +65,8 @@ const MoleculeInputTags = ({
 
   const handleFocusOut = () => setFocus(false)
 
-  const handleWrapperClick = () => {
-    innerRefInput?.current && innerRefInput.current.focus()
-  }
-
   return (
-    <div className={className} onClick={handleWrapperClick}>
+    <div className={className}>
       {tagsFromProps.map((label, index) => (
         <AtomTagItem
           key={index}

--- a/demo/molecule/autosuggestField/demo/index.js
+++ b/demo/molecule/autosuggestField/demo/index.js
@@ -97,7 +97,7 @@ const Demo = () => (
       <div className={CLASS_DEMO_SECTION} style={{background: '#2b91c1'}}>
         <h3>With contrast label</h3>
         <MoleculeAutosuggestField
-          id="with-placeholder"
+          id="with-contrast-label"
           label="Country"
           placeholder="Select a Country..."
           onChange={(_, {value}) => console.log(value)}
@@ -109,7 +109,7 @@ const Demo = () => (
       <div className={CLASS_DEMO_SECTION}>
         <h3>Without label</h3>
         <MoleculeAutosuggestField
-          id="with-placeholder"
+          id="without-label"
           placeholder="Select a Country..."
           onChange={(_, {value}) => console.log(value)}
           iconClear={<IconClose />}

--- a/demo/molecule/inputTags/demo/index.js
+++ b/demo/molecule/inputTags/demo/index.js
@@ -1,5 +1,4 @@
-/* eslint-disable */
-
+/* eslint-disable no-console */
 import React, {useRef} from 'react'
 import './index.scss'
 

--- a/demo/molecule/inputTags/demo/index.js
+++ b/demo/molecule/inputTags/demo/index.js
@@ -1,6 +1,6 @@
-/* eslint-disable no-console */
+/* eslint-disable */
 
-import React from 'react'
+import React, {useRef} from 'react'
 import './index.scss'
 
 import MoleculeInputTags, {
@@ -16,94 +16,109 @@ const CLASS_DEMO_SECTION = `${BASE_CLASS_DEMO}-section`
 
 const MoleculeInputTagsWithState = withStateValueTags(MoleculeInputTags)
 
-const Demo = () => (
-  <div className="sui-StudioPreview">
-    <div className="sui-StudioPreview-content sui-StudioDemo-preview">
-      <h1>Input tags</h1>
-      <p>
-        Check the console to verify the <code>onChangeTags</code> on
-        adding/removing tabs
-      </p>
-      <div className={CLASS_DEMO_SECTION}>
-        <h4>Basic</h4>
-        <MoleculeInputTagsWithState
-          name="inputTagsBeatles1"
-          value="George Martin"
-          tagsCloseIcon={<CloseIcon />}
-          tags={beatles}
-          onChangeTags={(_, {tags, name}) => {
-            console.log({[`onChangeTags___${name}`]: tags})
-          }}
-        />
-      </div>
-      <div className={CLASS_DEMO_SECTION}>
-        <h4>Entering tags on "Tab" press</h4>
-        <MoleculeInputTagsWithState
-          name="inputTagsBeatles2"
-          value="George Martin"
-          tagsCloseIcon={<CloseIcon />}
-          tags={beatles}
-          onEnterKey="Tab"
-          onChangeTags={(_, {tags, name}) => {
-            console.log({[`onChangeTags___${name}`]: tags})
-          }}
-        />
-      </div>
-      <div className={CLASS_DEMO_SECTION}>
-        <h4>Entering tags on "comma" press</h4>
-        <MoleculeInputTagsWithState
-          name="inputTagsBeatles3"
-          value="George Martin"
-          tagsCloseIcon={<CloseIcon />}
-          tags={beatles}
-          onEnterKey=","
-          onChangeTags={(_, {tags, name}) => {
-            console.log({[`onChangeTags___${name}`]: tags})
-          }}
-        />
-      </div>
-      <div className={CLASS_DEMO_SECTION}>
-        <h4>With size=SMALL</h4>
-        <MoleculeInputTagsWithState
-          name="inputTagsBeatles4"
-          tagsCloseIcon={<CloseIcon />}
-          tags={ledZeppelin}
-          size={inputSizes.SMALL}
-          onChangeTags={(_, {tags, name}) => {
-            console.log({[`onChangeTags___${name}`]: tags})
-          }}
-        />
-      </div>
-      <div className={CLASS_DEMO_SECTION}>
-        <h4>With error</h4>
-        <MoleculeInputTagsWithState
-          name="inputTagsBeatles5"
-          tagsCloseIcon={<CloseIcon />}
-          tags={queen}
-          errorState
-          onChangeTags={(_, {tags, name}) => {
-            console.log({[`onChangeTags___${name}`]: tags})
-          }}
-        />
-      </div>
-      <div className={CLASS_DEMO_SECTION}>
-        <h4>With onChange handler</h4>
-        <MoleculeInputTagsWithState
-          name="inputTagsBeatles6"
-          tagsCloseIcon={<CloseIcon />}
-          tags={queen}
-          onChange={(_, valuesToPropagate) => {
-            const {name, value} = valuesToPropagate
-            console.log({[`onChange___${name}`]: value})
-          }}
-          onChangeTags={(_, valuesToPropagate) => {
-            const {name, tags} = valuesToPropagate
-            console.log({[`onChangeTags___${name}`]: tags})
-          }}
-        />
+const Demo = () => {
+  const basicInputEl = useRef()
+  const tabPressInputEl = useRef()
+  const commaPressInputEl = useRef()
+  const withSizeSmallInputEl = useRef()
+  const withErrorInputEl = useRef()
+  const withOnChangeHandlerInputEl = useRef()
+
+  return (
+    <div className="sui-StudioPreview">
+      <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+        <h1>Input tags</h1>
+        <p>
+          Check the console to verify the <code>onChangeTags</code> on
+          adding/removing tabs
+        </p>
+        <div className={CLASS_DEMO_SECTION}>
+          <h4>Basic</h4>
+          <MoleculeInputTagsWithState
+            name="inputTagsBeatles1"
+            value="George Martin"
+            tagsCloseIcon={<CloseIcon />}
+            tags={beatles}
+            onChangeTags={(_, {tags, name}) => {
+              console.log({[`onChangeTags___${name}`]: tags})
+            }}
+            innerRefInput={basicInputEl}
+          />
+        </div>
+        <div className={CLASS_DEMO_SECTION}>
+          <h4>Entering tags on "Tab" press</h4>
+          <MoleculeInputTagsWithState
+            name="inputTagsBeatles2"
+            value="George Martin"
+            tagsCloseIcon={<CloseIcon />}
+            tags={beatles}
+            onEnterKey="Tab"
+            onChangeTags={(_, {tags, name}) => {
+              console.log({[`onChangeTags___${name}`]: tags})
+            }}
+            innerRefInput={tabPressInputEl}
+          />
+        </div>
+        <div className={CLASS_DEMO_SECTION}>
+          <h4>Entering tags on "comma" press</h4>
+          <MoleculeInputTagsWithState
+            name="inputTagsBeatles3"
+            value="George Martin"
+            tagsCloseIcon={<CloseIcon />}
+            tags={beatles}
+            onEnterKey=","
+            onChangeTags={(_, {tags, name}) => {
+              console.log({[`onChangeTags___${name}`]: tags})
+            }}
+            innerRefInput={commaPressInputEl}
+          />
+        </div>
+        <div className={CLASS_DEMO_SECTION}>
+          <h4>With size=SMALL</h4>
+          <MoleculeInputTagsWithState
+            name="inputTagsBeatles4"
+            tagsCloseIcon={<CloseIcon />}
+            tags={ledZeppelin}
+            size={inputSizes.SMALL}
+            onChangeTags={(_, {tags, name}) => {
+              console.log({[`onChangeTags___${name}`]: tags})
+            }}
+            innerRefInput={withSizeSmallInputEl}
+          />
+        </div>
+        <div className={CLASS_DEMO_SECTION}>
+          <h4>With error</h4>
+          <MoleculeInputTagsWithState
+            name="inputTagsBeatles5"
+            tagsCloseIcon={<CloseIcon />}
+            tags={queen}
+            errorState
+            onChangeTags={(_, {tags, name}) => {
+              console.log({[`onChangeTags___${name}`]: tags})
+            }}
+            innerRefInput={withErrorInputEl}
+          />
+        </div>
+        <div className={CLASS_DEMO_SECTION}>
+          <h4>With onChange handler</h4>
+          <MoleculeInputTagsWithState
+            name="inputTagsBeatles6"
+            tagsCloseIcon={<CloseIcon />}
+            tags={queen}
+            onChange={(_, valuesToPropagate) => {
+              const {name, value} = valuesToPropagate
+              console.log({[`onChange___${name}`]: value})
+            }}
+            onChangeTags={(_, valuesToPropagate) => {
+              const {name, tags} = valuesToPropagate
+              console.log({[`onChangeTags___${name}`]: tags})
+            }}
+            innerRefInput={withOnChangeHandlerInputEl}
+          />
+        </div>
       </div>
     </div>
-  </div>
-)
+  )
+}
 
 export default Demo


### PR DESCRIPTION
# Autosuggest actionable from tags

Add the focus of the field from anywhere via `onClick` event

- Adds consistency by leaving a single input source with variable `props` and for the rest with `restProps` for `MoleculeAutosuggest`, `MoleculeAutosuggestField`.
- Move `MoleculeAutosuggestField` of class component to functional component
- Apply handler prefix rule for event handlers
- Fix warnings in demo



![Sep-15-2020 14-49-39](https://user-images.githubusercontent.com/1263588/93212334-c4460400-f762-11ea-8664-e661d6df0831.gif)
