### PR TITLE
feat(atom/progressBar): allow children to be displayed inside the com…

### DIFF
--- a/components/atom/progressBar/package.json
+++ b/components/atom/progressBar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/react-atom-progress-bar",
-  "version": "1.10.0",
+  "version": "2.0.0",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/components/atom/progressBar/package.json
+++ b/components/atom/progressBar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/react-atom-progress-bar",
-  "version": "2.0.0",
+  "version": "1.10.0",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/components/atom/progressBar/src/CircleProgressBar/_settings.scss
+++ b/components/atom/progressBar/src/CircleProgressBar/_settings.scss
@@ -1,9 +1,13 @@
 $w-atom-circle-progress-bar-circle-large: 48px !default;
 $h-atom-circle-progress-bar-circle-large: $w-atom-circle-progress-bar-circle-large !default;
+$w-atom-circle-progress-bar-circle-medium: 24px !default;
+$h-atom-circle-progress-bar-circle-medium: $w-atom-circle-progress-bar-circle-medium !default;
 $w-atom-circle-progress-bar-circle-small: 16px !default;
 $h-atom-circle-progress-bar-circle-small: $w-atom-circle-progress-bar-circle-small !default;
 $w-atom-circle-progress-bar-circle-large--error: 32px !default;
 $h-atom-circle-progress-bar-circle-large--error: $w-atom-circle-progress-bar-circle-large--error !default;
+$w-atom-circle-progress-bar-circle-medium--error: 22px !default;
+$h-atom-circle-progress-bar-circle-medium--error: $w-atom-circle-progress-bar-circle-medium !default;
 $w-atom-circle-progress-bar-circle-small--error: 12px !default;
 $h-atom-circle-progress-bar-circle-small--error: $w-atom-circle-progress-bar-circle-small !default;
 $c-atom-circle-progress-bar-trail: $c-gray-lightest !default;

--- a/components/atom/progressBar/src/CircleProgressBar/index.js
+++ b/components/atom/progressBar/src/CircleProgressBar/index.js
@@ -21,7 +21,7 @@ const SIZE_TO_WIDTH_LINE_MAP = {
   [SIZES.SMALL]: 8
 }
 
-const BASE_CLASS_NAME = 'sui-AtomCircleProgressBar'
+const BASE_CLASS_NAME = 'sui-AtomCircleProgressBarV2'
 const INDICATOR_CLASS_NAME = `${BASE_CLASS_NAME}-indicator`
 
 const Indicator = ({percentage, status, errorIcon, size, children}) => {

--- a/components/atom/progressBar/src/CircleProgressBar/index.js
+++ b/components/atom/progressBar/src/CircleProgressBar/index.js
@@ -5,6 +5,7 @@ import Circle from './Circle'
 
 const SIZES = {
   LARGE: 'large',
+  MEDIUM: 'medium',
   SMALL: 'small'
 }
 
@@ -16,30 +17,35 @@ const STATUS = {
 
 const SIZE_TO_WIDTH_LINE_MAP = {
   [SIZES.LARGE]: 4,
+  [SIZES.MEDIUM]: 8,
   [SIZES.SMALL]: 8
 }
 
 const BASE_CLASS_NAME = 'sui-AtomCircleProgressBar'
 const INDICATOR_CLASS_NAME = `${BASE_CLASS_NAME}-indicator`
 
-const Indicator = props => {
-  const {percentage, status, errorIcon, size} = props // eslint-disable-line react/prop-types
+const Indicator = ({percentage, status, errorIcon, size, children}) => {
   if (status === STATUS.LOADING) return null
   return (
     <span
-      className={cx(INDICATOR_CLASS_NAME, {
-        [`${INDICATOR_CLASS_NAME}--small`]: size === SIZES.SMALL,
-        [`${INDICATOR_CLASS_NAME}--inner`]:
-          size === SIZES.LARGE || status === STATUS.ERROR,
-        [`${INDICATOR_CLASS_NAME}--outer`]:
-          size === SIZES.SMALL && status !== STATUS.ERROR,
-        [`${INDICATOR_CLASS_NAME}--error`]: status === STATUS.ERROR
-      })}
+      className={cx(
+        INDICATOR_CLASS_NAME,
+        `${INDICATOR_CLASS_NAME}--${status}`,
+        `${INDICATOR_CLASS_NAME}--${size}`
+      )}
     >
-      {status === STATUS.PROGRESS && <span>{percentage}%</span>}
+      {status === STATUS.PROGRESS && (children || `${percentage}%`)}
       {status === STATUS.ERROR && errorIcon}
     </span>
   )
+}
+
+Indicator.propTypes = {
+  percentage: PropTypes.number.isRequired,
+  status: PropTypes.oneOf(Object.values(STATUS)),
+  errorIcon: PropTypes.node,
+  size: PropTypes.oneOf(Object.values(SIZES)),
+  children: PropTypes.node
 }
 
 const CircleProgressBar = ({
@@ -48,15 +54,18 @@ const CircleProgressBar = ({
   errorIcon,
   size,
   isAnimatedOnChange,
-  hideIndicator
+  hideIndicator,
+  children
 }) => {
   const circleWidth = SIZE_TO_WIDTH_LINE_MAP[size]
 
   return (
     <div
-      className={cx(BASE_CLASS_NAME, {
-        [`${BASE_CLASS_NAME}--${size}`]: !!size && status !== STATUS.ERROR
-      })}
+      className={cx(
+        BASE_CLASS_NAME,
+        `${BASE_CLASS_NAME}--${size}`,
+        `${BASE_CLASS_NAME}--${status}`
+      )}
     >
       <Circle
         baseClassName={BASE_CLASS_NAME}
@@ -72,7 +81,9 @@ const CircleProgressBar = ({
           size={size}
           status={status}
           errorIcon={errorIcon}
-        />
+        >
+          {children}
+        </Indicator>
       )}
     </div>
   )
@@ -97,7 +108,9 @@ CircleProgressBar.propTypes = {
   isAnimatedOnChange: PropTypes.bool,
 
   /** Hide the indicator */
-  hideIndicator: PropTypes.bool
+  hideIndicator: PropTypes.bool,
+  /** Component to render inside the circle instead of the current progress */
+  children: PropTypes.node
 }
 
 CircleProgressBar.defaultProps = {

--- a/components/atom/progressBar/src/CircleProgressBar/index.scss
+++ b/components/atom/progressBar/src/CircleProgressBar/index.scss
@@ -1,7 +1,7 @@
 @import '~@s-ui/theme/lib/index';
 @import './settings';
 
-.sui-AtomCircleProgressBar {
+.sui-AtomCircleProgressBarV2 {
   background-color: transparent;
   font-size: $fz-atom-circle-progress-bar-text--outer;
   position: relative;

--- a/components/atom/progressBar/src/CircleProgressBar/index.scss
+++ b/components/atom/progressBar/src/CircleProgressBar/index.scss
@@ -3,49 +3,71 @@
 
 .sui-AtomCircleProgressBar {
   background-color: transparent;
-  display: inline-block;
-  position: relative;
+  font-size: $fz-atom-circle-progress-bar-text--outer;
 
   &--small {
+    height: $h-atom-circle-progress-bar-circle-small;
+    width: $w-atom-circle-progress-bar-circle-small;
+  }
+
+  &--medium {
+    align-items: center;
     display: flex;
+    position: relative;
+    justify-content: center;
+    font-size: $fz-atom-circle-progress-bar-text--inner;
+    height: $h-atom-circle-progress-bar-circle-medium;
+    width: $w-atom-circle-progress-bar-circle-medium;
+  }
+
+  &--large {
+    align-items: center;
+    display: flex;
+    position: relative;
+    justify-content: center;
+    font-size: $fz-atom-circle-progress-bar-text--inner;
+    height: $h-atom-circle-progress-bar-circle-large;
+    width: $w-atom-circle-progress-bar-circle-large;
+  }
+
+  &--error {
+    align-items: center;
+    display: flex;
+    position: relative;
+    justify-content: center;
   }
 
   &-indicator {
-    &--inner {
-      font-size: $fz-atom-circle-progress-bar-text--inner;
-      left: 50%;
-      margin: 0;
-      padding: 0;
-      position: absolute;
-      text-align: center;
-      top: calc(#{$h-atom-circle-progress-bar-circle-large} / 2);
-      transform: translate(-50%, -50%);
-    }
-
-    &--small {
-      font-size: $fz-atom-circle-progress-bar-text--outer;
-      top: calc(#{$h-atom-circle-progress-bar-circle-small} / 2);
-
-      &.sui-AtomCircleProgressBar-indicator--error {
-        svg {
-          height: $h-atom-circle-progress-bar-circle-small--error;
-          width: $w-atom-circle-progress-bar-circle-small--error;
-        }
-      }
-    }
-
-    &--outer {
-      font-size: $fz-atom-circle-progress-bar-text--outer;
+    margin: 0;
+    padding: 0;
+    position: absolute;
+    text-align: center;
+    &--small:not(&--error) {
       margin-left: $ml-atom-circle-progress-bar-text--outer;
     }
 
-    &--error {
-      top: 50%;
+    &--medium {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: $h-atom-circle-progress-bar-circle-medium;
+      width: $w-atom-circle-progress-bar-circle-medium;
+    }
 
+    &--large {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: $h-atom-circle-progress-bar-circle-large;
+      width: $w-atom-circle-progress-bar-circle-large;
+    }
+
+    &--error {
+      display: flex;
+      justify-content: center;
+      align-items: center;
       svg {
         fill: $c-atom-circle-progress-bar-trail--error;
-        height: $h-atom-circle-progress-bar-circle-large--error;
-        width: $w-atom-circle-progress-bar-circle-large--error;
       }
     }
   }
@@ -54,6 +76,11 @@
     &--small {
       height: $h-atom-circle-progress-bar-circle-small;
       width: $w-atom-circle-progress-bar-circle-small;
+    }
+
+    &--medium {
+      height: $h-atom-circle-progress-bar-circle-medium;
+      width: $w-atom-circle-progress-bar-circle-medium;
     }
 
     &--large {

--- a/components/atom/progressBar/src/CircleProgressBar/index.scss
+++ b/components/atom/progressBar/src/CircleProgressBar/index.scss
@@ -4,6 +4,7 @@
 .sui-AtomCircleProgressBar {
   background-color: transparent;
   font-size: $fz-atom-circle-progress-bar-text--outer;
+  position: relative;
 
   &--small {
     height: $h-atom-circle-progress-bar-circle-small;
@@ -13,7 +14,6 @@
   &--medium {
     align-items: center;
     display: flex;
-    position: relative;
     justify-content: center;
     font-size: $fz-atom-circle-progress-bar-text--inner;
     height: $h-atom-circle-progress-bar-circle-medium;
@@ -23,7 +23,6 @@
   &--large {
     align-items: center;
     display: flex;
-    position: relative;
     justify-content: center;
     font-size: $fz-atom-circle-progress-bar-text--inner;
     height: $h-atom-circle-progress-bar-circle-large;

--- a/components/atom/progressBar/src/LineProgressBar/index.js
+++ b/components/atom/progressBar/src/LineProgressBar/index.js
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types'
 import cx from 'classnames'
 
 const BASE_CLASS = 'sui-AtomLineProgressBarV2'
-const CLASS_INDICATOR = 'sui-AtomLineProgressBar-indicator'
-const CLASS_CONTAINER_BAR = 'sui-AtomLineProgressBar-container'
-const CLASS_BAR = 'sui-AtomLineProgressBar-bar'
-const CLASS_BAR_ANIMATED = 'sui-AtomLineProgressBar-bar--animated'
+const CLASS_INDICATOR = 'sui-AtomLineProgressBarV2-indicator'
+const CLASS_CONTAINER_BAR = 'sui-AtomLineProgressBarV2-container'
+const CLASS_BAR = 'sui-AtomLineProgressBarV2-bar'
+const CLASS_BAR_ANIMATED = 'sui-AtomLineProgressBarV2-bar--animated'
 
 const Indicator = props => {
   const {indicatorBottom, percentage, indicatorTotal} = props // eslint-disable-line react/prop-types

--- a/components/atom/progressBar/src/LineProgressBar/index.js
+++ b/components/atom/progressBar/src/LineProgressBar/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
-const BASE_CLASS = 'sui-AtomLineProgressBar'
+const BASE_CLASS = 'sui-AtomLineProgressBarV2'
 const CLASS_INDICATOR = 'sui-AtomLineProgressBar-indicator'
 const CLASS_CONTAINER_BAR = 'sui-AtomLineProgressBar-container'
 const CLASS_BAR = 'sui-AtomLineProgressBar-bar'

--- a/components/atom/progressBar/src/LineProgressBar/index.js
+++ b/components/atom/progressBar/src/LineProgressBar/index.js
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types'
 import cx from 'classnames'
 
 const BASE_CLASS = 'sui-AtomLineProgressBarV2'
-const CLASS_INDICATOR = 'sui-AtomLineProgressBarV2-indicator'
-const CLASS_CONTAINER_BAR = 'sui-AtomLineProgressBarV2-container'
-const CLASS_BAR = 'sui-AtomLineProgressBarV2-bar'
-const CLASS_BAR_ANIMATED = 'sui-AtomLineProgressBarV2-bar--animated'
+const CLASS_INDICATOR = `${BASE_CLASS}-indicator`
+const CLASS_CONTAINER_BAR = `${BASE_CLASS}-container`
+const CLASS_BAR = `${BASE_CLASS}-bar`
+const CLASS_BAR_ANIMATED = `${CLASS_BAR}--animated`
 
 const Indicator = props => {
   const {indicatorBottom, percentage, indicatorTotal} = props // eslint-disable-line react/prop-types

--- a/components/atom/progressBar/src/LineProgressBar/index.scss
+++ b/components/atom/progressBar/src/LineProgressBar/index.scss
@@ -11,7 +11,7 @@ $br-progress-container: $bdrs-l !default;
 $br-progress-bar: $bdrs-l !default;
 $h-progress-bar: $m-base !default;
 
-.sui-AtomLineProgressBar {
+.sui-AtomLineProgressBarV2 {
   &-indicator {
     display: inline-block;
     font-size: $fz-s;

--- a/demo/atom/progressBar/playground
+++ b/demo/atom/progressBar/playground
@@ -1,6 +1,8 @@
 /* eslint-disable react/prop-types, no-unused-vars, no-console */
 
-const ErrorIcon = () => (<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><g id="b1ecb616-50e4-4ef2-b242-520a10daccd0" data-name="Layer 2"><g id="a2656784-54b8-454e-b8cb-7a1e3d1f894e" data-name="icons-fill-download"><path d="M13.42,12l4.79-4.8A1,1,0,1,0,16.8,5.79L12,10.58,7.21,5.79a1,1,0,0,0-1.41,0,1,1,0,0,0,0,1.41L10.59,12,5.8,16.79a1,1,0,0,0,.7,1.71,1,1,0,0,0,.71-.3L12,13.41l4.8,4.79a1,1,0,0,0,.7.3,1,1,0,0,0,.71-1.71Z"/><path d="M0,0H24V24H0Z" fill="none"/></g></g></svg>)
+const ErrorIconSmall = () => (<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24"><g id="b1ecb616-50e4-4ef2-b242-520a10daccd0" data-name="Layer 2"><g id="a2656784-54b8-454e-b8cb-7a1e3d1f894e" data-name="icons-fill-download"><path d="M13.42,12l4.79-4.8A1,1,0,1,0,16.8,5.79L12,10.58,7.21,5.79a1,1,0,0,0-1.41,0,1,1,0,0,0,0,1.41L10.59,12,5.8,16.79a1,1,0,0,0,.7,1.71,1,1,0,0,0,.71-.3L12,13.41l4.8,4.79a1,1,0,0,0,.7.3,1,1,0,0,0,.71-1.71Z"/><path d="M0,0H24V24H0Z" fill="none"/></g></g></svg>)
+const ErrorIconLarge = () => (<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><g id="b1ecb616-50e4-4ef2-b242-520a10daccd0" data-name="Layer 2"><g id="a2656784-54b8-454e-b8cb-7a1e3d1f894e" data-name="icons-fill-download"><path d="M13.42,12l4.79-4.8A1,1,0,1,0,16.8,5.79L12,10.58,7.21,5.79a1,1,0,0,0-1.41,0,1,1,0,0,0,0,1.41L10.59,12,5.8,16.79a1,1,0,0,0,.7,1.71,1,1,0,0,0,.71-.3L12,13.41l4.8,4.79a1,1,0,0,0,.7.3,1,1,0,0,0,.71-1.71Z"/><path d="M0,0H24V24H0Z" fill="none"/></g></g></svg>)
+
 
 class StaticWithAnimation extends React.Component {
 
@@ -201,6 +203,12 @@ return (
       <div style={{background: 'white', padding: '10px'}} >
         <AtomProgressBar percentage={25} type="circle" />
       </div>
+      <h2>Basic with children</h2>
+      <div style={{background: 'white', padding: '10px'}} >
+        <AtomProgressBar percentage={25} type="circle" size="medium">
+          <ErrorIconLarge/>
+        </AtomProgressBar>
+      </div>
       <h3>Without indicator</h3>
       <div style={{background: 'white', padding: '10px'}} >
         <AtomProgressBar percentage={25} type="circle" hideIndicator />
@@ -208,16 +216,24 @@ return (
       <h2>With Error</h2>
       <h3>Large</h3>
       <div style={{background: 'white', padding: '10px'}} >
-        <AtomProgressBar percentage={0} type="circle" status="error" errorIcon={<ErrorIcon/>}/>
+        <AtomProgressBar percentage={0} type="circle" status="error" errorIcon={<ErrorIconLarge/>}/>
+      </div>
+      <h3>Medium</h3>
+      <div style={{background: 'white', padding: '10px'}} >
+        <AtomProgressBar percentage={0} type="circle" status="error" size="medium" errorIcon={<ErrorIconLarge/>}/>
       </div>
       <h3>Small</h3>
       <div style={{background: 'white', padding: '10px'}} >
-        <AtomProgressBar percentage={0} type="circle" status="error" size="small" errorIcon={<ErrorIcon/>}/>
+        <AtomProgressBar percentage={0} type="circle" status="error" size="small" errorIcon={<ErrorIconSmall/>}/>
       </div>
       <h2>Loading</h2>
       <h3>Large</h3>
       <div style={{background: 'white', padding: '10px'}} >
         <AtomProgressBar percentage={0} type="circle" status="loading"/>
+      </div>
+      <h3>Medium</h3>
+      <div style={{background: 'white', padding: '10px'}} >
+        <AtomProgressBar percentage={0} type="circle" size="medium" status="loading"/>
       </div>
       <h3>Small</h3>
       <div style={{background: 'white', padding: '10px'}} >


### PR DESCRIPTION
…ponent

We need to allow children to be displayed instead of the percentage to cover some usecases

BREAKING CHANGE:
Now the size of the errorIcon is delagated to the client in order to simplify the code

## Atom/progressBar
**TASK**: <!--- [jira TASK ID](jiraURL) -->


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

We need this change in order to be able to display the following usecases:

![image](https://user-images.githubusercontent.com/21960669/99519902-bb57f580-2992-11eb-8e21-8d26b238f416.png)

