### PR TITLE
feat(molecule/photoUploader): add border variable to photo uploader

### DIFF
--- a/components/molecule/photoUploader/src/index.scss
+++ b/components/molecule/photoUploader/src/index.scss
@@ -35,6 +35,7 @@ $c-photo-uploader-skeleton-hover: $c-white !default;
 $bd-photo-uploader-dropzone: 0 !default;
 $bdrs-photo-uploader-dropzone: $bdrs-l !default;
 $bdrs-photo-uploader-initial-state: $bdrs-l !default;
+$bg-photo-uploader-initial-state: $bg-photo-uploader !default;
 $bdrs-photo-uploader-drag-photo: $bdrs-l !default;
 $c-photo-uploader-initial-state: $c-primary !default;
 $jc-photo-uploader: center !default;
@@ -79,6 +80,7 @@ $maw-photo-uploader-thumb-drag-text: 200px;
   }
   &-initialState {
     align-items: center;
+    background: $bg-photo-uploader-initial-state;
     border: $bd-photo-uploader;
     border-radius: $bdrs-photo-uploader-initial-state;
     color: $c-photo-uploader-initial-state;

--- a/components/molecule/photoUploader/src/index.scss
+++ b/components/molecule/photoUploader/src/index.scss
@@ -32,6 +32,7 @@ $c-photo-uploader-action-buttons-hover: $c-white !default;
 $c-photo-uploader-drag-photo-rejected: $c-white !default;
 $c-photo-uploader-skeleton: $c-primary !default;
 $c-photo-uploader-skeleton-hover: $c-white !default;
+$bd-photo-uploader-dropzone: 0 !default;
 $bdrs-photo-uploader-dropzone: $bdrs-l !default;
 $bdrs-photo-uploader-initial-state: $bdrs-l !default;
 $bdrs-photo-uploader-drag-photo: $bdrs-l !default;
@@ -57,6 +58,7 @@ $maw-photo-uploader-thumb-drag-text: 200px;
 #{$base-class} {
   &-dropzone {
     background: $bg-photo-uploader;
+    border: $bd-photo-uploader-dropzone;
     border-radius: $bdrs-photo-uploader-dropzone;
     color: $c-photo-uploader;
     cursor: pointer;


### PR DESCRIPTION
## molecule/photoUploader


### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description, Motivation and Context
Add a new variable called: `$bd-photo-uploader-dropzone` so the border of the photo uploader can be customized.
Add a new variable called: `$bg-photo-uploader-initial-state` so the background of the photo uploader in the initial state can be customized.