### PR TITLE
chore(META): avoid repeated dependency that should be a peerDependency

### DIFF
--- a/components/atom/actionButton/package.json
+++ b/components/atom/actionButton/package.json
@@ -9,8 +9,10 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/react-atom-icon": "1"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/atom/backToTop/package.json
+++ b/components/atom/backToTop/package.json
@@ -9,8 +9,10 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/js": "2"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/atom/icon/package.json
+++ b/components/atom/icon/package.json
@@ -9,8 +9,10 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/react-hooks": "1"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/atom/input/package.json
+++ b/components/atom/input/package.json
@@ -9,8 +9,10 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "imask": "3.4.0"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/atom/popover/package.json
+++ b/components/atom/popover/package.json
@@ -9,10 +9,12 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/hoc": "1",
     "@s-ui/react-hooks": "1",
     "reactstrap": "7.1.0"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/atom/slider/package.json
+++ b/components/atom/slider/package.json
@@ -9,8 +9,10 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "rc-slider": "8"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/atom/switch/package.json
+++ b/components/atom/switch/package.json
@@ -9,8 +9,10 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/react-atom-label": "1"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/atom/textarea/package.json
+++ b/components/atom/textarea/package.json
@@ -9,8 +9,10 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/react-atom-help-text": "1"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/atom/tooltip/package.json
+++ b/components/atom/tooltip/package.json
@@ -9,9 +9,11 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/hoc": "1",
     "reactstrap": "7.1.0"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/atom/upload/package.json
+++ b/components/atom/upload/package.json
@@ -9,9 +9,11 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/react-atom-button": "1",
     "react-dropzone": "5.1.1"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/behavior/sticky/package.json
+++ b/components/behavior/sticky/package.json
@@ -9,8 +9,10 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "react-stickup": "1.7.2"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/molecule/autosuggest/package.json
+++ b/components/molecule/autosuggest/package.json
@@ -9,12 +9,14 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/hoc": "1",
     "@s-ui/js": "2",
     "@s-ui/react-atom-input": "4",
     "@s-ui/react-molecule-dropdown-list": "1",
     "@s-ui/react-molecule-input-tags": "2"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/molecule/autosuggestField/package.json
+++ b/components/molecule/autosuggestField/package.json
@@ -9,9 +9,11 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/react-molecule-autosuggest": "2",
     "@s-ui/react-molecule-field": "1"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/molecule/avatar/package.json
+++ b/components/molecule/avatar/package.json
@@ -9,9 +9,11 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/react-atom-image": "2",
     "@s-ui/react-atom-skeleton": "1"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/molecule/buttonGroupField/package.json
+++ b/components/molecule/buttonGroupField/package.json
@@ -9,9 +9,11 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/react-molecule-button-group": "2",
     "@s-ui/react-molecule-field": "1"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/molecule/checkboxField/package.json
+++ b/components/molecule/checkboxField/package.json
@@ -9,9 +9,11 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/react-atom-checkbox": "2",
     "@s-ui/react-molecule-field": "1"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/molecule/dataCounter/package.json
+++ b/components/molecule/dataCounter/package.json
@@ -9,11 +9,13 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/hoc": "1",
     "@s-ui/react-atom-input": "3",
     "@s-ui/react-molecule-field": "1",
     "@s-ui/react-atom-button": "1"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/molecule/dropdownList/package.json
+++ b/components/molecule/dropdownList/package.json
@@ -9,8 +9,10 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/react-atom-input": "4"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/molecule/dropdownOption/package.json
+++ b/components/molecule/dropdownOption/package.json
@@ -9,9 +9,11 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/js": "2",
     "@s-ui/react-atom-checkbox": "2"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/molecule/field/package.json
+++ b/components/molecule/field/package.json
@@ -9,10 +9,12 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/react-atom-help-text": "1",
     "@s-ui/react-atom-label": "1",
     "@s-ui/react-atom-validation-text": "1"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/molecule/inputField/package.json
+++ b/components/molecule/inputField/package.json
@@ -9,9 +9,11 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/react-atom-input": "4",
     "@s-ui/react-molecule-field": "1"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/molecule/inputTags/package.json
+++ b/components/molecule/inputTags/package.json
@@ -9,9 +9,11 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/react-atom-input": "4",
     "@s-ui/react-atom-tag": "2"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/molecule/notification/package.json
+++ b/components/molecule/notification/package.json
@@ -9,9 +9,11 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/react-atom-button": "1",
     "@s-ui/react-icons": "1"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/molecule/pagination/package.json
+++ b/components/molecule/pagination/package.json
@@ -9,9 +9,11 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/react-molecule-button-group": "2",
     "@s-ui/react-atom-button": "1"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/molecule/photoUploader/package.json
+++ b/components/molecule/photoUploader/package.json
@@ -9,7 +9,6 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "react-dropzone": "10.2.1",
     "react-sortablejs": "2.0.11",
     "@s-ui/react-hooks": "1",
@@ -17,6 +16,9 @@
     "@s-ui/react-atom-button": "1",
     "@s-ui/react-atom-icon": "1",
     "@s-ui/react-molecule-notification": "1"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/molecule/radioButtonField/package.json
+++ b/components/molecule/radioButtonField/package.json
@@ -9,9 +9,11 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/react-molecule-field": "1",
     "@s-ui/react-atom-radio-button": "1"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/molecule/select/package.json
+++ b/components/molecule/select/package.json
@@ -9,12 +9,14 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/js": "2",
     "@s-ui/hoc": "1",
     "@s-ui/react-atom-input": "4",
     "@s-ui/react-molecule-input-tags": "2",
     "@s-ui/react-molecule-dropdown-list": "1"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/molecule/selectField/package.json
+++ b/components/molecule/selectField/package.json
@@ -9,9 +9,11 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/react-molecule-select": "1",
     "@s-ui/react-molecule-field": "1"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/molecule/selectPopover/package.json
+++ b/components/molecule/selectPopover/package.json
@@ -9,8 +9,10 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/react-atom-button": "1"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/molecule/textareaField/package.json
+++ b/components/molecule/textareaField/package.json
@@ -9,9 +9,11 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/react-molecule-field": "1",
     "@s-ui/react-atom-textarea": "2"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/molecule/thumbnail/package.json
+++ b/components/molecule/thumbnail/package.json
@@ -9,8 +9,10 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/react-atom-image": "2"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/organism/nestedCheckboxes/package.json
+++ b/components/organism/nestedCheckboxes/package.json
@@ -9,8 +9,10 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1",
     "@s-ui/react-molecule-checkbox-field": "2"
+  },
+  "peerDependencies": {
+    "@s-ui/component-dependencies": "1"
   },
   "keywords": [],
   "author": "",

--- a/demo/package.json
+++ b/demo/package.json
@@ -8,5 +8,8 @@
       "packagesFolder": ".",
       "deepLevel": 3
     }
+  },
+  "dependencies": {
+    "undefined": "^0.1.0"
   }
 }


### PR DESCRIPTION
`@s-ui/component-dependencies` package is a peerDependency as we expected apps to use @s-ui/theme and the rest of dependencies instead having to be installed for each package.