### PR TITLE
feat(atom/tooltip): fix children element when include component

### DIFF
--- a/components/atom/tooltip/src/index.js
+++ b/components/atom/tooltip/src/index.js
@@ -67,7 +67,7 @@ class AtomTooltip extends Component {
             'div',
             {
               ref,
-              className: cx(className, `${className}--wrapper`),
+              className: `${className} ${className}--wrapper`,
               onTouchEnd
             },
             React.cloneElement(child)

--- a/components/atom/tooltip/src/index.js
+++ b/components/atom/tooltip/src/index.js
@@ -62,7 +62,7 @@ class AtomTooltip extends Component {
       this.onClickTarget = child.props.onClick
       this.title = child.props.title
 
-      return typeof child?.type !== 'string'
+      return typeof child.type !== 'string'
         ? React.createElement(
             'div',
             {

--- a/components/atom/tooltip/src/index.js
+++ b/components/atom/tooltip/src/index.js
@@ -61,11 +61,14 @@ class AtomTooltip extends Component {
     return React.Children.map(childrenOnly, child => {
       this.onClickTarget = child.props.onClick
       this.title = child.props.title
-      return React.cloneElement(child, {
-        ref,
-        className,
-        onTouchEnd
-      })
+
+      return typeof child?.type !== 'string'
+        ? React.createElement(
+            'div',
+            {ref, className, onTouchEnd},
+            React.cloneElement(child)
+          )
+        : React.cloneElement(child, {ref, className, onTouchEnd})
     })
   }
 

--- a/components/atom/tooltip/src/index.js
+++ b/components/atom/tooltip/src/index.js
@@ -65,7 +65,11 @@ class AtomTooltip extends Component {
       return typeof child?.type !== 'string'
         ? React.createElement(
             'div',
-            {ref, className, onTouchEnd},
+            {
+              ref,
+              className: cx(className, `${className}--wrapper`),
+              onTouchEnd
+            },
             React.cloneElement(child)
           )
         : React.cloneElement(child, {ref, className, onTouchEnd})

--- a/components/atom/tooltip/src/index.scss
+++ b/components/atom/tooltip/src/index.scss
@@ -71,6 +71,10 @@ $c-atom-tooltip-colors: (
   -webkit-touch-callout: none; /* iOS Safari */
   -webkit-user-select: none; /* Safari */
   user-select: none; /* Non-prefixed version, currently supported by Chrome and Opera */
+
+  &--wrapper {
+    display: inline-flex;
+  }
 }
 
 #{$base-class} {


### PR DESCRIPTION
ISSUES CLOSED: #1223

## [ATOM]/[TOOLTIP]

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description, Motivation and Context
Resolved issue https://github.com/SUI-Components/sui-components/issues/1223

Fixed issue with adding components without having to have a top container. In this way, if the Tooltip receives an element / component node has wrapper will be automatically.

Inside the children prop that it receives, a modifier with `display: inline-flex` is added to make it fit the content with which it is included.

```
<AtomTooltip>
  <AtomButton
    title="tooltip content"
    onClick={() => console.log('Hi!')}
  >
    Component
  </AtomButton>
</AtomTooltip>
```

### Screenshots - Animations

![CleanShot 2020-10-01 at 17 49 48](https://user-images.githubusercontent.com/1427623/94832703-886f9780-040e-11eb-961a-97d0c9c7a42c.gif)


