### PR TITLE
feat(molecule/autosuggestField): export autosuggest dropdown list sizes

### DIFF
--- a/components/molecule/autosuggestField/src/index.js
+++ b/components/molecule/autosuggestField/src/index.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types'
 
 import MoleculeField from '@s-ui/react-molecule-field'
 import MoleculeAutosuggest, {
-  MoleculeAutosuggestStates
+  MoleculeAutosuggestStates,
+  MoleculeAutosuggestDropdownListSizes
 } from '@s-ui/react-molecule-autosuggest'
 
 const getErrorState = ({successText, errorText}) => {
@@ -101,4 +102,4 @@ MoleculeAutosuggestField.propTypes = {
 }
 
 export default MoleculeAutosuggestField
-export {MoleculeAutosuggestStates}
+export {MoleculeAutosuggestStates, MoleculeAutosuggestDropdownListSizes}


### PR DESCRIPTION
## molecule/autosuggestField


### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context

We need to use `MoleculeAutosuggestDropdownListSizes` at **autosuggestField**, so, we export it to use it.

