### PR TITLE
feat(atom/badge): add NEUTRAL type

### DIFF
--- a/components/atom/badge/src/index.js
+++ b/components/atom/badge/src/index.js
@@ -16,6 +16,7 @@ const TYPES = {
   INFO: 'info',
   ALERT: 'alert',
   NEW: 'new',
+  NEUTRAL: 'neutral',
   PRIMARY: 'primary'
 }
 

--- a/components/atom/badge/src/index.scss
+++ b/components/atom/badge/src/index.scss
@@ -33,6 +33,10 @@ $badges: (
     bgc: $c-accent,
     c: $c-white
   ),
+  neutral: (
+    bgc: $c-white,
+    c: $c-gray-dark-3
+  ),
   primary: (
     bgc: $c-primary,
     c: $c-white
@@ -45,6 +49,7 @@ $badge-transparent: (
   alert: $c-alert,
   info: $c-gray,
   new: $c-accent,
+  neutral: $c-white,
   primary: $c-primary
 ) !default;
 

--- a/components/atom/badge/src/index.scss
+++ b/components/atom/badge/src/index.scss
@@ -49,7 +49,7 @@ $badge-transparent: (
   alert: $c-alert,
   info: $c-gray,
   new: $c-accent,
-  neutral: $c-white,
+  neutral: $c-gray-dark-3,
   primary: $c-primary
 ) !default;
 

--- a/demo/atom/badge/playground
+++ b/demo/atom/badge/playground
@@ -28,6 +28,7 @@ return (
         <AtomBadge label='info' type={atomBadgeTypes.INFO} transparent/>
         <AtomBadge label='alert' type={atomBadgeTypes.ALERT} transparent/>
         <AtomBadge label='new' type={atomBadgeTypes.NEW} transparent/>
+        <AtomBadge label='neutral' type={atomBadgeTypes.NEUTRAL} transparent/>
         <AtomBadge label='primary' type={atomBadgeTypes.PRIMARY} transparent/>
       </div>
     </div>
@@ -113,6 +114,7 @@ return (
         <AtomBadge label='info' type={atomBadgeTypes.INFO}/>
         <AtomBadge label='alert' type={atomBadgeTypes.ALERT}/>
         <AtomBadge label='new' type={atomBadgeTypes.NEW}/>
+        <AtomBadge label='neutral' type={atomBadgeTypes.NEUTRAL}/>
         <AtomBadge label='primary' type={atomBadgeTypes.PRIMARY}/>
       </div>
       <p className="sui-Studio-p">___</p>
@@ -122,6 +124,7 @@ return (
         <AtomBadge label='info' type={atomBadgeTypes.INFO} transparent/>
         <AtomBadge label='alert' type={atomBadgeTypes.ALERT} transparent/>
         <AtomBadge label='new' type={atomBadgeTypes.NEW} transparent/>
+        <AtomBadge label='neutral' type={atomBadgeTypes.NEUTRAL} transparent/>
         <AtomBadge label='primary' type={atomBadgeTypes.PRIMARY} transparent/>
       </div>
     </div>

--- a/demo/atom/badge/playground
+++ b/demo/atom/badge/playground
@@ -17,6 +17,7 @@ return (
         <AtomBadge label='info' type={atomBadgeTypes.INFO}/>
         <AtomBadge label='alert' type={atomBadgeTypes.ALERT}/>
         <AtomBadge label='new' type={atomBadgeTypes.NEW}/>
+        <AtomBadge label='neutral' type={atomBadgeTypes.NEUTRAL}/>
         <AtomBadge label='primary' type={atomBadgeTypes.PRIMARY}/>
       </div>
       <p className="sui-Studio-p">___</p>


### PR DESCRIPTION
## ATOM/BADGE
**TASK**: <!--- [jira TASK ID](jiraURL) -->

[SCMI-49320](https://jira.scmspain.com/browse/SCMI-49320)
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

Due to the need, from UX to RE, a new type of Badge has been added, called Neutral. `bgc: $c-white` y `c: $c-gray-dark-3 `
### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
