### PR TITLE
docs(examples): design link with converting link prop demo on button documentation

### DIFF
--- a/components/atom/button/src/index.js
+++ b/components/atom/button/src/index.js
@@ -58,11 +58,11 @@ const getPropsWithDefaultValues = props => {
   // if color or design are defined, use them with the passed or default value
   if (color || design) {
     if (design !== DESIGNS.LINK) {
-      color = color || 'primary'
+      color = color || COLORS.PRIMARY
     }
-    design = design || 'solid'
+    design = design || DESIGNS.SOLID
   } else {
-    type = type || 'primary'
+    type = type || COLORS.PRIMARY
   }
 
   return {
@@ -96,7 +96,7 @@ const AtomButton = props => {
     CLASS,
     !type && COLOR_CLASSES[color],
     !type && CLASSES[design],
-    type && CLASSES[type],
+    type ? CLASSES[type] : COLOR_CLASSES[type],
     groupPosition && `${CLASS}-group ${CLASS}-group--${groupPosition}`,
     groupPosition && focused && `${CLASS}-group--focused`,
     size && CLASSES[size],

--- a/components/atom/button/src/index.scss
+++ b/components/atom/button/src/index.scss
@@ -214,24 +214,6 @@ $icon-stroke-color: currentColor !default;
     }
   }
 
-  // link
-  &#{$base-class}--link:not(a) {
-    background: none;
-    border: none;
-    padding: 0;
-    cursor: pointer;
-    height: auto;
-    min-height: 0;
-    #{$base-class}-inner {
-      height: auto;
-    }
-    text-transform: none;
-    @include link();
-    &#{$base-class}--negative {
-      @include link(true);
-    }
-  }
-
   // Icons
   &-leftIcon,
   &-rightIcon,
@@ -253,6 +235,28 @@ $icon-stroke-color: currentColor !default;
     position: absolute;
   }
 
+  &#{$base-class}--link:not(#{$base-class}--solid):not(#{$base-class}--outline):not(#{$base-class}--flat) {
+    text-decoration: underline;
+    background: transparent;
+
+    border: none;
+    @include link();
+    padding: 0;
+    justify-content: center;
+    text-align: center;
+
+    @include button-focused {
+      background: transparent;
+    }
+
+    &#{$base-class}--negative {
+      background: transparent;
+      @include button-focused {
+        background: transparent;
+      }
+    }
+  }
+
   // Types and colors
   @each $name, $pair in $c-atom-button-colors {
     $color: nth($pair, 1);
@@ -263,6 +267,7 @@ $icon-stroke-color: currentColor !default;
         background: $color;
         border-color: $color;
         color: $color-invert;
+        text-decoration-line: none;
 
         @include button-focused {
           background: if(
@@ -291,8 +296,7 @@ $icon-stroke-color: currentColor !default;
       }
 
       &#{$base-class}--outline,
-      &#{$base-class}--flat,
-      &#{$base-class}--link:not(a) {
+      &#{$base-class}--flat {
         $bgc-atom-button-focused: color-variation($color, 4) !default;
         $bgc-atom-button-focused-invert: color-variation($color, -1) !default;
         $c-atom-button-focused: $color !default;
@@ -300,6 +304,7 @@ $icon-stroke-color: currentColor !default;
 
         border-color: $color;
         color: $color;
+        text-decoration-line: none;
 
         @include button-focused {
           background: if(
@@ -325,19 +330,20 @@ $icon-stroke-color: currentColor !default;
           }
         }
       }
-      &#{$base-class}--link:not(a) {
-        $c-atom-button-focused: $color !default;
-        $c-atom-button-focused-invert: $color-invert !default;
-        background: transparent;
+      &#{$base-class}--link:not(#{$base-class}--solid):not(#{$base-class}--outline):not(#{$base-class}--flat) {
+        $c-atom-button-focused: color-variation($color, -1) !default;
+        $c-atom-button-focused-invert: color-variation(
+          $color-invert,
+          -1
+        ) !default;
+
+        color: $color;
         @include button-focused {
-          background: transparent;
           color: $c-atom-button-focused;
         }
         &#{$base-class}--negative {
-          background: transparent;
           color: $color;
           @include button-focused {
-            background: transparent;
             color: $c-atom-button-focused;
           }
         }
@@ -401,13 +407,6 @@ $icon-stroke-color: currentColor !default;
     #{$base-class}-leftIcon,
     #{$base-class}-rightIcon {
       margin: 0;
-    }
-  }
-
-  &--link {
-    &,
-    &:hover {
-      text-decoration: none;
     }
   }
 }

--- a/components/atom/button/src/index.scss
+++ b/components/atom/button/src/index.scss
@@ -236,7 +236,6 @@ $icon-stroke-color: currentColor !default;
   }
 
   &#{$base-class}--link:not(#{$base-class}--solid):not(#{$base-class}--outline):not(#{$base-class}--flat) {
-    text-decoration: underline;
     background: transparent;
 
     border: none;
@@ -244,7 +243,7 @@ $icon-stroke-color: currentColor !default;
     padding: 0;
     justify-content: center;
     text-align: center;
-
+    text-decoration: none;
     @include button-focused {
       background: transparent;
     }

--- a/demo/atom/button/demo/index.js
+++ b/demo/atom/button/demo/index.js
@@ -155,56 +155,52 @@ const LinkAndDesignLinkArticle = () => {
             </Fragment>
           ))}
           <Cell />
-          {[...atomButtonColorsIterator, ...atomButtonSocialColorsIterator].map(
-            ([{color}], index) => (
-              <Fragment key={index}>
-                <Cell
-                  style={{...flexCenteredStyle, justifyContent: 'flex-start'}}
-                >
-                  <Label>{color}</Label>
-                </Cell>
-                {atomButtonDesignsIterator.map(([{design}], key) => (
-                  <Fragment key={key}>
-                    <Cell
-                      style={{...flexCenteredStyle, flexDirection: 'column'}}
+          {[
+            ...atomButtonColorsIterator,
+            [{color: undefined}],
+            ...atomButtonSocialColorsIterator
+          ].map(([{color}], index) => (
+            <Fragment key={index}>
+              <Cell
+                style={{...flexCenteredStyle, justifyContent: 'flex-start'}}
+              >
+                <Label>{color || '–'}</Label>
+              </Cell>
+              {atomButtonDesignsIterator.map(([{design}], key) => (
+                <Fragment key={key}>
+                  <Cell style={{...flexCenteredStyle, flexDirection: 'column'}}>
+                    <AtomButton
+                      design={design}
+                      color={color}
+                      leftIcon={socialIconsMapper[color]}
+                      negative={mode === 'dark'}
+                      size={size}
+                      fullWidth
                     >
-                      <AtomButton
-                        design={design}
-                        color={color}
-                        leftIcon={socialIconsMapper[color]}
-                        negative={mode === 'dark'}
-                        size={size}
-                        fullWidth
-                      >
-                        Button
-                      </AtomButton>
-                    </Cell>
-                    <Cell
-                      style={{...flexCenteredStyle, flexDirection: 'column'}}
+                      Button
+                    </AtomButton>
+                  </Cell>
+                  <Cell style={{...flexCenteredStyle, flexDirection: 'column'}}>
+                    <AtomButton
+                      link
+                      href="#"
+                      design={design}
+                      color={color}
+                      leftIcon={socialIconsMapper[color]}
+                      negative={mode === 'dark'}
+                      size={size}
+                      fullWidth
                     >
-                      <AtomButton
-                        link
-                        href="#"
-                        design={design}
-                        color={color}
-                        leftIcon={socialIconsMapper[color]}
-                        negative={mode === 'dark'}
-                        size={size}
-                        fullWidth
-                      >
-                        Button
-                      </AtomButton>
-                    </Cell>
-                  </Fragment>
-                ))}
-                <Cell
-                  style={{...flexCenteredStyle, justifyContent: 'flex-end'}}
-                >
-                  <Label>{color}</Label>
-                </Cell>
-              </Fragment>
-            )
-          )}
+                      Button
+                    </AtomButton>
+                  </Cell>
+                </Fragment>
+              ))}
+              <Cell style={{...flexCenteredStyle, justifyContent: 'flex-end'}}>
+                <Label>{color || '–'}</Label>
+              </Cell>
+            </Fragment>
+          ))}
           <Cell />
           {Array.from(Array(4).keys()).map(key => (
             <Fragment key={key}>

--- a/demo/atom/button/demo/index.js
+++ b/demo/atom/button/demo/index.js
@@ -93,153 +93,17 @@ const flexCenteredStyle = {
   alignContent: 'center'
 }
 
-const LinkAndDesignLinkArticle = () => {
-  const [state, setState] = useState({mode: 'light', size: undefined})
-  const setStatus = newState => setState({...state, ...newState})
-  const {size, mode} = state
-  return (
-    <Article className={CLASS_SECTION}>
-      <H2>Combining Design Link and Prop Link</H2>
-      <Paragraph>
-        This component offers a simple way to replate its own HTML element for
-        an anchor ('a') element using the boolean <Code>link</Code> prop
-        combined with the <Code>href</Code> prop for the destination url.
-      </Paragraph>
-      <Grid cols={2} gutter={[10, 10]}>
-        <Cell style={{...flexCenteredStyle, justifyContent: 'flex-start'}}>
-          <Label>negative</Label>
-        </Cell>
-        <Cell style={{...flexCenteredStyle, justifyContent: 'flex-end'}}>
-          <Label>size</Label>
-        </Cell>
-        <Cell style={{...flexCenteredStyle, justifyContent: 'flex-start'}}>
-          <RadioButtonGroup
-            label="negative"
-            value={mode === 'light' ? 'false' : 'true'}
-            onChange={value =>
-              setStatus({mode: value === 'true' ? 'dark' : 'light'})
-            }
-          >
-            <RadioButton value="false" label="false" />
-            <RadioButton value="true" label="true" />
-          </RadioButtonGroup>
-        </Cell>
-        <Cell style={{...flexCenteredStyle, justifyContent: 'flex-end'}}>
-          <RadioButtonGroup onChange={value => setStatus({size: value})}>
-            <RadioButton value="small" label="small" />
-            <RadioButton value="medium" label="medium" />
-            <RadioButton value="large" label="large" />
-          </RadioButtonGroup>
-        </Cell>
-      </Grid>
-      <br />
-      <Box mode={mode}>
-        <Grid cols={12} gutter={[10, 10]}>
-          <Cell />
-          {[...atomButtonDesignsIterator, [{design: undefined}]].map(
-            ([{design}], index) => (
-              <Fragment key={index}>
-                <Cell span={2} style={flexCenteredStyle}>
-                  <Label>{design || '–'}</Label>
-                </Cell>
-              </Fragment>
-            )
-          )}
-          <Cell />
-          <Cell />
-          {Array.from(Array(5).keys()).map(key => (
-            <Fragment key={key}>
-              {['button', 'link'].map((type, index) => (
-                <Cell key={index} style={flexCenteredStyle}>
-                  <Label>{type}</Label>
-                </Cell>
-              ))}
-            </Fragment>
-          ))}
-          <Cell />
-          {[
-            ...atomButtonColorsIterator,
-            [{color: undefined}],
-            ...atomButtonSocialColorsIterator
-          ].map(([{color}], index) => (
-            <Fragment key={index}>
-              <Cell
-                style={{...flexCenteredStyle, justifyContent: 'flex-start'}}
-              >
-                <Label>{color || '–'}</Label>
-              </Cell>
-              {[...atomButtonDesignsIterator, [{design: undefined}]].map(
-                ([{design}], key) => (
-                  <Fragment key={key}>
-                    <Cell
-                      style={{...flexCenteredStyle, flexDirection: 'column'}}
-                    >
-                      <AtomButton
-                        design={design}
-                        color={color}
-                        leftIcon={socialIconsMapper[color]}
-                        negative={mode === 'dark'}
-                        size={size}
-                        fullWidth
-                      >
-                        Button
-                      </AtomButton>
-                    </Cell>
-                    <Cell
-                      style={{...flexCenteredStyle, flexDirection: 'column'}}
-                    >
-                      <AtomButton
-                        link
-                        href="#"
-                        design={design}
-                        color={color}
-                        leftIcon={socialIconsMapper[color]}
-                        negative={mode === 'dark'}
-                        size={size}
-                        fullWidth
-                      >
-                        Button
-                      </AtomButton>
-                    </Cell>
-                  </Fragment>
-                )
-              )}
-              <Cell style={{...flexCenteredStyle, justifyContent: 'flex-end'}}>
-                <Label>{color || '–'}</Label>
-              </Cell>
-            </Fragment>
-          ))}
-          <Cell />
-          {Array.from(Array(5).keys()).map(key => (
-            <Fragment key={key}>
-              {['button', 'link'].map((type, index) => (
-                <Cell key={index} style={flexCenteredStyle}>
-                  <Label>{type}</Label>
-                </Cell>
-              ))}
-            </Fragment>
-          ))}
-          <Cell />
-          <Cell />
-          {[...atomButtonDesignsIterator, [{design: undefined}]].map(
-            ([{design}], index) => (
-              <Fragment key={index}>
-                <Cell span={2} style={flexCenteredStyle}>
-                  <Label>{design || '–'}</Label>
-                </Cell>
-              </Fragment>
-            )
-          )}
-          <Cell />
-        </Grid>
-      </Box>
-    </Article>
-  )
-}
-
 const Demo = () => {
-  const [state, setState] = useState({content: 'button'})
-  const {negative, content, icon, leftIcon, rightIcon} = state
+  const [state, setState] = useState({content: 'button', link: false})
+  const {
+    negative,
+    content,
+    icon,
+    leftIcon,
+    rightIcon,
+    socialButtons,
+    link
+  } = state
   return (
     <div className="sui-StudioPreview">
       <H1>Button</H1>
@@ -436,8 +300,6 @@ const Demo = () => {
         </Article>
       </Article>
       <br />
-      <LinkAndDesignLinkArticle />
-      <br />
       <Article className={CLASS_SECTION} mode="light">
         <H2>Other extra button boolean props</H2>
         <Paragraph>
@@ -455,6 +317,12 @@ const Demo = () => {
         </Paragraph>
         <Paragraph>
           <Code>fullWidth</Code>: fits all the available with given.
+        </Paragraph>
+        <Paragraph>
+          <Code>link</Code>: converts the button element to an anchor element,
+          keeping its own configured design. A simple way to replace its own
+          HTML element for an anchor ('a') element using the boolean link prop
+          combined with the href prop for the destination url.
         </Paragraph>
         <Grid cols={2} gutter={10}>
           <Cell
@@ -562,7 +430,23 @@ const Demo = () => {
               label={starIcon}
             />
           </Cell>
-          <Cell />
+          <Cell
+            style={{
+              ...flexCenteredStyle,
+              justifyContent: 'flex-start',
+              flexDirection: 'column',
+              alignItems: 'flex-start'
+            }}
+          >
+            <Label>Social buttons</Label>
+            <RadioButton
+              value={socialButtons}
+              onClick={() => {
+                setState({...state, socialButtons: !socialButtons})
+              }}
+              label={socialButtons ? 'disable' : 'enable'}
+            />
+          </Cell>
           <Cell
             style={{
               ...flexCenteredStyle,
@@ -589,16 +473,43 @@ const Demo = () => {
               </>
             )}
           </Cell>
+          <Cell
+            span={2}
+            style={{
+              ...flexCenteredStyle,
+              justifyContent: 'flex-start',
+              flexDirection: 'column',
+              alignItems: 'flex-start'
+            }}
+          >
+            <Label>Link element</Label>
+            <RadioButton
+              value={link}
+              onClick={() => {
+                setState({...state, link: !link})
+              }}
+              label={link ? 'disable' : 'enable'}
+            />
+          </Cell>
           <Cell span={2}>
-            <Article mode={negative ? 'dark' : 'light'}>
-              <Grid cols={7} gutter={10}>
+            <Box mode={negative ? 'dark' : 'light'}>
+              <Grid cols={7} gutter={[10, 10]}>
                 <Cell />
-                {atomButtonColorsIterator.map(([{color}], index) => (
-                  <Cell key={index} style={flexCenteredStyle}>
-                    <Label>{color}</Label>
-                  </Cell>
-                ))}
-                {atomButtonDesignsIterator.map(([{design}], index) => (
+                {[[{design: undefined}], ...atomButtonDesignsIterator].map(
+                  ([{design}], index) => (
+                    <Fragment key={index}>
+                      <Cell style={flexCenteredStyle}>
+                        <Label>{design || '–'}</Label>
+                      </Cell>
+                    </Fragment>
+                  )
+                )}
+                <Cell />
+                {[
+                  ...atomButtonColorsIterator,
+                  [{color: undefined}],
+                  ...(socialButtons ? atomButtonSocialColorsIterator : [])
+                ].map(([{color}], index) => (
                   <Fragment key={index}>
                     <Cell
                       style={{
@@ -606,27 +517,56 @@ const Demo = () => {
                         justifyContent: 'flex-start'
                       }}
                     >
-                      <Label>{design}</Label>
+                      <Label>{color || '–'}</Label>
                     </Cell>
-                    {atomButtonColorsIterator.map(([{color}], index) => (
-                      <Cell key={index} style={flexCenteredStyle}>
-                        <AtomButton
-                          design={design}
-                          color={color}
-                          {...state}
-                          {...{
-                            leftIcon: icon && leftIcon,
-                            rightIcon: icon && rightIcon
-                          }}
-                        >
-                          {icon && !leftIcon && !rightIcon ? starIcon : content}
-                        </AtomButton>
-                      </Cell>
-                    ))}
+                    {[[{design: undefined}], ...atomButtonDesignsIterator].map(
+                      ([{design}], key) => (
+                        <Fragment key={key}>
+                          <Cell
+                            style={{
+                              ...flexCenteredStyle,
+                              flexDirection: 'column'
+                            }}
+                          >
+                            <AtomButton
+                              negative={negative === 'dark'}
+                              design={design}
+                              color={color}
+                              {...state}
+                              {...{
+                                leftIcon: icon && leftIcon,
+                                rightIcon: icon && rightIcon,
+                                href: link ? '#' : undefined
+                              }}
+                            >
+                              {icon && !leftIcon && !rightIcon
+                                ? starIcon
+                                : content}
+                            </AtomButton>
+                          </Cell>
+                        </Fragment>
+                      )
+                    )}
+                    <Cell
+                      style={{...flexCenteredStyle, justifyContent: 'flex-end'}}
+                    >
+                      <Label>{color || '–'}</Label>
+                    </Cell>
                   </Fragment>
                 ))}
+                <Cell />
+                {[...atomButtonDesignsIterator, [{design: undefined}]].map(
+                  ([{design}], index) => (
+                    <Fragment key={index}>
+                      <Cell style={flexCenteredStyle}>
+                        <Label>{design || '–'}</Label>
+                      </Cell>
+                    </Fragment>
+                  )
+                )}
+                <Cell />
               </Grid>
-            </Article>
+            </Box>
           </Cell>
         </Grid>
       </Article>

--- a/demo/atom/button/demo/index.js
+++ b/demo/atom/button/demo/index.js
@@ -140,7 +140,7 @@ const LinkAndDesignLinkArticle = () => {
             ([{design}], index) => (
               <Fragment key={index}>
                 <Cell span={2} style={flexCenteredStyle}>
-                  <Label>{design || '-'}</Label>
+                  <Label>{design || '–'}</Label>
                 </Cell>
               </Fragment>
             )
@@ -210,7 +210,7 @@ const LinkAndDesignLinkArticle = () => {
             </Fragment>
           ))}
           <Cell />
-          {Array.from(Array(4).keys()).map(key => (
+          {Array.from(Array(5).keys()).map(key => (
             <Fragment key={key}>
               {['button', 'link'].map((type, index) => (
                 <Cell key={index} style={flexCenteredStyle}>
@@ -221,13 +221,15 @@ const LinkAndDesignLinkArticle = () => {
           ))}
           <Cell />
           <Cell />
-          {atomButtonDesignsIterator.map(([{design}], index) => (
-            <Fragment key={index}>
-              <Cell span={2} style={flexCenteredStyle}>
-                <Label>{design}</Label>
-              </Cell>
-            </Fragment>
-          ))}
+          {[...atomButtonDesignsIterator, [{design: undefined}]].map(
+            ([{design}], index) => (
+              <Fragment key={index}>
+                <Cell span={2} style={flexCenteredStyle}>
+                  <Label>{design || '–'}</Label>
+                </Cell>
+              </Fragment>
+            )
+          )}
           <Cell />
         </Grid>
       </Box>

--- a/demo/atom/button/demo/index.js
+++ b/demo/atom/button/demo/index.js
@@ -134,18 +134,20 @@ const LinkAndDesignLinkArticle = () => {
       </Grid>
       <br />
       <Box mode={mode}>
-        <Grid cols={10} gutter={[10, 10]}>
+        <Grid cols={12} gutter={[10, 10]}>
           <Cell />
-          {atomButtonDesignsIterator.map(([{design}], index) => (
-            <Fragment key={index}>
-              <Cell span={2} style={flexCenteredStyle}>
-                <Label>{design}</Label>
-              </Cell>
-            </Fragment>
-          ))}
+          {[...atomButtonDesignsIterator, [{design: undefined}]].map(
+            ([{design}], index) => (
+              <Fragment key={index}>
+                <Cell span={2} style={flexCenteredStyle}>
+                  <Label>{design || '-'}</Label>
+                </Cell>
+              </Fragment>
+            )
+          )}
           <Cell />
           <Cell />
-          {Array.from(Array(4).keys()).map(key => (
+          {Array.from(Array(5).keys()).map(key => (
             <Fragment key={key}>
               {['button', 'link'].map((type, index) => (
                 <Cell key={index} style={flexCenteredStyle}>
@@ -166,36 +168,42 @@ const LinkAndDesignLinkArticle = () => {
               >
                 <Label>{color || '–'}</Label>
               </Cell>
-              {atomButtonDesignsIterator.map(([{design}], key) => (
-                <Fragment key={key}>
-                  <Cell style={{...flexCenteredStyle, flexDirection: 'column'}}>
-                    <AtomButton
-                      design={design}
-                      color={color}
-                      leftIcon={socialIconsMapper[color]}
-                      negative={mode === 'dark'}
-                      size={size}
-                      fullWidth
+              {[...atomButtonDesignsIterator, [{design: undefined}]].map(
+                ([{design}], key) => (
+                  <Fragment key={key}>
+                    <Cell
+                      style={{...flexCenteredStyle, flexDirection: 'column'}}
                     >
-                      Button
-                    </AtomButton>
-                  </Cell>
-                  <Cell style={{...flexCenteredStyle, flexDirection: 'column'}}>
-                    <AtomButton
-                      link
-                      href="#"
-                      design={design}
-                      color={color}
-                      leftIcon={socialIconsMapper[color]}
-                      negative={mode === 'dark'}
-                      size={size}
-                      fullWidth
+                      <AtomButton
+                        design={design}
+                        color={color}
+                        leftIcon={socialIconsMapper[color]}
+                        negative={mode === 'dark'}
+                        size={size}
+                        fullWidth
+                      >
+                        Button
+                      </AtomButton>
+                    </Cell>
+                    <Cell
+                      style={{...flexCenteredStyle, flexDirection: 'column'}}
                     >
-                      Button
-                    </AtomButton>
-                  </Cell>
-                </Fragment>
-              ))}
+                      <AtomButton
+                        link
+                        href="#"
+                        design={design}
+                        color={color}
+                        leftIcon={socialIconsMapper[color]}
+                        negative={mode === 'dark'}
+                        size={size}
+                        fullWidth
+                      >
+                        Button
+                      </AtomButton>
+                    </Cell>
+                  </Fragment>
+                )
+              )}
               <Cell style={{...flexCenteredStyle, justifyContent: 'flex-end'}}>
                 <Label>{color || '–'}</Label>
               </Cell>

--- a/demo/atom/button/demo/index.js
+++ b/demo/atom/button/demo/index.js
@@ -12,6 +12,7 @@ import {
   Label,
   H1,
   H2,
+  Box,
   Paragraph,
   Article,
   Code,
@@ -90,6 +91,144 @@ const flexCenteredStyle = {
   wrap: 'nowrap',
   alignItems: 'center',
   alignContent: 'center'
+}
+
+const LinkAndDesignLinkArticle = () => {
+  const [state, setState] = useState({mode: 'light', size: undefined})
+  const setStatus = newState => setState({...state, ...newState})
+  const {size, mode} = state
+  return (
+    <Article className={CLASS_SECTION}>
+      <H2>Combining Design Link and Prop Link</H2>
+      <Paragraph>
+        This component offers a simple way to replate its own HTML element for
+        an anchor ('a') element using the boolean <Code>link</Code> prop
+        combined with the <Code>href</Code> prop for the destination url.
+      </Paragraph>
+      <Grid cols={2} gutter={[10, 10]}>
+        <Cell style={{...flexCenteredStyle, justifyContent: 'flex-start'}}>
+          <Label>negative</Label>
+        </Cell>
+        <Cell style={{...flexCenteredStyle, justifyContent: 'flex-end'}}>
+          <Label>size</Label>
+        </Cell>
+        <Cell style={{...flexCenteredStyle, justifyContent: 'flex-start'}}>
+          <RadioButtonGroup
+            label="negative"
+            value={mode === 'light' ? 'false' : 'true'}
+            onChange={value =>
+              setStatus({mode: value === 'true' ? 'dark' : 'light'})
+            }
+          >
+            <RadioButton value="false" label="false" />
+            <RadioButton value="true" label="true" />
+          </RadioButtonGroup>
+        </Cell>
+        <Cell style={{...flexCenteredStyle, justifyContent: 'flex-end'}}>
+          <RadioButtonGroup onChange={value => setStatus({size: value})}>
+            <RadioButton value="small" label="small" />
+            <RadioButton value="medium" label="medium" />
+            <RadioButton value="large" label="large" />
+          </RadioButtonGroup>
+        </Cell>
+      </Grid>
+      <br />
+      <Box mode={mode}>
+        <Grid cols={10} gutter={[10, 10]}>
+          <Cell />
+          {atomButtonDesignsIterator.map(([{design}], index) => (
+            <Fragment key={index}>
+              <Cell span={2} style={flexCenteredStyle}>
+                <Label>{design}</Label>
+              </Cell>
+            </Fragment>
+          ))}
+          <Cell />
+          <Cell />
+          {Array.from(Array(4).keys()).map(key => (
+            <Fragment key={key}>
+              {['button', 'link'].map((type, index) => (
+                <Cell key={index} style={flexCenteredStyle}>
+                  <Label>{type}</Label>
+                </Cell>
+              ))}
+            </Fragment>
+          ))}
+          <Cell />
+          {[...atomButtonColorsIterator, ...atomButtonSocialColorsIterator].map(
+            ([{color}], index) => (
+              <Fragment key={index}>
+                <Cell
+                  style={{...flexCenteredStyle, justifyContent: 'flex-start'}}
+                >
+                  <Label>{color}</Label>
+                </Cell>
+                {atomButtonDesignsIterator.map(([{design}], key) => (
+                  <Fragment key={key}>
+                    <Cell
+                      style={{...flexCenteredStyle, flexDirection: 'column'}}
+                    >
+                      <AtomButton
+                        design={design}
+                        color={color}
+                        leftIcon={socialIconsMapper[color]}
+                        negative={mode === 'dark'}
+                        size={size}
+                        fullWidth
+                      >
+                        Button
+                      </AtomButton>
+                    </Cell>
+                    <Cell
+                      style={{...flexCenteredStyle, flexDirection: 'column'}}
+                    >
+                      <AtomButton
+                        link
+                        href="#"
+                        design={design}
+                        color={color}
+                        leftIcon={socialIconsMapper[color]}
+                        negative={mode === 'dark'}
+                        size={size}
+                        fullWidth
+                      >
+                        Button
+                      </AtomButton>
+                    </Cell>
+                  </Fragment>
+                ))}
+                <Cell
+                  style={{...flexCenteredStyle, justifyContent: 'flex-end'}}
+                >
+                  <Label>{color}</Label>
+                </Cell>
+              </Fragment>
+            )
+          )}
+          <Cell />
+          {Array.from(Array(4).keys()).map(key => (
+            <Fragment key={key}>
+              {['button', 'link'].map((type, index) => (
+                <Cell key={index} style={flexCenteredStyle}>
+                  <Label>{type}</Label>
+                </Cell>
+              ))}
+            </Fragment>
+          ))}
+          <Cell />
+          <Cell />
+          {atomButtonDesignsIterator.map(([{design}], index) => (
+            <Fragment key={index}>
+              <Cell span={2} style={flexCenteredStyle}>
+                <Label>{design}</Label>
+              </Cell>
+            </Fragment>
+          ))}
+          <Cell />
+        </Grid>
+      </Box>
+    </Article>
+  )
 }
 
 const Demo = () => {
@@ -272,7 +411,7 @@ const Demo = () => {
       </Article>
       <br />
       <Article className={CLASS_SECTION}>
-        <H2>Link</H2>
+        <H2>Link Design</H2>
         <div>
           <Paragraph>
             Buttons, can also look like links in some cases under the{' '}
@@ -290,6 +429,8 @@ const Demo = () => {
           deserunt mollit anim id est laborum."
         </Article>
       </Article>
+      <br />
+      <LinkAndDesignLinkArticle />
       <br />
       <Article className={CLASS_SECTION} mode="light">
         <H2>Other extra button boolean props</H2>


### PR DESCRIPTION
## ATOM/BUTTON
**TASK**: <!--- [jira TASK ID](jiraURL) -->


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] DEMO

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
- The combination of `design="link"` and `link` props produces lots of confusion. The main goal is to create a demo that combines all the cases in order to identify the corner cases and achieve a solution.
- Fixes the styling combination of both usages together.

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->

new section to test it on `Combining Design Link and Prop Link` section
DEMO: [https://sui-components-qxgk9saqq.vercel.app/workbench/atom/button/demo](https://sui-components-qxgk9saqq.vercel.app/workbench/atom/button/demo)
there is an added fix for the styles props combined
FIXED DEMO: [https://sui-components-crb28crlk.vercel.app/workbench/atom/button/demo](https://sui-components-crb28crlk.vercel.app/workbench/atom/button/demo)

The final demo is
[https://sui-components-noynjw6lj.vercel.app/workbench/atom/button/demo](https://sui-components-noynjw6lj.vercel.app/workbench/atom/button/demo)