### PR TITLE
feat(organism/avatarGroup): proposal to add avatar group component 👥

### DIFF
--- a/components/organism/avatarGroup/.gitignore
+++ b/components/organism/avatarGroup/.gitignore
@@ -1,0 +1,2 @@
+lib
+node_modules

--- a/components/organism/avatarGroup/.npmignore
+++ b/components/organism/avatarGroup/.npmignore
@@ -1,0 +1,2 @@
+src
+assets

--- a/components/organism/avatarGroup/README.md
+++ b/components/organism/avatarGroup/README.md
@@ -1,0 +1,66 @@
+# OrganismAvatarGroup
+
+Stack related avatars as a group.
+
+<!-- ![](./assets/preview.png) -->
+
+## Installation
+
+```sh
+$ npm install @s-ui/react-organism-avatar-group
+```
+
+## Usage
+
+### Basic usage
+
+#### Import package and use the component
+
+```js
+import OrganismAvatarGroup from '@s-ui/react-organism-avatar-group'
+
+return (<OrganismAvatarGroup />)
+```
+
+#### Import the styles (Sass)
+
+```css
+@import '~@s-ui/theme/lib/index';
+@import '~@s-ui/react-organism-avatar-group/lib/index';
+```
+
+### Size
+
+Modify the size of the avatars with `size` prop. Choose between `small`, `medium`, `large` and `xlarge`
+
+```jsx
+import OrganismAvatarGroup from '@s-ui/react-organism-avatar-group'
+
+const SizeStory = () => (
+  <>
+    <OrganismAvatarGroup size="large">
+      <OrganismAvatarGroup.Avatar name="Kiko Ruiz" />
+      <OrganismAvatarGroup.Avatar name="Miguel Angel Duran" />
+    </OrganismAvatarGroup>
+  </>
+);
+```
+
+### Max
+
+Set a maximun number of avatars to show using `max` prop.
+
+```jsx
+import OrganismAvatarGroup from '@s-ui/react-organism-avatar-group'
+
+const MaxStory = () => (
+  <>
+    <OrganismAvatarGroup max={1}>
+      <OrganismAvatarGroup.Avatar name="Arturo Lopez" />
+      <OrganismAvatarGroup.Avatar name="Andres Lucas" />
+    </OrganismAvatarGroup>
+  </>
+);
+```
+
+> **Find full description and more examples in the [demo page](#).**

--- a/components/organism/avatarGroup/package.json
+++ b/components/organism/avatarGroup/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@s-ui/react-organism-avatar-group",
+  "version": "1.0.0",
+  "description": "",
+  "main": "lib/index.js",
+  "scripts": {
+    "build": "npx rimraf ./lib && npm run build:js && npm run build:styles",
+    "build:js": "../../../node_modules/.bin/babel --presets sui ./src --out-dir ./lib",
+    "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
+  },
+  "dependencies": {
+    "@s-ui/component-dependencies": "1",
+    "@s-ui/react-molecule-avatar": "1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT"
+}

--- a/components/organism/avatarGroup/src/index.js
+++ b/components/organism/avatarGroup/src/index.js
@@ -1,0 +1,54 @@
+import React, {forwardRef} from 'react'
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import MoleculeAvatar, {AVATAR_SIZES} from '@s-ui/react-molecule-avatar'
+
+const OrganismAvatarGroup = forwardRef(
+  (
+    {
+      className: classNameProp,
+      max = 3,
+      size = AVATAR_SIZES.MEDIUM,
+      children: childrenProp,
+      ...others
+    },
+    ref
+  ) => {
+    const baseClassName = 'react-OrganismAvatarGroup'
+    const className = cx(
+      baseClassName,
+      classNameProp,
+      `${baseClassName}--${size}`
+    )
+    const children = React.Children.toArray(childrenProp).filter(child =>
+      React.isValidElement(child)
+    )
+    const avatars = children
+      .slice(0, max)
+      .reverse()
+      .map(child =>
+        React.cloneElement(child, {size, className: `${baseClassName}-avatar`})
+      )
+
+    const rest = children.length - avatars.length
+
+    return (
+      <div ref={ref} role="group" className={className} {...others}>
+        {rest > 0 && <span className={`${baseClassName}-rest`}>+{rest}</span>}
+        {avatars}
+      </div>
+    )
+  }
+)
+
+OrganismAvatarGroup.Avatar = MoleculeAvatar
+
+OrganismAvatarGroup.displayName = 'OrganismAvatarGroup'
+OrganismAvatarGroup.propTypes = {
+  className: PropTypes.string,
+  size: PropTypes.oneOf(Object.values(AVATAR_SIZES)),
+  max: PropTypes.number,
+  children: PropTypes.node
+}
+
+export default OrganismAvatarGroup

--- a/components/organism/avatarGroup/src/index.scss
+++ b/components/organism/avatarGroup/src/index.scss
@@ -1,0 +1,44 @@
+@import '~@s-ui/theme/lib/index';
+@import '~@s-ui/react-molecule-avatar/lib/index';
+
+$mr-avatar-group: -0.55em !default;
+$bgc-avatar-group-rest: $bgc-avatar !default;
+
+.react-OrganismAvatarGroup {
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: flex-end;
+
+  &-avatar,
+  &-rest {
+    margin-right: $mr-avatar-group;
+  }
+
+  &-avatar {
+    &:first-child {
+      margin-right: 0;
+    }
+  }
+
+  &-rest {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: $bdrs-rounded;
+    background-color: $bgc-avatar-group-rest;
+  }
+
+  @each $key-size, $size in $s-avatar {
+    &--#{$key-size} &-rest {
+      width: $size;
+      min-width: $size;
+      height: $size;
+    }
+  }
+
+  @each $key-size, $size in $fs-avatar-name {
+    &--#{$key-size} {
+      font-size: $size;
+    }
+  }
+}

--- a/demo/organism/avatarGroup/playground
+++ b/demo/organism/avatarGroup/playground
@@ -1,0 +1,36 @@
+return (
+  <div
+    style={{
+      maxWidth: '1280px',
+      width: '100%',
+      margin: '0 auto',
+      padding: '12px'
+    }}
+  >
+    <h1>AvatarGroup 👥</h1>
+
+    <h2>Size</h2>
+    <OrganismAvatarGroup>
+      <OrganismAvatarGroup.Avatar name="David Garcia" />
+      <OrganismAvatarGroup.Avatar name="Arnau Rivas" />
+    </OrganismAvatarGroup>
+    <OrganismAvatarGroup style={{marginTop: '8px'}} size="large">
+      <OrganismAvatarGroup.Avatar name="Kiko Ruiz" />
+      <OrganismAvatarGroup.Avatar name="Miguel Angel Duran" />
+    </OrganismAvatarGroup>
+
+    <h2>Max</h2>
+    <OrganismAvatarGroup max={3}>
+      <OrganismAvatarGroup.Avatar
+        name="Arturo Lopez"
+        src="https://avatars2.githubusercontent.com/u/23620759?s=460&u=8e2dc39fcf72fcdb88590a501c5a5976bcea7b5d&v=4"
+      />
+      <OrganismAvatarGroup.Avatar name="Carlos Villuendas" />
+      <OrganismAvatarGroup.Avatar
+        name="Andres Lucas"
+        src="https://avatars1.githubusercontent.com/u/1674036?s=460&v=4"
+      />
+      <OrganismAvatarGroup.Avatar name="David Garcia" />
+    </OrganismAvatarGroup>
+  </div>
+)

--- a/test/organism/avatarGroup/index.js
+++ b/test/organism/avatarGroup/index.js
@@ -1,0 +1,76 @@
+/* eslint react/jsx-no-undef:0 */
+/* eslint no-undef:0 */
+
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+import chai, {expect} from 'chai'
+import chaiDOM from 'chai-dom'
+
+chai.use(chaiDOM)
+
+describe('OrganismAvatarGroup', () => {
+  const Component = OrganismAvatarGroup
+  const setup = setupEnvironment(Component)
+
+  it('should render without crashing', () => {
+    // Given
+    const props = {}
+
+    // When
+    const component = <Component {...props} />
+
+    // Then
+    const div = document.createElement('div')
+    ReactDOM.render(component, div)
+    ReactDOM.unmountComponentAtNode(div)
+  })
+
+  it('should not render null', () => {
+    // Given
+    const props = {}
+
+    // When
+    const {container} = setup(props)
+
+    // Then
+    expect(container.innerHTML).to.be.a('string')
+    expect(container.innerHTML).to.not.have.lengthOf(0)
+  })
+
+  it('should render avatars', () => {
+    // Given
+    const props = {
+      children: [
+        <OrganismAvatarGroup.Avatar key="1" />,
+        <OrganismAvatarGroup.Avatar key="2" />
+      ]
+    }
+
+    // When
+    const {getByRole} = setup(props)
+
+    // Then
+    expect(getByRole('group').childNodes.length).to.be.eql(2)
+  })
+
+  it('should render a maximum number of avatars', () => {
+    // Given
+    const props = {
+      max: 2,
+      children: [
+        <OrganismAvatarGroup.Avatar key="1" />,
+        <OrganismAvatarGroup.Avatar key="2" />,
+        <OrganismAvatarGroup.Avatar key="3" />,
+        <OrganismAvatarGroup.Avatar key="4" />
+      ]
+    }
+
+    // When
+    const {getByRole, getByText} = setup(props)
+
+    // Then
+    expect(getByRole('group').childNodes.length).to.be.eql(3)
+    expect(getByText('+2')).to.be.visible
+  })
+})


### PR DESCRIPTION
**Is your component proposal related to a problem? Please describe.**

Sometimes could be useful to group related avatars.

**Describe the solution you'd like**

A component called `OrganismAvatarGroup` that could wrap several avatars setting the same size and a maximum number to be displayed for all of them

**Screenshots**
<p align="center">
<img src="https://user-images.githubusercontent.com/6877967/94174901-3373d480-fe96-11ea-8d6d-8f6d5b171ff4.png" />
</p>
