### PR TITLE
feat(atom/upload): remove atom icon and add sass vars

### DIFF
--- a/components/atom/upload/package.json
+++ b/components/atom/upload/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@s-ui/component-dependencies": "1",
     "@s-ui/react-atom-button": "1",
-    "@s-ui/react-atom-icon": "1",
     "react-dropzone": "5.1.1"
   },
   "keywords": [],

--- a/components/atom/upload/src/index.js
+++ b/components/atom/upload/src/index.js
@@ -1,10 +1,6 @@
 import React, {useState, useEffect, lazy, Suspense} from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import AtomIcon, {
-  ATOM_ICON_COLORS,
-  ATOM_ICON_SIZES
-} from '@s-ui/react-atom-icon'
 const Dropzone = lazy(() => import('react-dropzone'))
 
 const STATUSES = {
@@ -29,7 +25,6 @@ const AtomUpload = ({
   multiple,
   maxSize,
   accept,
-  iconSize = ATOM_ICON_SIZES.large,
   ...props
 }) => {
   const [ready, setReady] = useState(false)
@@ -52,13 +47,7 @@ const AtomUpload = ({
     return (
       <div className={cx(BASE_CLASS, `${BASE_CLASS}--${status}`)}>
         <>
-          <AtomIcon
-            size={iconSize}
-            color={ATOM_ICON_COLORS.currentColor}
-            className={classNameIcon}
-          >
-            {IconStatus}
-          </AtomIcon>
+          <span className={classNameIcon}>{IconStatus}</span>
           <div className={CLASS_BLOCK_TEXT}>
             <h4 className={CLASS_BLOCK_TEXT_MAIN}>{textStatus}</h4>
             {isActive && (hasTextExplanation || hasButton) && (
@@ -79,12 +68,12 @@ const AtomUpload = ({
       {hasValidStatus && ready && (
         <Suspense fallback={null}>
           <Dropzone
+            accept={accept}
             className={`${BASE_CLASS}-dropzone`}
             disabled={status !== STATUSES.ACTIVE}
-            onDrop={handleFileSelectionChange}
-            multiple={multiple}
             maxSize={maxSize}
-            accept={accept}
+            multiple={multiple}
+            onDrop={handleFileSelectionChange}
           >
             {renderStatusBlock(status)}
           </Dropzone>
@@ -151,9 +140,7 @@ AtomUpload.propTypes = {
   accept: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.arrayOf(PropTypes.string)
-  ]),
-  /** Size of icon */
-  iconSize: PropTypes.oneOf(Object.values(ATOM_ICON_SIZES))
+  ])
 }
 
 export {STATUSES as uploadStatuses}

--- a/components/atom/upload/src/index.scss
+++ b/components/atom/upload/src/index.scss
@@ -1,6 +1,5 @@
 @import '~@s-ui/theme/lib/index';
 @import '~@s-ui/react-atom-button/lib/index';
-@import '~@s-ui/react-atom-icon/lib/index';
 
 $bdrs-atom-upload: $bdrs-none !default;
 $bw-atom-upload: $bdw-m !default;
@@ -16,6 +15,11 @@ $fz-atom-upload-text: $fz-xl !default;
 $fz-atom-upload-text-secondary: $fz-l !default;
 $h-atom-upload-icon: $sz-icon-xl * 2 !default;
 $w-atom-upload-icon: $sz-icon-xl * 2 !default;
+$m-atom-upload-text-secondary: 0px 0px $m-l 0px !default;
+$fw-atom-upload-text-main: $fw-semi-bold !default;
+$fw-atom-upload-text-secondary: $fw-light !default;
+$c-atom-upload-text-main: $c-atom-upload !default;
+$c-atom-upload-text-secondary: $c-atom-upload !default;
 $jc-atom-upload-content: inherit !default;
 $m-atom-upload-main-text: $m-l 0 !default;
 
@@ -44,15 +48,17 @@ $m-atom-upload-main-text: $m-l 0 !default;
     }
 
     &-main {
+      color: $c-atom-upload-text-main;
       font-size: $fz-atom-upload-text;
-      font-weight: $fw-semi-bold;
+      font-weight: $fw-atom-upload-text-main;
       margin: $m-atom-upload-main-text;
     }
 
     &-secondary {
+      color: $c-atom-upload-text-secondary;
       font-size: $fz-atom-upload-text-secondary;
-      font-weight: $fw-light;
-      margin-bottom: $m-l;
+      font-weight: $fw-atom-upload-text-secondary;
+      margin: $m-atom-upload-text-secondary;
     }
   }
 


### PR DESCRIPTION


BREAKING CHANGE:
Remove atom icon dep


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description, Motivation and Context
Add sass variables to be able to style the component even more from vertical themes.
Also since the svg repos already wrap SVG in AtomIcon we can remove the dependency from this component and use the icon prop instead


