### PR TITLE
A11y/add aria label to input and autosuggest

### DIFF
--- a/components/atom/input/src/Input/Component/index.js
+++ b/components/atom/input/src/Input/Component/index.js
@@ -65,6 +65,7 @@ const Input = ({
   value,
   charsSize,
   tabIndex = DEFAULT_PROPS.TAB_INDEX,
+  ariaLabel,
   maxLength,
   minLength,
   defaultValue,
@@ -111,6 +112,7 @@ const Input = ({
     <input
       className={className}
       tabIndex={tabIndex}
+      aria-label={ariaLabel}
       disabled={disabled}
       readOnly={readOnly}
       id={id}
@@ -198,6 +200,8 @@ Input.propTypes = {
   noBorder: PropTypes.bool,
   /** tabindex value */
   tabIndex: PropTypes.number,
+  /* Native aria-label attribute for a11y */
+  ariaLabel: PropTypes.string,
   /** native required attribtue  */
   required: PropTypes.bool,
   /** native pattern attribute */

--- a/components/molecule/autosuggest/src/components/SingleSelection.js
+++ b/components/molecule/autosuggest/src/components/SingleSelection.js
@@ -28,7 +28,8 @@ const MoleculeAutosuggestSingleSelection = ({
   disabled,
   required,
   tabIndex,
-  autoComplete,
+  ariaLabel,
+  autoComplete = 'nope',
   rightButton,
   inputMode,
   type
@@ -71,6 +72,7 @@ const MoleculeAutosuggestSingleSelection = ({
         disabled={disabled}
         required={required}
         tabIndex={tabIndex}
+        ariaLabel={ariaLabel}
         autoComplete={autoComplete}
         button={rightButton}
         inputMode={inputMode}
@@ -93,10 +95,5 @@ const MoleculeAutosuggestSingleSelection = ({
 
 MoleculeAutosuggestSingleSelection.displayName =
   'MoleculeAutosuggestSingleSelection'
-
-MoleculeAutosuggestSingleSelection.defaultProps = {
-  value: '',
-  autoComplete: 'nope'
-}
 
 export default MoleculeAutosuggestSingleSelection


### PR DESCRIPTION
## atom/input, molecule/autosuggest
**TASK**: [Confluence entry](https://confluence.mpi-internal.com/pages/viewpage.action?pageId=172759982#id-06.Detalle:Definirmejorasdejerarqu%C3%ADa,accesibilidadysem%C3%A1ntica-3.3Camposdeformulariosinlabel)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description, Motivation and Context

- [x] New optional `ariaLabel` prop.
- [x] Bonus: a deprecated `defaultProps` is removed in `molecule/autosuggest`.

Covers scenarios where is not possible to add a visible label. See https://www.w3.org/TR/WCAG20-TECHS/ARIA14.html
