### PR TITLE
feat(atom/textarea): rename sass variables to follow naming convention

### DIFF
--- a/components/atom/textarea/src/index.scss
+++ b/components/atom/textarea/src/index.scss
@@ -3,6 +3,8 @@
 
 $short-num-lines: 5 !default;
 $long-num-lines: 7 !default;
+$short-num-lines-atom-textarea: $short-num-lines !default;
+$long-num-lines-atom-textarea: $long-num-lines !default;
 
 $p-atom-textarea: 2px !default;
 $pm-atom-textarea: $p-m !default; // deprecated
@@ -55,13 +57,13 @@ $base-class: '.sui-AtomTextarea';
 
   &--short {
     height: calc(
-      (#{$lh-atom-textarea} * #{$short-num-lines}) + #{$pt-atom-textarea}
+      (#{$lh-atom-textarea} * #{$short-num-lines-atom-textarea}) + #{$pt-atom-textarea}
     );
   }
 
   &--long {
     height: calc(
-      (#{$lh-atom-textarea} * #{$long-num-lines}) + #{$pt-atom-textarea}
+      (#{$lh-atom-textarea} * #{$long-num-lines-atom-textarea}) + #{$pt-atom-textarea}
     );
   }
 


### PR DESCRIPTION
## atom/textarea
**TASK**: N/A

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description, Motivation and Context
Technically not a bug, I'm just introducing two new sass variables to replace two existing ones in a backwards compatible way.
$short-num-lines and $long-num-lines were not referring to `atom/textarea` component so with this change, I'm following our sass variables naming convention also here.

### Screenshots - Animations
N/A