### PR TITLE
Feat/add atom tag outline version

### DIFF
--- a/components/atom/tag/README.md
+++ b/components/atom/tag/README.md
@@ -73,7 +73,7 @@ Actionable tags can be used as an anchor. Same as `<a>` to define an interactivi
 ```js
 <AtomTag
   label="Navigation Tag"
-  onClick={() => window.alert('click!')}
+  onClick={() => alert('click!')}
 />
 
 <AtomTag

--- a/components/atom/tag/README.md
+++ b/components/atom/tag/README.md
@@ -2,7 +2,7 @@
 
 > Atom Element: SUI Tag
 
-![](./assets/screenshot.png)
+We use tags to visually emphasise features of the UI and make recognition and interaction easier.
 
 ## Installation
 
@@ -25,7 +25,83 @@ import AtomTag from '@s-ui/react-atom-tag'
 />
 ```
 
+### Size
+
+Tags structure can have 3 main sizes: Small, medium (default) and large. You can use this prop size to modify it.
+
+`small | medium (default) | large`
+
+```js
+<AtomTag
+  label="Structure Tag"
+  size="small"
+/>
+
+<AtomTag
+  label="Structure Tag"
+  size="medium"
+/>
+
+<AtomTag
+  label="Structure Tag"
+  size="large"
+/>
+```
+
+### Design
+
+Tags structure can have 2 designs: Solid (default) and outline. You can use this prop design to modify it.
+
+`solid (default) | outline`
+
+```js
+<AtomTag
+  label="Structure Tag"
+  design="solid"
+/>
+
+<AtomTag
+  label="Structure Tag"
+  design="outline"
+/>
+```
+
+### Actionable
+
+Actionable tags can be used as an anchor. Same as `<a>` to define an interactivity with the component.
+
+```js
+<AtomTag
+  label="Navigation Tag"
+  onClick={() => window.alert('click!')}
+/>
+
+<AtomTag
+  href="https://sui-components.now.sh/"
+  label="Anchor Tag"
+  target="_blank"
+/>
+```
+
+### Icons
+
+Tags can include an action icon (generally a close icon). This icon will always be located to the right of content. You can add use the icon and closeIcon to added a icon.
+
+```js
+<AtomTag label="Tag Structure Tag" icon={<Icon />} />
+```
+
+### Responsive
+
+Use the responsive true for make responsive layout. keep large size in mobile.
+
+```js
+<AtomTag label="Tag Structure" responsive />
+```
+
 ### Tag types
+
+Use the type in order to color it as desired from a high order component.
 
 If you want to customize your tag you can pass a prop to identify this type and you also need to set your custom set of types in Sass:
 
@@ -33,11 +109,11 @@ If you want to customize your tag you can pass a prop to identify this type and 
 
 ```css
 $atom-tag-types: (
-  "alert": (
+  'alert': (
     bgc: red,
     c: white
   ),
-  "warning": (
+  'warning': (
     bgc: orange,
     c: white
   )

--- a/components/atom/tag/README.md
+++ b/components/atom/tag/README.md
@@ -15,9 +15,7 @@ npm install @s-ui/react-atom-tag --save
 ```js
 import AtomTag from '@s-ui/react-atom-tag'
 
-<AtomTag
-  label='Tag Structure'
-/>
+<AtomTag label='Tag Structure' />
 ```
 
 ### Size

--- a/components/atom/tag/README.md
+++ b/components/atom/tag/README.md
@@ -18,11 +18,6 @@ import AtomTag from '@s-ui/react-atom-tag'
 <AtomTag
   label='Tag Structure'
 />
-
-<AtomTag
-  label='Navigation Tag'
-  onClick={() => alert('click!')}
-/>
 ```
 
 ### Size
@@ -109,11 +104,11 @@ If you want to customize your tag you can pass a prop to identify this type and 
 
 ```css
 $atom-tag-types: (
-  'alert': (
+  "alert": (
     bgc: red,
     c: white
   ),
-  'warning': (
+  "warning": (
     bgc: orange,
     c: white
   )

--- a/components/atom/tag/src/_settings.scss
+++ b/components/atom/tag/src/_settings.scss
@@ -1,0 +1,37 @@
+$bd-atom-tag: none !default;
+$bgc-atom-tag: color-variation($c-gray, 3) !default;
+$mw-label: 240px !default;
+
+// sizes
+$h-atom-tag-l: 40px !default;
+$h-atom-tag-m: 32px !default;
+$h-atom-tag-s: 24px !default;
+$m-atom-tag: $m-m !default;
+$p-atom-tag-l: 0 $p-l !default;
+$p-atom-tag-m: 0 $p-l !default;
+$p-atom-tag-s: 0 $p-m !default;
+
+// outline
+$bc-atom-tag-outline: color-variation($c-gray, 3) !default;
+$bdw-atom-tag-outline: $bdw-s !default;
+$bgc-atom-tag-outline: $c-white !default;
+
+// actionable
+$bgc-atom-tag-actionable: $c-primary !default;
+$bgc-atom-tag-actionable--hover: $c-primary-dark !default;
+$c-atom-tag-actionable: $c-white !default;
+$bd-atom-tag-actionable: none !default;
+$bgc-atom-tag-actionable-invert: $c-white !default;
+$bgc-atom-tag-actionable-invert--hover: $c-primary !default;
+$c-atom-tag-actionable-invert: $c-primary !default;
+$c-atom-tag-actionable-invert--hover: $c-white !default;
+
+// clickable
+$w-atom-tag-clickable: 32px !default;
+
+// closable
+$bgc-atom-tag-closable-icon--hover: $c-system !default;
+$c-atom-tag-closable-icon--hover: $c-gray !default;
+
+// types
+$atom-tag-types: () !default;

--- a/components/atom/tag/src/index.js
+++ b/components/atom/tag/src/index.js
@@ -12,12 +12,15 @@ const ACTIONABLE_ONLY_PROPS = [
   'linkFactory',
   'rel'
 ]
+
 const STANDARD_ONLY_PROPS = ['closeIcon', 'onClose']
+
 const SIZES = {
   LARGE: 'large',
   MEDIUM: 'medium',
   SMALL: 'small'
 }
+
 const LINK_TYPES = {
   NOFOLLOW: 'nofollow',
   NOOPENER: 'noopener',
@@ -26,6 +29,12 @@ const LINK_TYPES = {
   NEXT: 'next',
   TAG: 'tag'
 }
+
+export const DESIGNS = {
+  SOLID: 'solid',
+  OUTLINE: 'outline'
+}
+
 /**
  * returns key:value in obj except for those keys defined in props
  * @param {Object} obj
@@ -41,11 +50,20 @@ const filterKeys = (obj, listOfProps) =>
   }, {})
 
 const AtomTag = props => {
-  const {href, icon, onClick, size, responsive, type} = props
+  const {
+    design = DESIGNS.SOLID,
+    href,
+    icon,
+    onClick,
+    responsive,
+    size,
+    type
+  } = props
   const isActionable = onClick || href
   const classNames = cx(
     'sui-AtomTag',
     `sui-AtomTag-${size}`,
+    `sui-AtomTag--${design}`,
     type && `sui-AtomTag--${type}`,
     responsive && 'sui-AtomTag--responsive',
     icon && 'sui-AtomTag-hasIcon'
@@ -120,7 +138,11 @@ AtomTag.propTypes = {
   /**
    * true for make responsive layout. keep large size in mobile
    */
-  responsive: PropTypes.bool
+  responsive: PropTypes.bool,
+  /**
+   * Design style of button: 'solid' (default), 'outline', 'flat', 'link'
+   */
+  design: PropTypes.oneOf(Object.values(DESIGNS))
 }
 
 AtomTag.defaultProps = {
@@ -128,5 +150,6 @@ AtomTag.defaultProps = {
 }
 
 export default AtomTag
+export {DESIGNS as atomTagDesigns}
 export {SIZES as atomTagSizes}
 export {LINK_TYPES as linkTypes}

--- a/components/atom/tag/src/index.js
+++ b/components/atom/tag/src/index.js
@@ -50,23 +50,15 @@ const filterKeys = (obj, listOfProps) =>
   }, {})
 
 const AtomTag = props => {
-  const {
-    design = DESIGNS.SOLID,
-    href,
-    icon,
-    onClick,
-    responsive,
-    size,
-    type
-  } = props
+  const {design, href, icon, onClick, responsive, size, type} = props
   const isActionable = onClick || href
   const classNames = cx(
     'sui-AtomTag',
     `sui-AtomTag-${size}`,
-    `sui-AtomTag--${design}`,
-    type && `sui-AtomTag--${type}`,
+    design && `sui-AtomTag--${design}`,
+    icon && 'sui-AtomTag-hasIcon',
     responsive && 'sui-AtomTag--responsive',
-    icon && 'sui-AtomTag-hasIcon'
+    type && `sui-AtomTag--${type}`
   )
 
   /**
@@ -151,5 +143,5 @@ AtomTag.defaultProps = {
 
 export default AtomTag
 export {DESIGNS as atomTagDesigns}
-export {SIZES as atomTagSizes}
 export {LINK_TYPES as linkTypes}
+export {SIZES as atomTagSizes}

--- a/components/atom/tag/src/index.scss
+++ b/components/atom/tag/src/index.scss
@@ -1,31 +1,6 @@
 @import '~@s-ui/theme/lib/settings-compat-v7/index';
 @import '~@s-ui/theme/lib/index';
-
-$bd-atom-tag: none !default;
-$bgc-atom-tag: color-variation($c-gray, 3) !default;
-$bgc-atom-tag-actionable: $c-primary !default;
-$bgc-atom-tag-actionable--hover: $c-primary-dark !default;
-$c-atom-tag-actionable: $c-white !default;
-$bd-atom-tag-actionable: none !default;
-$bgc-atom-tag-actionable-invert: $c-white !default;
-$bgc-atom-tag-actionable-invert--hover: $c-primary !default;
-$c-atom-tag-actionable-invert: $c-primary !default;
-$c-atom-tag-actionable-invert--hover: $c-white !default;
-$h-atom-tag-l: 40px !default;
-$h-atom-tag-m: 32px !default;
-$h-atom-tag-s: 24px !default;
-$m-atom-tag: $m-m !default;
-$mw-label: 240px !default;
-$p-atom-tag-l: 0 $p-l !default;
-$p-atom-tag-m: 0 $p-l !default;
-$p-atom-tag-s: 0 $p-m !default;
-$w-atom-tag-clickable: 32px !default;
-$atom-tag-types: () !default;
-$bgc-atom-tag-closable-icon--hover: $c-system !default;
-$c-atom-tag-closable-icon--hover: $c-gray !default;
-$bc-atom-tag-outline: color-variation($c-gray, 3) !default;
-$bdw-atom-tag-outline: $bdw-s !default;
-$bgc-atom-tag-outline: $c-white !default;
+@import './settings';
 
 @mixin icon-atom-tag($type) {
   @include sui-icon--small;

--- a/components/atom/tag/src/index.scss
+++ b/components/atom/tag/src/index.scss
@@ -7,6 +7,10 @@ $bgc-atom-tag-actionable: $c-primary !default;
 $bgc-atom-tag-actionable--hover: $c-primary-dark !default;
 $c-atom-tag-actionable: $c-white !default;
 $bd-atom-tag-actionable: none !default;
+$bgc-atom-tag-actionable-invert: $c-white !default;
+$bgc-atom-tag-actionable-invert--hover: $c-primary !default;
+$c-atom-tag-actionable-invert: $c-primary !default;
+$c-atom-tag-actionable-invert--hover: $c-white !default;
 $h-atom-tag-l: 40px !default;
 $h-atom-tag-m: 32px !default;
 $h-atom-tag-s: 24px !default;
@@ -19,6 +23,9 @@ $w-atom-tag-clickable: 32px !default;
 $atom-tag-types: () !default;
 $bgc-atom-tag-closable-icon--hover: $c-system !default;
 $c-atom-tag-closable-icon--hover: $c-gray !default;
+$bc-atom-tag-outline: color-variation($c-gray, 3) !default;
+$bdw-atom-tag-outline: $bdw-s !default;
+$bgc-atom-tag-outline: $c-white !default;
 
 @mixin icon-atom-tag($type) {
   @include sui-icon--small;
@@ -45,6 +52,7 @@ $c-atom-tag-closable-icon--hover: $c-gray !default;
 }
 
 .sui-AtomTag {
+  $self: &;
   background-color: $bgc-atom-tag;
   border: $bd-atom-tag;
   border-radius: ceil($h-atom-tag-m / 2);
@@ -118,6 +126,19 @@ $c-atom-tag-closable-icon--hover: $c-gray !default;
       cursor: pointer;
       fill: $c-atom-tag-actionable;
     }
+
+    &#{$self}--outline {
+      border-color: $c-atom-tag-actionable-invert;
+      color: $c-atom-tag-actionable-invert;
+      fill: $c-atom-tag-actionable-invert;
+
+      &:hover,
+      &:active {
+        background-color: $bgc-atom-tag-actionable-invert--hover;
+        color: $c-atom-tag-actionable-invert--hover;
+        fill: $c-atom-tag-actionable-invert--hover;
+      }
+    }
   }
 
   &-small {
@@ -169,6 +190,11 @@ $c-atom-tag-closable-icon--hover: $c-gray !default;
         @include icon-secondary-clickable-area($h-atom-tag-l);
       }
     }
+  }
+
+  &--outline {
+    background-color: $bgc-atom-tag-outline;
+    border: $bdw-atom-tag-outline solid $bc-atom-tag-outline;
   }
 
   @each $name, $type in $atom-tag-types {

--- a/demo/atom/tag/demo/index.js
+++ b/demo/atom/tag/demo/index.js
@@ -1,5 +1,8 @@
 import React from 'react'
-import AtomTag, {atomTagSizes} from '../../../../components/atom/tag/src'
+import AtomTag, {
+  atomTagDesigns,
+  atomTagSizes
+} from '../../../../components/atom/tag/src'
 import {CloseIcon, Icon} from './icons'
 
 export default () => (
@@ -23,6 +26,11 @@ export default () => (
             <td>
               <AtomTag label="Tag Structure" size={atomTagSizes.SMALL} />
               <AtomTag
+                design={atomTagDesigns.OUTLINE}
+                label="Tag Outline"
+                size={atomTagSizes.SMALL}
+              />
+              <AtomTag
                 closeIcon={<CloseIcon />}
                 label="Close Tag"
                 size={atomTagSizes.SMALL}
@@ -31,7 +39,7 @@ export default () => (
                 icon={<Icon />}
                 label="Icon Tag"
                 size={atomTagSizes.SMALL}
-              />{' '}
+              />
               <AtomTag
                 closeIcon={<CloseIcon />}
                 icon={<Icon />}
@@ -45,6 +53,11 @@ export default () => (
             <td>
               <AtomTag label="Tag Structure" size={atomTagSizes.MEDIUM} />
               <AtomTag
+                design={atomTagDesigns.OUTLINE}
+                label="Tag Outline"
+                size={atomTagSizes.MEDIUM}
+              />
+              <AtomTag
                 closeIcon={<CloseIcon />}
                 label="Close Tag"
                 size={atomTagSizes.MEDIUM}
@@ -53,7 +66,7 @@ export default () => (
                 icon={<Icon />}
                 label="Icon Tag"
                 size={atomTagSizes.MEDIUM}
-              />{' '}
+              />
               <AtomTag
                 closeIcon={<CloseIcon />}
                 icon={<Icon />}
@@ -67,6 +80,11 @@ export default () => (
             <td>
               <AtomTag label="Tag Structure" size={atomTagSizes.LARGE} />
               <AtomTag
+                design={atomTagDesigns.OUTLINE}
+                label="Tag Outline"
+                size={atomTagSizes.LARGE}
+              />
+              <AtomTag
                 closeIcon={<CloseIcon />}
                 label="Close Tag"
                 size={atomTagSizes.LARGE}
@@ -75,7 +93,7 @@ export default () => (
                 icon={<Icon />}
                 label="Icon Tag"
                 size={atomTagSizes.LARGE}
-              />{' '}
+              />
               <AtomTag
                 closeIcon={<CloseIcon />}
                 icon={<Icon />}
@@ -87,16 +105,65 @@ export default () => (
         </table>
       </div>
       <div className="sui-Studio-wrapper--light">
-        <h2 className="sui-Studio-h2">Types</h2>
+        <h2 className="sui-Studio-h2">Design</h2>
         <p className="sui-Studio-p">
-          Use the <code className="sui-Studio-code">type</code> in order to
-          color it as desired from a high order component.
+          Tags structure can have 2 designs: Solid <small>(default)</small> and
+          outline. You can use this prop{' '}
+          <code className="sui-Studio-code">design</code> to modify it.
         </p>
-        <div>
-          <AtomTag label="Sale" type="warning" />
-          <AtomTag label="Special" type="special" />
-          <AtomTag label="5 min ago" type="date" />
-        </div>
+        <table>
+          <tr>
+            <td className="sui-Studio-label">Solid</td>
+            <td>
+              <AtomTag label="Tag Structure" size={atomTagSizes.MEDIUM} />
+              <AtomTag
+                closeIcon={<CloseIcon />}
+                label="Close Tag"
+                size={atomTagSizes.MEDIUM}
+              />
+              <AtomTag
+                icon={<Icon />}
+                label="Icon Tag"
+                size={atomTagSizes.MEDIUM}
+              />
+              <AtomTag
+                closeIcon={<CloseIcon />}
+                icon={<Icon />}
+                label="Icon & Close Tag"
+                size={atomTagSizes.MEDIUM}
+              />
+            </td>
+          </tr>
+          <tr>
+            <td className="sui-Studio-label">Outline</td>
+            <td>
+              <AtomTag
+                design={atomTagDesigns.OUTLINE}
+                label="Tag Structure"
+                size={atomTagSizes.MEDIUM}
+              />
+              <AtomTag
+                closeIcon={<CloseIcon />}
+                design={atomTagDesigns.OUTLINE}
+                label="Close Tag"
+                size={atomTagSizes.MEDIUM}
+              />
+              <AtomTag
+                design={atomTagDesigns.OUTLINE}
+                icon={<Icon />}
+                label="Icon Tag"
+                size={atomTagSizes.MEDIUM}
+              />
+              <AtomTag
+                closeIcon={<CloseIcon />}
+                design={atomTagDesigns.OUTLINE}
+                icon={<Icon />}
+                label="Icon & Close Tag"
+                size={atomTagSizes.MEDIUM}
+              />
+            </td>
+          </tr>
+        </table>
       </div>
       <div className="sui-Studio-wrapper--light">
         <h2 className="sui-Studio-h2">Actionable</h2>
@@ -130,8 +197,40 @@ export default () => (
             target="_blank"
           />
         </div>
+        <p className="sui-Studio-p">___</p>
+        <p className="sui-Studio-p">
+          With <code className="sui-Studio-code">outline</code> design.
+        </p>
+        <div>
+          <AtomTag
+            design={atomTagDesigns.OUTLINE}
+            label="Navigation Tag"
+            onClick={() => window.alert('click!')}
+          />
+          <AtomTag
+            design={atomTagDesigns.OUTLINE}
+            href="https://sui-components.now.sh/"
+            label="Anchor Tag"
+            target="_blank"
+          />
+          <AtomTag
+            design={atomTagDesigns.OUTLINE}
+            href="https://sui-components.now.sh/"
+            icon={<Icon />}
+            iconPlacement="right"
+            label="Icon placement right"
+            target="_blank"
+          />
+          <AtomTag
+            design={atomTagDesigns.OUTLINE}
+            href="https://sui-components.now.sh/"
+            icon={<Icon />}
+            iconPlacement="left"
+            label="Icon placement left"
+            target="_blank"
+          />
+        </div>
       </div>
-
       <div className="sui-Studio-wrapper--light">
         <h2 className="sui-Studio-h2">Icons</h2>
         <p className="sui-Studio-p">
@@ -219,6 +318,18 @@ export default () => (
             responsive
             size={atomTagSizes.LARGE}
           />
+        </div>
+      </div>
+      <div className="sui-Studio-wrapper--light">
+        <h2 className="sui-Studio-h2">Types</h2>
+        <p className="sui-Studio-p">
+          Use the <code className="sui-Studio-code">type</code> in order to
+          color it as desired from a high order component.
+        </p>
+        <div>
+          <AtomTag label="Sale" type="warning" />
+          <AtomTag label="Special" type="special" />
+          <AtomTag label="5 min ago" type="date" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## ATOM/TAG

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description, Motivation and Context


We needed to have an `outline ` version for the component, just like the [button component](https://sui-components.now.sh/workbench/atom/button/demo) is being used. Now by default the atom tag component has its `outline ` version and the visual aspect is also modified when it receives the `actionable` prop.

###  API updated:

```
design: solid (default) | outline
```

**Use:**

```js
<AtomTag design="solid" />
```

```js
<AtomTag design="outline" />
```

For not to break version, the `solid` version is by default and does not modify any CSS class of the component. For the rest os value of `design` prop, added a modifier CSS class:

```css
.sui-AtomTag--outline { ... }
```


<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

**EXTRA:**
Additionally, generate up to date documentation and moved config SASS variables to another file for better code structure.

### Screenshots - Animations

#### Design
![image](https://user-images.githubusercontent.com/1427623/98686199-90551c80-2368-11eb-81cd-28594922b5db.png)

#### With actionable outline variation
![image](https://user-images.githubusercontent.com/1427623/98686248-9ea33880-2368-11eb-9ff6-7f23985914ed.png)

![image](https://user-images.githubusercontent.com/1427623/98686385-c98d8c80-2368-11eb-888d-5ce4a01ef651.png)

