### PR TITLE
feat(atom/input): remove browser  native arrows appearance in input t…

### DIFF
--- a/components/atom/input/src/Input/Component/index.scss
+++ b/components/atom/input/src/Input/Component/index.scss
@@ -66,4 +66,14 @@ $class-read-only: '#{$base-class}--readOnly';
       border-color: $color;
     }
   }
+
+  &[type='number'] {
+    -moz-appearance: textfield;
+
+    &::-webkit-outer-spin-button,
+    &::-webkit-inner-spin-button {
+      appearance: none;
+      margin: 0;
+    }
+  }
 }


### PR DESCRIPTION
ISSUES CLOSED: #1274

## ATOM/INPUT
**TASK**: [SUIC-193](https://jira.scmspain.com/browse/)


### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description, Motivation and Context

The default behavior/styles of inputs, depends of your type, these changes hide native browser arrows in input type `number'.

### Screenshots

|       | **Chrome** | **Firefox** |
|--------|--------|---------|
| **⚠️ Before** | ![image](https://user-images.githubusercontent.com/1427623/97220528-e607c180-17cb-11eb-95dc-dc55963ea951.png) | ![image](https://user-images.githubusercontent.com/1427623/97220563-f455dd80-17cb-11eb-93a9-d1124b06277d.png) |
| **✅ After**  | ![image](https://user-images.githubusercontent.com/1427623/97220778-4c8cdf80-17cc-11eb-8abe-a021983823e0.png) | ![image](https://user-images.githubusercontent.com/1427623/97220751-40088700-17cc-11eb-9e5b-7988a687f63e.png) |


<!-- Adding images or gif animations of your changes improves the understanding of your changes -->