### PR TITLE
feat(atom/input): add defaultValue prop support

### DIFF
--- a/components/atom/input/src/Input/Component/index.js
+++ b/components/atom/input/src/Input/Component/index.js
@@ -67,6 +67,7 @@ const Input = ({
   tabIndex = DEFAULT_PROPS.TAB_INDEX,
   maxLength,
   minLength,
+  defaultValue,
   min,
   max,
   step,
@@ -123,6 +124,7 @@ const Input = ({
       type={type}
       value={value}
       size={charsSize}
+      defaultValue={defaultValue}
       maxLength={maxLength}
       minLength={minLength}
       max={max}
@@ -182,6 +184,8 @@ Input.propTypes = {
   type: PropTypes.string,
   /* value of the control */
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  /* default value of the control */
+  defaultValue: PropTypes.string,
   /* react ref to access DOM node */
   reference: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
   /** Wether to show the input or not */

--- a/demo/atom/input/demo/index.js
+++ b/demo/atom/input/demo/index.js
@@ -211,7 +211,7 @@ export default () => (
       </div>
 
       <div style={field}>
-        <h4>Inline Form</h4>
+        <h4>Default value</h4>
         <AtomInput defaultValue="Default value" />
       </div>
     </div>

--- a/demo/atom/input/demo/index.js
+++ b/demo/atom/input/demo/index.js
@@ -209,6 +209,11 @@ export default () => (
           button={<SuiButton>Submit</SuiButton>}
         />
       </div>
+
+      <div style={field}>
+        <h4>Inline Form</h4>
+        <AtomInput defaultValue="Default value" />
+      </div>
     </div>
   </div>
 )


### PR DESCRIPTION
**Is your component proposal related to a problem? Please describe.**
There are cases where you want to set a default value for an input and still use it as an uncontrolled component

**Describe the solution you'd like**
Add [defaultValue](https://www.w3schools.com/jsref/prop_text_defaultvalue.asp) prop support and a simple example.
```jsx
const Example = () => {
  return <AtomInput defaultValue={query.name} />
}
```

**Preview**
https://sui-components.schibstedspain.vercel.app/workbench/atom/input/demo