### PR TITLE
fix(atom/button): default props type deprecated usage mode

### DIFF
--- a/components/atom/button/src/index.js
+++ b/components/atom/button/src/index.js
@@ -58,11 +58,11 @@ const getPropsWithDefaultValues = props => {
   // if color or design are defined, use them with the passed or default value
   if (color || design) {
     if (design !== DESIGNS.LINK) {
-      color = color || COLORS.PRIMARY
+      color = color || 'primary'
     }
     design = design || DESIGNS.SOLID
   } else {
-    type = type || COLORS.PRIMARY
+    type = type || 'primary'
   }
 
   return {
@@ -96,7 +96,7 @@ const AtomButton = props => {
     CLASS,
     !type && COLOR_CLASSES[color],
     !type && CLASSES[design],
-    type ? CLASSES[type] : COLOR_CLASSES[type],
+    type && CLASSES[type],
     groupPosition && `${CLASS}-group ${CLASS}-group--${groupPosition}`,
     groupPosition && focused && `${CLASS}-group--focused`,
     size && CLASSES[size],


### PR DESCRIPTION
## ATOM/BUTTON
**TASK**: <!--- [jira TASK ID](jiraURL) -->


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
when there is no given design or color prop, the default props callback is failing on the returning COLORS.PRIMARY value cuz it is not an object but a normal array of values

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
