### PR TITLE
feat(molecule/badgeCounter): use status instead of custom property

### DIFF
--- a/components/molecule/badgeCounter/src/index.js
+++ b/components/molecule/badgeCounter/src/index.js
@@ -9,7 +9,8 @@ const CLASS_BULLET = `${BASE_CLASS}-bullet`
 const CLASS_SMALL = `${CLASS_BULLET}-small`
 const CLASS_MEDIUM = `${CLASS_BULLET}-medium`
 const CLASS_LARGE = `${CLASS_BULLET}-large`
-const CLASS_CUSTOM = `${CLASS_BULLET}-custom`
+const CLASS_DISABLED = 'is-disabled'
+const CLASS_SELECTED = 'is-selected'
 
 const CLASS_MEDIUM_THREE_CHARS = `${CLASS_MEDIUM}--threeCharacters`
 const CLASS_LARGE_THREE_CHARS = `${CLASS_LARGE}--threeCharacters`
@@ -18,6 +19,12 @@ const SIZES = {
   SMALL: 'small',
   MEDIUM: 'medium',
   LARGE: 'large'
+}
+
+const STATUS = {
+  DEFAULT: 'default',
+  DISABLED: 'disabled',
+  SELECTED: 'selected'
 }
 
 const VARIANTS = {
@@ -29,15 +36,17 @@ const MAX_LABEL = '+99'
 
 const MoleculeBadgeCounter = ({
   children,
-  custom = false,
   label = '',
   size,
+  status,
   variant
 }) => {
   const hasLabel = Boolean(label)
   const hasChildren = Boolean(children)
 
   const CLASS_SIZE = getClassSize({size, hasLabel})
+
+  const CLASS_STATUS = getClassStatus({status})
 
   const CLASS_LENGTH_LABEL = getClassLengthLabel({hasLabel, label, size})
 
@@ -52,10 +61,10 @@ const MoleculeBadgeCounter = ({
   const classNameBullet = cx(
     CLASS_BULLET,
     CLASS_SIZE,
+    CLASS_STATUS,
     CLASS_VARIANT,
     CLASS_LENGTH_LABEL,
     {
-      [CLASS_CUSTOM]: custom,
       [CLASS_WITH_CHILDREN]: Boolean(children)
     }
   )
@@ -78,6 +87,13 @@ const getClassSize = ({size, hasLabel}) => {
   return CLASS_SMALL
 }
 
+const getClassStatus = ({status}) => {
+  if (status === STATUS.DISABLED) return CLASS_DISABLED
+  if (status === STATUS.SELECTED) return CLASS_SELECTED
+
+  return ''
+}
+
 const getClassLengthLabel = ({hasLabel, label, size}) => {
   if (!hasLabel || (label + '').length < 3) return ''
 
@@ -91,14 +107,14 @@ MoleculeBadgeCounter.propTypes = {
   /** children */
   children: PropTypes.node,
 
-  /** Allows you to customize the background and text color */
-  custom: PropTypes.bool,
-
   /** Number to be displayed inside the bullet */
   label: PropTypes.number,
 
   /** Size (small, medium or large) */
   size: PropTypes.oneOf(Object.values(SIZES)),
+
+  /** Status (default, disabled or selected) */
+  status: PropTypes.oneOf(Object.values(STATUS)),
 
   /** Variant (dot or exclamation) */
   variant: PropTypes.oneOf(Object.values(VARIANTS))
@@ -107,5 +123,6 @@ MoleculeBadgeCounter.propTypes = {
 export default MoleculeBadgeCounter
 export {
   SIZES as moleculeBadgeCounterSizes,
+  STATUS as moleculeBadgeCounterStatus,
   VARIANTS as moleculeBadgeCounterVariants
 }

--- a/components/molecule/badgeCounter/src/index.scss
+++ b/components/molecule/badgeCounter/src/index.scss
@@ -10,10 +10,6 @@ $bdw-molecule-badge-counter: 0 !default;
 $c-molecule-badge-counter: $c-white !default;
 $fz-molecule-badge-counter: $fz-xxs !default;
 
-/* custom */
-$bgc-molecule-badge-counter-custom: $c-primary-light-3 !default;
-$c-molecule-badge-counter-custom: $c-primary !default;
-
 /* small */
 $molecule-badge-counter-small-diameter: 12px !default;
 $molecule-badge-counter-small-diameter-dot: 4px !default;
@@ -33,6 +29,14 @@ $molecule-badge-counter-large-offset-top: -12px !default;
 $molecule-badge-counter-large-offset-right: -22px !default;
 $fz-molecule-badge-counter-large: $fz-xs !default;
 
+/* disabled */
+$bgc-molecule-badge-counter-disabled: $c-gray-light-3 !default;
+$c-molecule-badge-counter-disabled: $c-gray !default;
+
+/* selected */
+$bgc-molecule-badge-counter-selected: $c-primary-light-3 !default;
+$c-molecule-badge-counter-selected: $c-primary !default;
+
 .sui-MoleculeBadgeCounter {
   display: inline-block;
   position: relative;
@@ -50,6 +54,16 @@ $fz-molecule-badge-counter-large: $fz-xs !default;
     font-size: $fz-molecule-badge-counter;
     justify-content: center;
 
+    &.is-disabled {
+      background-color: $bgc-molecule-badge-counter-disabled;
+      color: $c-molecule-badge-counter-disabled;
+    }
+  
+    &.is-selected {
+      background-color: $bgc-molecule-badge-counter-selected;
+      color: $c-molecule-badge-counter-selected;
+    }
+
     &-dot {
       background-color: $c-white;
       border-style: solid;
@@ -60,11 +74,6 @@ $fz-molecule-badge-counter-large: $fz-xs !default;
       &::after {
         content: '!';
       }
-    }
-
-    &-custom {
-      background-color: $bgc-molecule-badge-counter-custom;
-      color: $c-molecule-badge-counter-custom;
     }
 
     &-small {

--- a/demo/molecule/badgeCounter/playground
+++ b/demo/molecule/badgeCounter/playground
@@ -23,6 +23,12 @@ return (
       <MoleculeBadgeCounter>Text</MoleculeBadgeCounter>
     </p>
     <p>
+      <MoleculeBadgeCounter status={moleculeBadgeCounterStatus.DISABLED} />
+    </p>
+    <p>
+      <MoleculeBadgeCounter status={moleculeBadgeCounterStatus.SELECTED} />
+    </p>
+    <p>
       <MoleculeBadgeCounter>
         <Icon />
       </MoleculeBadgeCounter>
@@ -52,6 +58,12 @@ return (
     </p>
     <p>
       <MoleculeBadgeCounter label="142" />
+    </p>
+    <p>
+      Disabled: <MoleculeBadgeCounter size={moleculeBadgeCounterSizes.MEDIUM} status={moleculeBadgeCounterStatus.DISABLED} label="50" />
+    </p>
+    <p>
+      Selected: <MoleculeBadgeCounter size={moleculeBadgeCounterSizes.MEDIUM} status={moleculeBadgeCounterStatus.SELECTED} label="50" />
     </p>
     <p>
       <MoleculeBadgeCounter size={moleculeBadgeCounterSizes.MEDIUM}>
@@ -90,7 +102,10 @@ return (
       <MoleculeBadgeCounter size={moleculeBadgeCounterSizes.LARGE} label="142" />
     </p>
     <p>
-      <MoleculeBadgeCounter size={moleculeBadgeCounterSizes.LARGE} custom label="50" />
+      Disabled: <MoleculeBadgeCounter size={moleculeBadgeCounterSizes.LARGE} status={moleculeBadgeCounterStatus.DISABLED} label="50" />
+    </p>
+    <p>
+      Selected: <MoleculeBadgeCounter size={moleculeBadgeCounterSizes.LARGE} status={moleculeBadgeCounterStatus.SELECTED} label="50" />
     </p>
     <p>
       <MoleculeBadgeCounter size={moleculeBadgeCounterSizes.LARGE}>


### PR DESCRIPTION
## [Molecule]/[BadgeCounter]
**TASK**: <!--- [SCMI-47974](https://jira.scmspain.com/browse/SCMI-47974) -->
⏮️ Past PR: https://github.com/SUI-Components/sui-components/pull/1257

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description, Motivation and Context

After last Pull Request, `custom` prop doesn't solve the problem, because we need a `disabled` and `selected` status.

### Screenshots - Animations

![image](https://user-images.githubusercontent.com/13108014/96463548-1d53fc80-1227-11eb-8fb6-ece229e2e7ce.png)

