### PR TITLE
fix(molecule/photoUploader): install fixed version of file-selector to avoid breaking builds

### DIFF
--- a/components/molecule/photoUploader/package.json
+++ b/components/molecule/photoUploader/package.json
@@ -8,7 +8,9 @@
     "build:js": "../../../node_modules/.bin/babel --presets sui ./src --out-dir ./lib",
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
+  "@//COMMENT": "file-selector dependency is installed and fixed to 0.1.13 in order to avoid problems with https://github.com/react-dropzone/file-selector/issues/37.",
   "dependencies": {
+    "file-selector": "0.1.13",
     "react-dropzone": "10.2.1",
     "react-sortablejs": "2.0.11",
     "@s-ui/react-hooks": "1",


### PR DESCRIPTION
Fix file-selector version to avoid problems with builds.