### PR TITLE
feat(molecule/autosuggest): add autoclose behavior

### DIFF
--- a/components/molecule/autosuggest/src/components/MultipleSelection.js
+++ b/components/molecule/autosuggest/src/components/MultipleSelection.js
@@ -8,6 +8,7 @@ import withClearUI from '../hoc/withClearUI'
 const MoleculeInputTagsWithClearUI = withClearUI(MoleculeInputTags)
 
 const MoleculeAutosuggestFieldMultiSelection = ({
+  autoClose,
   id,
   refMoleculeAutosuggest,
   tags,
@@ -45,21 +46,21 @@ const MoleculeAutosuggestFieldMultiSelection = ({
       value: '',
       tags: newTags
     })
-    onToggle(ev, {isOpen: false})
+    autoClose && onToggle(ev, {isOpen: false})
     refMoleculeAutosuggest.current.focus()
   }
 
   const handleChangeTags = (ev, {tags, value}) => {
     const isOpen = Boolean(value)
     onChangeTags(ev, {tags})
-    onToggle(ev, {isOpen})
+    autoClose && onToggle(ev, {isOpen})
     refMoleculeAutosuggest.current.focus()
   }
 
   const handleChange = (ev, {value}) => {
     const isOpen = Boolean(value)
     onChange(ev, {value})
-    onToggle(ev, {isOpen})
+    autoClose && onToggle(ev, {isOpen})
   }
 
   const handleClear = () => {

--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -35,19 +35,20 @@ const getIsTypeableKey = key => {
 }
 
 const MoleculeAutosuggest = ({
+  autoClose = true,
   children,
   disabled,
   errorState,
   id = '',
   isOpen,
-  keysCloseList,
-  keysSelection,
+  keysCloseList = ['Escape'],
+  keysSelection = [' ', 'Enter'],
   multiselection,
-  onBlur,
-  onChange,
-  onEnter,
-  onFocus,
-  onToggle,
+  onBlur = () => {},
+  onChange = () => {},
+  onEnter = () => {},
+  onFocus = () => {},
+  onToggle = () => {},
   refMoleculeAutosuggest: refMoleculeAutosuggestFromProps,
   state,
   ...restProps
@@ -144,7 +145,7 @@ const MoleculeAutosuggest = ({
         ![domInnerInput, ...options].includes(currentElementFocused) &&
         !domContainer.contains(currentElementFocused)
       if (focusOutFromOutside) {
-        if (isOpen) {
+        if (autoClose && isOpen) {
           closeList(ev)
         } else {
           setFocus(false)
@@ -160,7 +161,7 @@ const MoleculeAutosuggest = ({
     if (key !== 'ArrowDown') ev.stopPropagation()
     if (key === 'Enter') {
       onEnter(ev)
-      closeList(ev)
+      onEnter && autoClose && closeList(ev)
     }
   }
 
@@ -170,23 +171,24 @@ const MoleculeAutosuggest = ({
   }
 
   const autosuggestSelectionProps = {
-    refMoleculeAutosuggestFromProps,
-    onToggle,
-    onChange,
-    onBlur,
-    onEnter,
-    onFocus,
+    autoClose,
+    children: extendedChildren,
+    disabled,
+    errorState,
+    id,
+    innerRefInput: refMoleculeAutosuggestInput,
     isOpen,
     keysCloseList,
     keysSelection,
-    disabled,
-    errorState,
-    state,
-    id,
+    onBlur,
+    onChange,
+    onEnter,
+    onFocus,
     onInputKeyDown: handleInputKeyDown,
+    onToggle,
     refMoleculeAutosuggest: refMoleculeAutosuggest,
-    innerRefInput: refMoleculeAutosuggestInput,
-    children: extendedChildren,
+    refMoleculeAutosuggestFromProps,
+    state,
     ...restProps
   }
 
@@ -213,11 +215,8 @@ const MoleculeAutosuggest = ({
 }
 
 MoleculeAutosuggest.propTypes = {
-  /** The DOM id global attribute. */
-  id: PropTypes.string,
-
-  /** if select accept single value or multiple values */
-  multiselection: PropTypes.bool,
+  /** Auto close suggestion list. */
+  autoClose: PropTypes.bool,
 
   /** children */
   children: PropTypes.any,
@@ -225,97 +224,92 @@ MoleculeAutosuggest.propTypes = {
   /** if the component is disabled or not */
   disabled: PropTypes.bool,
 
-  /** value selected */
-  value: PropTypes.any,
-
-  /* list of values displayed as tags */
-  tags: PropTypes.array,
-
-  /** list of values to be displayed on the select */
-  options: PropTypes.array,
-
-  /** if list of options is displayed or not */
-  isOpen: PropTypes.bool,
-
-  /** callback when arrow up/down is clicked → to show/hide list of options */
-  onToggle: PropTypes.func,
-
-  /* callback to be called with every update of the list of tags */
-  onChangeTags: PropTypes.func,
-
-  /* callback to be called with every update of the input value */
-  onChange: PropTypes.func,
-
-  /* callback to be called when input losses focus */
-  onBlur: PropTypes.func,
-
-  /** Icon for closing (removing) tags */
-  iconCloseTag: PropTypes.node,
+  /** true = error, false = success, null = neutral */
+  errorState: PropTypes.bool,
 
   /** Icon for clearing values */
   iconClear: PropTypes.node,
 
-  /** size (height) of the list */
-  size: PropTypes.oneOf(Object.values(SIZES)),
+  /** Icon for closing (removing) tags */
+  iconCloseTag: PropTypes.node,
 
-  /** callback triggered when the user press enter when the suggestion is closed */
-  onEnter: PropTypes.func,
-
-  /** callback triggered when the user clicks on right icon */
-  onClickRightIcon: PropTypes.func,
-
-  /** callback triggered when the user selects the suggested item */
-  onSelect: PropTypes.func,
-
-  /** Right UI Icon */
-  rightIcon: PropTypes.node,
-
-  /** list of key identifiers that will trigger a selection */
-  keysSelection: PropTypes.array,
-
-  /** list of key identifiers that will close the list */
-  keysCloseList: PropTypes.array,
-
-  /* object generated w/ Reacte.createRef method to get a DOM reference of internal input */
-  refMoleculeAutosuggest: PropTypes.object,
-
-  /* native required html attribute */
-  required: PropTypes.bool,
-
-  /* native tabIndex html attribute */
-  tabIndex: PropTypes.number,
-
-  /** true = error, false = success, null = neutral */
-  errorState: PropTypes.bool,
-
-  /* Will set a red/green/orange border if set to 'error' / 'success' / 'alert' */
-  state: PropTypes.oneOf(Object.values(AUTOSUGGEST_STATES)),
-
-  /* Button prop to be passe down to the input field */
-  rightButton: PropTypes.node,
-
-  /** Left UI Icon */
-  leftIcon: PropTypes.node,
-
-  /** callback triggered when the user focuses on the input */
-  onFocus: PropTypes.func,
+  /** The DOM id global attribute. */
+  id: PropTypes.string,
 
   /** To select input keyboard mode on mobile. It can be 'numeric', 'decimal', 'email', etc */
   inputMode: PropTypes.string,
 
-  /** native input types (text, date, ...), 'sui-password' */
-  type: PropTypes.oneOf(Object.values(inputTypes))
-}
+  /** if list of options is displayed or not */
+  isOpen: PropTypes.bool,
 
-MoleculeAutosuggest.defaultProps = {
-  onChange: () => {},
-  onBlur: () => {},
-  onToggle: () => {},
-  onEnter: () => {},
-  onSelect: () => {},
-  onFocus: () => {},
-  keysSelection: [' ', 'Enter'],
-  keysCloseList: ['Escape']
+  /** list of key identifiers that will close the list */
+  keysCloseList: PropTypes.array,
+
+  /** list of key identifiers that will trigger a selection */
+  keysSelection: PropTypes.array,
+
+  /** Left UI Icon */
+  leftIcon: PropTypes.node,
+
+  /** if select accept single value or multiple values */
+  multiselection: PropTypes.bool,
+
+  /** callback to be called when input losses focus */
+  onBlur: PropTypes.func,
+
+  /** callback to be called with every update of the input value */
+  onChange: PropTypes.func,
+
+  /** callback to be called with every update of the list of tags */
+  onChangeTags: PropTypes.func,
+
+  /** callback triggered when the user clicks on right icon */
+  onClickRightIcon: PropTypes.func,
+
+  /** callback triggered when the user press enter when the suggestion is closed */
+  onEnter: PropTypes.func,
+
+  /** callback triggered when the user focuses on the input */
+  onFocus: PropTypes.func,
+
+  /** callback triggered when the user selects the suggested item */
+  onSelect: PropTypes.func,
+
+  /** callback when arrow up/down is clicked → to show/hide list of options */
+  onToggle: PropTypes.func,
+
+  /** list of values to be displayed on the select */
+  options: PropTypes.array,
+
+  /** object generated w/ Reacte.createRef method to get a DOM reference of internal input */
+  refMoleculeAutosuggest: PropTypes.object,
+
+  /** native required html attribute */
+  required: PropTypes.bool,
+
+  /** Button prop to be passe down to the input field */
+  rightButton: PropTypes.node,
+
+  /** Right UI Icon */
+  rightIcon: PropTypes.node,
+
+  /** size (height) of the list */
+  size: PropTypes.oneOf(Object.values(SIZES)),
+
+  /** Will set a red/green/orange border if set to 'error' / 'success' / 'alert' */
+  state: PropTypes.oneOf(Object.values(AUTOSUGGEST_STATES)),
+
+  /** native tabIndex html attribute */
+  tabIndex: PropTypes.number,
+
+  /** list of values displayed as tags */
+  tags: PropTypes.array,
+
+  /** native input types (text, date, ...), 'sui-password' */
+  type: PropTypes.oneOf(Object.values(inputTypes)),
+
+  /** value selected */
+  value: PropTypes.any
 }
 
 const MoleculeAutoSuggestWithOpenToggle = withOpenToggle(MoleculeAutosuggest)

--- a/demo/molecule/autosuggest/demo/index.js
+++ b/demo/molecule/autosuggest/demo/index.js
@@ -5,6 +5,7 @@ import MoleculeAutosuggest, {
   MoleculeAutosuggestStates
 } from '../../../../components/molecule/autosuggest/src'
 import MoleculeAutosuggestOption from '@s-ui/react-molecule-dropdown-option'
+import MoleculeAutosuggestField from '@s-ui/react-molecule-autosuggest-field'
 import SuiButton from '@s-ui/react-atom-button'
 
 import withDynamicOptions from './hoc/withDynamicOptions'
@@ -28,8 +29,20 @@ const MoleculeAutosuggestWithStateTags = withStateValueTags(
   MoleculeAutosuggestWithDynamicOptions
 )
 
+const MoleculeAutosuggestWithStateTagsLabels = withStateValueTags(
+  MoleculeAutosuggestField
+)
+
 const BASE_CLASS_DEMO = 'DemoMoleculeAutosuggest'
 const CLASS_DEMO_SECTION = `${BASE_CLASS_DEMO}-section`
+
+const options = [
+  {id: 'C10', name: 'Reservado'},
+  {id: 'C20', name: 'Llamar'},
+  {id: 'C30', name: 'No se Rick'},
+  {id: 'C40', name: 'Comisión'},
+  {id: '100', name: 'Mola'}
+]
 
 const Demo = () => (
   <div className="sui-StudioPreview">
@@ -182,6 +195,30 @@ const Demo = () => (
       <div className={CLASS_DEMO_SECTION}>
         <h3>With Placeholder</h3>
         <ComboCountries />
+      </div>
+
+      <h2>Autosugegst list is open</h2>
+      <div className={CLASS_DEMO_SECTION} style={{paddingBottom: '200px'}}>
+        <h3>With preselected Value</h3>
+        <MoleculeAutosuggestWithStateTagsLabels
+          label="Etiquetas"
+          placeholder="Selecciona las etiquetas a asignar al contacto"
+          onChange={(_, {value}) => console.log(value)}
+          onEnter={(_, {value}) => console.log(value)}
+          onSelect={(_, {value}) => console.log(value)}
+          iconClear={<IconClose />}
+          tags={['Mola.']}
+          isOpen
+          autoClose={false}
+          multiselection
+          onChangeTags={(_, {tags}) => console.log(tags)}
+        >
+          {options.map(({id, name}) => (
+            <MoleculeAutosuggestOption id={id} key={id} value={name}>
+              {name}
+            </MoleculeAutosuggestOption>
+          ))}
+        </MoleculeAutosuggestWithStateTagsLabels>
       </div>
     </div>
   </div>

--- a/demo/molecule/autosuggest/demo/package.json
+++ b/demo/molecule/autosuggest/demo/package.json
@@ -11,9 +11,10 @@
   "license": "ISC",
   "dependencies": {
     "@s-ui/hoc": "1",
+    "@s-ui/react-atom-button": "1",
+    "@s-ui/react-molecule-autosuggest-field": "2",
     "@s-ui/react-molecule-dropdown-option": "1",
     "@s-ui/react-molecule-select": "1",
-    "@s-ui/react-atom-button": "1",
     "axios": "^0.19.0"
   }
 }

--- a/demo/package.json
+++ b/demo/package.json
@@ -8,8 +8,5 @@
       "packagesFolder": ".",
       "deepLevel": 3
     }
-  },
-  "dependencies": {
-    "undefined": "^0.1.0"
   }
 }


### PR DESCRIPTION
## molecule/autosuggest


### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description, Motivation and Context

We have a new behavior. In multi-selection we need the suggestions list be and stay open, and to do it we add a new prop `autoClose` with **true** default value to backward compatibility.

- [x] Added new prop with default value
- [x] Use the new prop to add the new behavior
- [x] Reordered props
- [x] Moved to new syntax the default props values
- [x] Added the new behavior to the demo
- [x] Removed the ghost `"undefined": "^0.1.0"` package 🙈


### Screenshots - Animations

![autosuggest](https://user-images.githubusercontent.com/1307927/101027700-a5dcf100-3578-11eb-9873-653ac63d6c71.gif)

[https://sui-components-hdchlpvq2.vercel.app/workbench/molecule/autosuggest/demo](https://sui-components-hdchlpvq2.vercel.app/workbench/molecule/autosuggest/demo)
