### PR TITLE
feat(molecule/collapsible): disable max height

### DIFF
--- a/components/molecule/collapsible/src/index.js
+++ b/components/molecule/collapsible/src/index.js
@@ -63,14 +63,13 @@ const MoleculeCollapsible = ({
     [`${CONTENT_CLASS}--withTransition`]: withTransition,
     [`${CONTENT_CLASS}--withOverflow`]: withOverflow
   })
-  const containerHeight =
-    showButton && collapsed ? `${height}px` : `${maxHeight}px`
+  const containerHeight = collapsed ? `${height}px` : `${maxHeight}px`
 
   return (
     <div className={wrapperClassName}>
       <div
         className={contentClassName}
-        style={{maxHeight: `${containerHeight}`}}
+        style={{maxHeight: !showButton ? 'none' : containerHeight}}
       >
         <div ref={childrenContainer}>{children}</div>
       </div>


### PR DESCRIPTION
## [Molecule]/[Collapsible]
https://jira.scmspain.com/browse/SCMI-50632


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description, Motivation and Context
**Context**
When you use an imported font (bigger than the default one) and a short text that doesn't need to be collapsible there is a bug caused by a race condition between the component render and the font import, if the component render before the font when the font updates the text will be collapsed and there will be no show button to expand it

**Solution**
Set max height to none when the show button is false.

### Screenshots - Animations
Before
![image](https://user-images.githubusercontent.com/8220448/100222809-6455a180-2ef9-11eb-92ce-1d797fbc23d7.png)

After
![image](https://user-images.githubusercontent.com/8220448/100222849-71729080-2ef9-11eb-83b9-0473e6156270.png)

