### PR TITLE
fix(atom/button): use prop rel in AtomButton when it is a link

### DIFF
--- a/components/atom/button/README.md
+++ b/components/atom/button/README.md
@@ -117,7 +117,7 @@ When `link` property is passed, the component will render an html link.
 import Button from '@s-ui/react-atom-button'
 
 return (
-  <Button link href='http://www.schibsted.com/' target='_blank'>Link</Button>
+  <Button link href='http://www.schibsted.com/' target='_blank' rel="nofollow noopener">Link</Button>
 )
 
 ```

--- a/components/atom/button/src/Button.js
+++ b/components/atom/button/src/Button.js
@@ -14,13 +14,12 @@ const Button = ({
 }) => {
   if (isSubmit) attrs.type = 'submit'
   if (isButton) attrs.type = 'button'
+
+  const defaultRel = target === '_blank' ? 'noopener' : undefined
+  const rel = attrs.rel || defaultRel
+
   return link ? (
-    <Link
-      {...attrs}
-      href={href}
-      target={target}
-      rel={target === '_blank' ? 'noopener' : undefined}
-    >
+    <Link {...attrs} href={href} target={target} rel={rel}>
       {children}
     </Link>
   ) : (


### PR DESCRIPTION
`rel` attribute can have different values as you can see in: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#:~:text=The%20rel%20attribute%20defines%20the,which%20the%20attribute%20is%20found.

We need to enable the possibility of sent the value we want in props and use it. `nofollow`, `noopener`, `noreferrer` are common values`rel` could countains