### PR TITLE
fix(molecule/tabs): prevent render content element if there is empty

### DIFF
--- a/components/molecule/tabs/src/index.js
+++ b/components/molecule/tabs/src/index.js
@@ -46,7 +46,9 @@ const MoleculeTabs = ({variant, type, children, onChange}) => {
   return (
     <div className={className}>
       <ul className={CLASS_SCROLLER}>{extendedChildren}</ul>
-      <div className={CLASS_CONTENT}>{activeTabContent}</div>
+      {activeTabContent ? (
+        <div className={CLASS_CONTENT}>{activeTabContent}</div>
+      ) : null}
     </div>
   )
 }

--- a/demo/package.json
+++ b/demo/package.json
@@ -8,8 +8,5 @@
       "packagesFolder": ".",
       "deepLevel": 3
     }
-  },
-  "dependencies": {
-    "undefined": "^0.1.0"
   }
 }

--- a/demo/package.json
+++ b/demo/package.json
@@ -8,5 +8,8 @@
       "packagesFolder": ".",
       "deepLevel": 3
     }
+  },
+  "dependencies": {
+    "undefined": "^0.1.0"
   }
 }


### PR DESCRIPTION
## Molecule/Tabs


### Types of changes
If we do not set a content for a tab, this component renders an empy div. 
This is not a desired behavior

### Description, Motivation and Context
We are using MoleculeTabs for tab content, but this content is in other position, not jus following tabs. So, we are using tabs without content and manage state in our component.

### Screenshots - Animations
Tabs toggle Vehicle list with other kind of content, but not the form and the header.
![image](https://user-images.githubusercontent.com/5390428/95455175-c2d8b780-096d-11eb-83d3-8c41a9dece06.png)

