### PR TITLE
feat(atom/image): use picture tag around img and add sources prop

### DIFF
--- a/components/atom/image/README.md
+++ b/components/atom/image/README.md
@@ -20,28 +20,28 @@ import AtomImage from '@s-ui/react-atom-image'
 ### Basic usage
 
 ```javascript
-<AtomImage 
-  src={ urlImage } 
-  alt="Nice Picture" 
+<AtomImage
+  src={ urlImage }
+  alt="Nice Picture"
 />
 ```
 
 ### With skeleton while loading
 
 ```javascript
-<AtomImage 
-  src={ urlImage } 
-  alt="Nice Picture" 
-  skeleton={ urlImageSkeleton } 
+<AtomImage
+  src={ urlImage }
+  alt="Nice Picture"
+  skeleton={ urlImageSkeleton }
 />
 ```
 
 ### With placeholder while loading
 
 ```javascript
-<AtomImage 
-  src={ urlImage } 
-  alt="Nice Picture" 
+<AtomImage
+  src={ urlImage }
+  alt="Nice Picture"
   placeholder={ urlImagePlaceholder }
 />
 ```
@@ -49,9 +49,9 @@ import AtomImage from '@s-ui/react-atom-image'
 ### With spinner while loading
 
 ```javascript
-<AtomImage 
-  src={ urlImage } 
-  alt="Nice Picture" 
+<AtomImage
+  src={ urlImage }
+  alt="Nice Picture"
   spinner={ Spinner }
 />
 ```
@@ -59,12 +59,25 @@ import AtomImage from '@s-ui/react-atom-image'
 ### With custom Error if error loading
 
 ```javascript
-<AtomImage 
-  src={ urlImage } 
-  alt="Nice Picture" 
+<AtomImage
+  src={ urlImage }
+  alt="Nice Picture"
   errorText="Oh no!! This image couldn't be loaded"
   errorIcon={ MyIconErrorLoading }
 />
+```
+
+### With picture sources [mdn picture](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture)
+
+Loads 50x50 image when the viewport is under 480px, elsewise it loads a 150x150 image
+
+```js
+<AtomImage
+  src='https://via.placeholder.com/50'
+  alt=''
+  sources={[
+    {srcset: 'https://via.placeholder.com/150', media: '(min-width: 480px)'}
+  ]}
 ```
 
 

--- a/components/atom/image/src/index.js
+++ b/components/atom/image/src/index.js
@@ -29,7 +29,7 @@ const AtomImage = ({
   errorText,
   onError,
   onLoad,
-  sources,
+  sources = [],
   alt,
   ...imgProps
 }) => {
@@ -146,10 +146,6 @@ AtomImage.propTypes = {
 
   /** <img> props */
   ...htmlImgProps
-}
-
-AtomImage.defaultProps = {
-  sources: []
 }
 
 export default AtomImage

--- a/components/atom/image/src/index.js
+++ b/components/atom/image/src/index.js
@@ -137,7 +137,12 @@ AtomImage.propTypes = {
    * Source tags inside picture element,
    * array of props defined in https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source expected
    */
-  sources: PropTypes.array,
+  sources: PropTypes.arrayOf(
+    PropTypes.shape({
+      srcSet: PropTypes.string,
+      media: PropTypes.string
+    })
+  ),
 
   /** <img> props */
   ...htmlImgProps

--- a/components/atom/image/src/index.js
+++ b/components/atom/image/src/index.js
@@ -29,6 +29,8 @@ const AtomImage = ({
   errorText,
   onError,
   onLoad,
+  sources,
+  alt,
   ...imgProps
 }) => {
   const [loading, setLoading] = useState(true)
@@ -80,13 +82,19 @@ const AtomImage = ({
         className={classNamesFigure}
         style={!error && (placeholder || skeleton) ? figureStyles : {}}
       >
-        <img
-          className={CLASS_IMAGE}
-          onLoad={handleLoad}
-          onError={handleError}
-          ref={imageRef}
-          {...imgProps}
-        />
+        <picture>
+          {sources.map((source, idx) => (
+            <source key={idx} {...source} />
+          ))}
+          <img
+            className={CLASS_IMAGE}
+            onLoad={handleLoad}
+            onError={handleError}
+            ref={imageRef}
+            alt={alt}
+            {...imgProps}
+          />
+        </picture>
       </figure>
       {!error && loading && SpinnerExtended}
       {error && (
@@ -125,8 +133,18 @@ AtomImage.propTypes = {
   /** Function to be called when the image completed its loading  */
   onLoad: PropTypes.func,
 
+  /**
+   * Source tags inside picture element,
+   * array of props defined in https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source expected
+   */
+  sources: PropTypes.array,
+
   /** <img> props */
   ...htmlImgProps
+}
+
+AtomImage.defaultProps = {
+  sources: []
 }
 
 export default AtomImage

--- a/demo/atom/image/demo/index.js
+++ b/demo/atom/image/demo/index.js
@@ -100,6 +100,24 @@ const Demo = () => {
           <li className={CLASS_DEMO_LIST_ITEM}>
             <div className={CLASS_DEMO_CONTAINER_IMAGES}>
               <AtomImage
+                src="https://via.placeholder.com/50"
+                alt=""
+                sources={[
+                  {
+                    srcSet: 'https://via.placeholder.com/150',
+                    media: '(min-width: 480px)'
+                  }
+                ]}
+              />
+            </div>
+            <small style={{margin: '10px'}}>
+              Loads 50x50 image when viewport is under 480px
+            </small>
+          </li>
+
+          <li className={CLASS_DEMO_LIST_ITEM}>
+            <div className={CLASS_DEMO_CONTAINER_IMAGES}>
+              <AtomImage
                 src={IMAGES.FINAL}
                 placeholder={IMAGES.PLACEHOLDER}
                 alt="Nice View"


### PR DESCRIPTION
## atom/image

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
Adds performant picture sources depending on the current device. We use the thumbnail component witch uses this one to show the company logo in our cards, these logos can be resized depending on query params in order to load the lower res images in mobile but we can't take advantage of them as this feature isn't implemented.

Since mdn's docs mention that the picture tag may include zero or more sources and one image and that it's semantically correct to use picture inside figure ([stack overflow](https://stackoverflow.com/a/23941403)), I've added the picture tag as fixed element within the component

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Screenshots - Animations

<img src="https://user-images.githubusercontent.com/17549662/101324141-0d8d8780-386a-11eb-9f7b-045c3bbee7e3.gif" width="300" />

