### PR TITLE
fix(atom/table): remove Optional Chaining to generate the API documentation

### DIFF
--- a/components/atom/table/src/index.js
+++ b/components/atom/table/src/index.js
@@ -16,17 +16,17 @@ const CELL_PADDING = {
 }
 
 const AtomTable = ({
-  head,
+  head = [],
   body,
-  foot,
+  foot = [],
   fullWidth,
   cellPadding,
   borderBottom,
   onRowClick,
   zebraStriped
 }) => {
-  const hasHead = Boolean(head?.length)
-  const hasFoot = Boolean(foot?.length)
+  const hasHead = Boolean(head.length)
+  const hasFoot = Boolean(foot.length)
   const isRowActionable = Boolean(onRowClick)
   const baseClass = 'react-AtomTable'
   const tableClass = cx(`${baseClass}`, {


### PR DESCRIPTION

## atom/table

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description, Motivation and Context

We can't see the API documentation for the **AtomTable** component because `react-docgen` doesn't support Optional Chaining. The solution is ad a default value to `head` and `foot` props.

