### PR TITLE
feat(atom/button): add alignText prop

### DIFF
--- a/components/atom/button/src/config.js
+++ b/components/atom/button/src/config.js
@@ -18,6 +18,11 @@ export const DESIGNS = {
   LINK: 'link'
 }
 
+export const ALIGN_TEXT = {
+  CENTER: 'center',
+  LEFT: 'left'
+}
+
 /**
  * Available colors for the button
  */
@@ -82,6 +87,7 @@ export const OWN_PROPS = [
   'design',
   'focused',
   'fullWidth',
+  'alignText',
   'groupPosition',
   'leftIcon',
   'negative',

--- a/components/atom/button/src/config.js
+++ b/components/atom/button/src/config.js
@@ -88,7 +88,7 @@ export const OWN_PROPS = [
   'design',
   'focused',
   'fullWidth',
-  'alignText',
+  'alignment',
   'groupPosition',
   'leftIcon',
   'negative',

--- a/components/atom/button/src/config.js
+++ b/components/atom/button/src/config.js
@@ -18,9 +18,10 @@ export const DESIGNS = {
   LINK: 'link'
 }
 
-export const ALIGN_TEXT = {
+export const ALIGNMENT = {
   CENTER: 'center',
-  LEFT: 'left'
+  LEFT: 'left',
+  RIGHT: 'right'
 }
 
 /**

--- a/components/atom/button/src/index.js
+++ b/components/atom/button/src/index.js
@@ -4,6 +4,7 @@ import {
   CLASS,
   COLORS,
   DESIGNS,
+  ALIGN_TEXT,
   ICON_POSITIONS,
   GROUP_POSITIONS,
   MODIFIERS,
@@ -25,6 +26,7 @@ const createClasses = (array, sufix = '') => {
 const CLASSES = createClasses([
   ...TYPES,
   ...Object.values(DESIGNS),
+  ...Object.values(ALIGN_TEXT),
   ...MODIFIERS,
   ...Object.values(SIZES),
   'empty'
@@ -54,7 +56,7 @@ const getModifiers = props => {
 }
 
 const getPropsWithDefaultValues = props => {
-  let {color, design, type} = props
+  let {color, design, alignText, type} = props
   // if color or design are defined, use them with the passed or default value
   if (color || design) {
     if (design !== DESIGNS.LINK) {
@@ -69,6 +71,7 @@ const getPropsWithDefaultValues = props => {
     color,
     design,
     type,
+    alignText: alignText || 'center',
     ...props
   }
 }
@@ -84,6 +87,7 @@ const AtomButton = props => {
     rightIcon,
     size,
     design,
+    alignText,
     title,
     disabled,
     isLoading,
@@ -97,6 +101,7 @@ const AtomButton = props => {
     !type && COLOR_CLASSES[color],
     !type && CLASSES[design],
     type && CLASSES[type],
+    alignText && CLASSES[alignText],
     groupPosition && `${CLASS}-group ${CLASS}-group--${groupPosition}`,
     groupPosition && focused && `${CLASS}-group--focused`,
     size && CLASSES[size],
@@ -214,6 +219,10 @@ AtomButton.propTypes = {
    */
   size: PropTypes.oneOf(Object.values(SIZES)),
   /**
+   * Align text 'center' (default), 'left'
+   */
+  alignText: PropTypes.bool,
+  /**
    * If true loading state will be enabled
    */
   isLoading: PropTypes.bool,
@@ -277,3 +286,4 @@ export {COLORS as atomButtonColors}
 export {DESIGNS as atomButtonDesigns}
 export {SIZES as atomButtonSizes}
 export {TYPES as atomButtonTypes}
+export {ALIGN_TEXT as atomButtonAlignText}

--- a/components/atom/button/src/index.js
+++ b/components/atom/button/src/index.js
@@ -71,7 +71,7 @@ const getPropsWithDefaultValues = props => {
     color,
     design,
     type,
-    alignText: alignText || 'center',
+    alignText: alignText || ALIGN_TEXT.CENTER,
     ...props
   }
 }
@@ -221,7 +221,7 @@ AtomButton.propTypes = {
   /**
    * Align text 'center' (default), 'left'
    */
-  alignText: PropTypes.bool,
+  alignText: PropTypes.oneOf(Object.values(ALIGN_TEXT)),
   /**
    * If true loading state will be enabled
    */

--- a/components/atom/button/src/index.js
+++ b/components/atom/button/src/index.js
@@ -219,7 +219,7 @@ AtomButton.propTypes = {
    */
   size: PropTypes.oneOf(Object.values(SIZES)),
   /**
-   * Align content 'center' (default), 'left'
+   * Align content 'center' (default), 'left' and 'right'
    */
   alignment: PropTypes.oneOf(Object.values(ALIGNMENT)),
   /**

--- a/components/atom/button/src/index.js
+++ b/components/atom/button/src/index.js
@@ -4,7 +4,7 @@ import {
   CLASS,
   COLORS,
   DESIGNS,
-  ALIGN_TEXT,
+  ALIGNMENT,
   ICON_POSITIONS,
   GROUP_POSITIONS,
   MODIFIERS,
@@ -26,7 +26,7 @@ const createClasses = (array, sufix = '') => {
 const CLASSES = createClasses([
   ...TYPES,
   ...Object.values(DESIGNS),
-  ...Object.values(ALIGN_TEXT),
+  ...Object.values(ALIGNMENT),
   ...MODIFIERS,
   ...Object.values(SIZES),
   'empty'
@@ -56,7 +56,7 @@ const getModifiers = props => {
 }
 
 const getPropsWithDefaultValues = props => {
-  let {color, design, alignText, type} = props
+  let {color, design, alignment = ALIGNMENT.CENTER, type} = props
   // if color or design are defined, use them with the passed or default value
   if (color || design) {
     if (design !== DESIGNS.LINK) {
@@ -71,7 +71,7 @@ const getPropsWithDefaultValues = props => {
     color,
     design,
     type,
-    alignText: alignText || ALIGN_TEXT.CENTER,
+    alignment,
     ...props
   }
 }
@@ -87,7 +87,7 @@ const AtomButton = props => {
     rightIcon,
     size,
     design,
-    alignText,
+    alignment,
     title,
     disabled,
     isLoading,
@@ -101,7 +101,7 @@ const AtomButton = props => {
     !type && COLOR_CLASSES[color],
     !type && CLASSES[design],
     type && CLASSES[type],
-    alignText && CLASSES[alignText],
+    alignment && CLASSES[alignment],
     groupPosition && `${CLASS}-group ${CLASS}-group--${groupPosition}`,
     groupPosition && focused && `${CLASS}-group--focused`,
     size && CLASSES[size],
@@ -219,9 +219,9 @@ AtomButton.propTypes = {
    */
   size: PropTypes.oneOf(Object.values(SIZES)),
   /**
-   * Align text 'center' (default), 'left'
+   * Align content 'center' (default), 'left'
    */
-  alignText: PropTypes.oneOf(Object.values(ALIGN_TEXT)),
+  alignment: PropTypes.oneOf(Object.values(ALIGNMENT)),
   /**
    * If true loading state will be enabled
    */
@@ -286,4 +286,4 @@ export {COLORS as atomButtonColors}
 export {DESIGNS as atomButtonDesigns}
 export {SIZES as atomButtonSizes}
 export {TYPES as atomButtonTypes}
-export {ALIGN_TEXT as atomButtonAlignText}
+export {ALIGNMENT as atomButtonAlignment}

--- a/components/atom/button/src/index.scss
+++ b/components/atom/button/src/index.scss
@@ -368,12 +368,16 @@ $icon-stroke-color: currentColor !default;
     }
   }
 
+  &--center {
+    text-align: center;
+  }
+
   &--left {
     text-align: left;
   }
 
-  &--center {
-    text-align: center;
+  &--right {
+    text-align: right;
   }
 
   // Modifiers

--- a/components/atom/button/src/index.scss
+++ b/components/atom/button/src/index.scss
@@ -147,7 +147,6 @@ $icon-stroke-color: currentColor !default;
   border-radius: $bdrs-atom-button;
   box-sizing: border-box;
   display: inline-block;
-  text-align: center;
   font: {
     family: $ff-atom-button;
     size: $fz-atom-button;
@@ -256,7 +255,7 @@ $icon-stroke-color: currentColor !default;
     }
   }
 
-  // Types and colors
+  // Types, colors and align text
   @each $name, $pair in $c-atom-button-colors {
     $color: nth($pair, 1);
     $color-invert: nth($pair, 2);
@@ -369,6 +368,14 @@ $icon-stroke-color: currentColor !default;
     }
   }
 
+  &--left {
+    text-align: left;
+  }
+
+  &--center {
+    text-align: center;
+  }
+
   // Modifiers
   &--disabled {
     cursor: default;
@@ -397,7 +404,6 @@ $icon-stroke-color: currentColor !default;
 
   &--fullWidth {
     justify-content: center;
-    text-align: center;
     width: 100%;
   }
 

--- a/demo/atom/button/demo/index.js
+++ b/demo/atom/button/demo/index.js
@@ -5,7 +5,8 @@ import {useState, Fragment} from 'react'
 import AtomButton, {
   atomButtonColors,
   atomButtonDesigns,
-  atomButtonSizes
+  atomButtonSizes,
+  atomButtonAlignment
 } from '../../../../components/atom/button/src'
 import {
   AntDesignIcon,
@@ -75,6 +76,11 @@ const atomButtonSizesIterator = [
   undefined,
   atomButtonSizes.LARGE
 ].map((size, index) => [{size}, index])
+const atomButtonAlignmentIterator = [
+  undefined,
+  atomButtonAlignment.LEFT,
+  atomButtonAlignment.RIGHT
+].map((alignment, index) => [{alignment}, index])
 const socialIconsMapper = {
   'social-facebook': facebookIcon,
   'social-twitter': twitterIcon,
@@ -273,6 +279,32 @@ const Demo = () => {
           {atomButtonSizesIterator.map(([{size}], index) => (
             <Cell key={index} style={flexCenteredStyle}>
               <AtomButton size={size} color="primary">
+                Button
+              </AtomButton>
+            </Cell>
+          ))}
+        </Grid>
+      </Article>
+      <br />
+      <Article className={CLASS_SECTION}>
+        <H2>Alignment</H2>
+        <div>
+          <Paragraph>
+            Button content alignment, under the prop <Code>alignment</Code>{' '}
+            exported from <Code>atomButtonAlignment</Code>
+          </Paragraph>
+        </div>
+        <Grid cols={3} gutter={10} style={{columnGap: '20px'}}>
+          {atomButtonAlignmentIterator.map(([{alignment}], index) => (
+            <Fragment key={index}>
+              <Cell style={flexCenteredStyle}>
+                <Label>{alignment || 'DEFAULT'}</Label>
+              </Cell>
+            </Fragment>
+          ))}
+          {atomButtonAlignmentIterator.map(([{alignment}], index) => (
+            <Cell key={index}>
+              <AtomButton alignment={alignment} fullWidth color="primary">
                 Button
               </AtomButton>
             </Cell>

--- a/demo/package.json
+++ b/demo/package.json
@@ -8,8 +8,5 @@
       "packagesFolder": ".",
       "deepLevel": 3
     }
-  },
-  "dependencies": {
-    "undefined": "^0.1.0"
   }
 }

--- a/demo/package.json
+++ b/demo/package.json
@@ -8,5 +8,8 @@
       "packagesFolder": ".",
       "deepLevel": 3
     }
+  },
+  "dependencies": {
+    "undefined": "^0.1.0"
   }
 }


### PR DESCRIPTION
## Atom/Button

Add new prop "alignText"  to be able to align text left or center. By default it will be "center".


### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor


### Screenshots - Animations
<img width="268" alt="Captura de pantalla 2020-12-10 a las 10 25 03" src="https://user-images.githubusercontent.com/55990391/101752573-fa7cf080-3ad1-11eb-8294-d88d8fad3a5a.png">
