### PR TITLE
feat(molecule/field): accept element in successText, errorText, alert…

### DIFF
--- a/components/molecule/field/src/index.js
+++ b/components/molecule/field/src/index.js
@@ -162,16 +162,16 @@ MoleculeField.propTypes = {
   name: PropTypes.string.isRequired,
 
   /** Success message to display when success state  */
-  successText: PropTypes.oneOfType([PropTypes.bool, PropTypes.element]),
+  successText: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
 
   /** Error message to display when error state  */
-  errorText: PropTypes.oneOfType([PropTypes.bool, PropTypes.element]),
+  errorText: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
 
   /** Error message to display when alert state  */
-  alertText: PropTypes.oneOfType([PropTypes.bool, PropTypes.element]),
+  alertText: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
 
   /** Help Text to display */
-  helpText: PropTypes.oneOfType([PropTypes.bool, PropTypes.element]),
+  helpText: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
 
   /** Boolean to decide if elements should be set inline */
   inline: PropTypes.bool,

--- a/components/molecule/field/src/index.js
+++ b/components/molecule/field/src/index.js
@@ -162,32 +162,16 @@ MoleculeField.propTypes = {
   name: PropTypes.string.isRequired,
 
   /** Success message to display when success state  */
-  successText: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.boo,
-    PropTypes.elementl
-  ]),
+  successText: PropTypes.oneOfType([PropTypes.boo, PropTypes.element]),
 
   /** Error message to display when error state  */
-  errorText: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.bool,
-    PropTypes.element
-  ]),
+  errorText: PropTypes.oneOfType([PropTypes.bool, PropTypes.element]),
 
   /** Error message to display when alert state  */
-  alertText: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.bool,
-    PropTypes.element
-  ]),
+  alertText: PropTypes.oneOfType([PropTypes.bool, PropTypes.element]),
 
   /** Help Text to display */
-  helpText: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.bool,
-    PropTypes.element
-  ]),
+  helpText: PropTypes.oneOfType([PropTypes.bool, PropTypes.element]),
 
   /** Boolean to decide if elements should be set inline */
   inline: PropTypes.bool,

--- a/components/molecule/field/src/index.js
+++ b/components/molecule/field/src/index.js
@@ -162,16 +162,32 @@ MoleculeField.propTypes = {
   name: PropTypes.string.isRequired,
 
   /** Success message to display when success state  */
-  successText: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  successText: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.boo,
+    PropTypes.elementl
+  ]),
 
   /** Error message to display when error state  */
-  errorText: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  errorText: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.bool,
+    PropTypes.element
+  ]),
 
   /** Error message to display when alert state  */
-  alertText: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  alertText: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.bool,
+    PropTypes.element
+  ]),
 
   /** Help Text to display */
-  helpText: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  helpText: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.bool,
+    PropTypes.element
+  ]),
 
   /** Boolean to decide if elements should be set inline */
   inline: PropTypes.bool,

--- a/components/molecule/field/src/index.js
+++ b/components/molecule/field/src/index.js
@@ -162,7 +162,7 @@ MoleculeField.propTypes = {
   name: PropTypes.string.isRequired,
 
   /** Success message to display when success state  */
-  successText: PropTypes.oneOfType([PropTypes.boo, PropTypes.element]),
+  successText: PropTypes.oneOfType([PropTypes.bool, PropTypes.element]),
 
   /** Error message to display when error state  */
   errorText: PropTypes.oneOfType([PropTypes.bool, PropTypes.element]),


### PR DESCRIPTION
## [molecule]/[field]
**TASK**: <!--- [jira TASK ID](jiraURL) --> 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description, Motivation and Context
<!--- Describe your changes in detail -->
#### Changes:
feat(molecule/field): accept `element` as type in the following props: successText, errorText, alertText and helpText.

<!--- Why is this change required? What problem does it solve? -->
#### Motivation
Until now the props successText, errorText, alertText and helpText in the molecule/field component could only render plain text.
With this change successText, errorText, alertText and helpText can render anything 🙌🏽

So we can do things like adding a text that when clicked opens a modal.
![image](https://user-images.githubusercontent.com/32937662/97673087-77f12200-1a8b-11eb-950d-f0f6e282e023.png)

When clicking help text should open a modal: 

![image](https://user-images.githubusercontent.com/32937662/97675530-c56f8e00-1a8f-11eb-8611-4214bf187fb1.png)

<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
