### PR TITLE
feat(molecule/modal): add size and contentless props

### DIFF
--- a/components/molecule/modal/src/Content/_index.scss
+++ b/components/molecule/modal/src/Content/_index.scss
@@ -1,0 +1,13 @@
+.sui-MoleculeModalContent {
+  -webkit-overflow-scrolling: touch;
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: $pt-molecule-modal-content $pr-molecule-modal-content
+    $pb-molecule-modal-content $pl-molecule-modal-content;
+  position: relative;
+
+  &--without-indentation {
+    padding: 0;
+    margin: 0;
+  }
+}

--- a/components/molecule/modal/src/Content/index.js
+++ b/components/molecule/modal/src/Content/index.js
@@ -1,0 +1,51 @@
+import {useRef} from 'react'
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+
+const MoleculeModalContent = ({
+  className: classNameProp,
+  enableContentScroll,
+  withoutIndentation,
+  ...others
+}) => {
+  const baseClassName = 'sui-MoleculeModalContent'
+  const contentRef = useRef()
+  const className = cx(baseClassName, {
+    [`${baseClassName}--without-indentation`]: withoutIndentation
+  })
+
+  const preventScrollIfNeeded = ev => {
+    const {clientHeight, scrollHeight} = contentRef.current
+    const noScroll = scrollHeight <= clientHeight
+    if (!enableContentScroll && noScroll) ev.preventDefault()
+  }
+
+  const avoidOverscroll = () => {
+    const {offsetHeight, scrollTop, scrollHeight} = contentRef.current
+    const currentScroll = scrollTop + offsetHeight
+
+    if (scrollTop === 0) {
+      contentRef.current.scrollTop = 1
+    } else if (currentScroll >= scrollHeight) {
+      contentRef.current.scrollTop = scrollTop - 1
+    }
+  }
+
+  return (
+    <div
+      className={className}
+      ref={contentRef}
+      onTouchStart={avoidOverscroll}
+      onTouchMove={preventScrollIfNeeded}
+      {...others}
+    />
+  )
+}
+
+MoleculeModalContent.propTypes = {
+  className: PropTypes.string,
+  enableContentScroll: PropTypes.bool,
+  withoutIndentation: PropTypes.bool
+}
+
+export default MoleculeModalContent

--- a/components/molecule/modal/src/Footer/_index.scss
+++ b/components/molecule/modal/src/Footer/_index.scss
@@ -1,0 +1,5 @@
+.sui-MoleculeModalFooter {
+  padding: $pt-molecule-modal-footer $pr-molecule-modal-footer
+    $pb-molecule-modal-footer $pl-molecule-modal-footer;
+  border-top: $bd-molecule-modal-footer;
+}

--- a/components/molecule/modal/src/Footer/index.js
+++ b/components/molecule/modal/src/Footer/index.js
@@ -1,0 +1,13 @@
+import PropTypes from 'prop-types'
+
+const MoleculeModalFooter = ({className, ...others}) => {
+  const baseClassName = 'sui-MoleculeModalFooter'
+
+  return <footer className={baseClassName} {...others} />
+}
+
+MoleculeModalFooter.propTypes = {
+  className: PropTypes.string
+}
+
+export default MoleculeModalFooter

--- a/components/molecule/modal/src/_settings.scss
+++ b/components/molecule/modal/src/_settings.scss
@@ -16,6 +16,12 @@ $m-molecule-modal-dialog-mobile: $m-l !default;
 $maw-molecule-modal-dialog: 600px !default;
 $maw-molecule-modal-dialog--full: 1200px !default;
 $miw-molecule-modal-dialog: 288px !default;
+$s-molecule-modal-dialog: (
+  xsmall: 384px,
+  small: 448px,
+  medium: 512px,
+  large: 576px
+) !default;
 
 $bg-molecule-modal-header: transparent !default;
 $bd-molecule-modal-header: 1px solid $c-gray-light !default;
@@ -46,3 +52,20 @@ $z-molecule-modal-icon-floating: $z-modal !default;
 
 $m-molecule-modal-content: $m-l $m-xl !default;
 $p-molecule-modal-content: 0 !default;
+
+$pt-molecule-modal-content: $p-l !default;
+$pb-molecule-modal-content: $pt-molecule-modal-content !default;
+$pr-molecule-modal-content: $p-xl !default;
+$pl-molecule-modal-content: $pr-molecule-modal-content !default;
+
+// maintain backward compatibility in case someone uses any $pX-molecule-modal-content existing variables
+$mt-molecule-modal-content: $pt-molecule-modal-content !default;
+$mb-molecule-modal-content: $pb-molecule-modal-content !default;
+$mr-molecule-modal-content: $pr-molecule-modal-content !default;
+$ml-molecule-modal-content: $pl-molecule-modal-content !default;
+
+$bd-molecule-modal-footer: 1px solid $c-gray-light !default;
+$pt-molecule-modal-footer: $p-l !default;
+$pb-molecule-modal-footer: $p-l !default;
+$pr-molecule-modal-footer: $pr-molecule-modal-content !default;
+$pl-molecule-modal-footer: $pl-molecule-modal-content !default;

--- a/components/molecule/modal/src/index.js
+++ b/components/molecule/modal/src/index.js
@@ -15,8 +15,17 @@ import {SUPPORTED_KEYS} from './config'
 import {suitClass} from './helpers'
 import {Close} from './Close'
 import {HeaderRender} from './HeaderRender'
+import MoleculeModalContent from './Content'
+import MoleculeModalFooter from './Footer'
 import WithAnimation from './HoC/WithAnimation'
 import WithUrlState from './HoC/WithUrlState'
+
+export const MODAL_SIZES = {
+  XSMALL: 'xsmall',
+  SMALL: 'small',
+  MEDIUM: 'medium',
+  LARGE: 'large'
+}
 
 const toggleWindowScroll = disableScroll => {
   window.document.body.classList.toggle('is-MoleculeModal-open', disableScroll)
@@ -30,6 +39,7 @@ const MoleculeModal = ({
   fitContent = false,
   fitWindow = false,
   floatingIconClose = false,
+  size,
   header,
   iconClose = false,
   isClosing,
@@ -38,9 +48,9 @@ const MoleculeModal = ({
   onClose = () => {},
   portalContainerId = 'modal-react-portal',
   usePortal = true,
-  withoutIndentation = false
+  withoutIndentation = false,
+  isContentless
 }) => {
-  const contentRef = useRef()
   const wrapperRef = useRef()
 
   const [isClientReady, setIsClientReady] = useState(false)
@@ -89,34 +99,19 @@ const MoleculeModal = ({
     }
   }, [onKeyDown])
 
-  const preventScrollIfNeeded = ev => {
-    const {clientHeight, scrollHeight} = contentRef.current
-    const noScroll = scrollHeight <= clientHeight
-    if (!enableContentScroll && noScroll) ev.preventDefault()
-  }
-
-  const avoidOverscroll = () => {
-    const {offsetHeight, scrollTop, scrollHeight} = contentRef.current
-    const currentScroll = scrollTop + offsetHeight
-
-    if (scrollTop === 0) {
-      contentRef.current.scrollTop = 1
-    } else if (currentScroll >= scrollHeight) {
-      contentRef.current.scrollTop = scrollTop - 1
-    }
-  }
-
   const handleOutsideClick = ev => {
     if (closeOnOutsideClick && ev.target === wrapperRef.current) {
       closeModal(ev)
     }
   }
 
-  const extendedChildren = Children.toArray(children).map(child =>
-    cloneElement(child, {
-      onClose: closeModal
-    })
-  )
+  const renderChildren = () => {
+    return Children.toArray(children).map(child =>
+      cloneElement(child, {
+        onClose: closeModal
+      })
+    )
+  }
 
   const renderModal = () => {
     const wrapperClassName = cx(suitClass(), {
@@ -127,11 +122,8 @@ const MoleculeModal = ({
     const dialogClassName = cx(suitClass({element: 'dialog'}), {
       [suitClass({element: 'dialog--full'})]: fitWindow,
       [suitClass({element: 'dialog--out'})]: isClosing,
-      [suitClass({element: 'dialog--fit'})]: fitContent
-    })
-
-    const contentClassName = cx(suitClass({element: 'content'}), {
-      [suitClass({element: 'content--without-indentation'})]: withoutIndentation
+      [suitClass({element: 'dialog--fit'})]: fitContent,
+      [suitClass({element: `dialog--${size}`})]: !!size
     })
 
     return (
@@ -157,14 +149,16 @@ const MoleculeModal = ({
               floatingIconClose={floatingIconClose}
             />
           )}
-          <div
-            className={contentClassName}
-            onTouchStart={avoidOverscroll}
-            onTouchMove={preventScrollIfNeeded}
-            ref={contentRef}
-          >
-            {extendedChildren}
-          </div>
+          {isContentless ? (
+            renderChildren()
+          ) : (
+            <MoleculeModalContent
+              enableContentScroll={enableContentScroll}
+              withoutIndentation={withoutIndentation}
+            >
+              {renderChildren()}
+            </MoleculeModalContent>
+          )}
         </div>
       </div>
     )
@@ -210,6 +204,10 @@ MoleculeModal.propTypes = {
    * true if you want a modal that fit contents in mobile devices, otherwise, false
    */
   fitContent: PropTypes.bool,
+  /**
+   * Max width of the modal to be used
+   */
+  size: PropTypes.oneOf(Object.values(MODAL_SIZES)),
   /**
    * true if you want a modal without content indentation
    */
@@ -267,6 +265,9 @@ const MoleculeModalWithAnimation = WithAnimation(MoleculeModal)
 const MoleculeModalWithUrlState = WithUrlState(MoleculeModalWithAnimation)
 
 MoleculeModalWithAnimation.displayName = 'MoleculeModal'
+
+MoleculeModalWithAnimation.Content = MoleculeModalContent
+MoleculeModalWithAnimation.Footer = MoleculeModalFooter
 
 export {MoleculeModalWithUrlState, MoleculeModalWithAnimation}
 export default MoleculeModalWithAnimation

--- a/components/molecule/modal/src/index.js
+++ b/components/molecule/modal/src/index.js
@@ -105,13 +105,12 @@ const MoleculeModal = ({
     }
   }
 
-  const renderChildren = () => {
-    return Children.toArray(children).map(child =>
+  const renderChildren = () =>
+    Children.toArray(children).map(child =>
       cloneElement(child, {
         onClose: closeModal
       })
     )
-  }
 
   const renderModal = () => {
     const wrapperClassName = cx(suitClass(), {
@@ -241,7 +240,7 @@ MoleculeModal.propTypes = {
    */
   onAnimationEnd: PropTypes.func,
   /**
-   * If true children won't be wrapped with content
+   * Defines whether children will be wrapped with content or not
    */
   isContentless: PropTypes.bool,
   /**

--- a/components/molecule/modal/src/index.js
+++ b/components/molecule/modal/src/index.js
@@ -241,6 +241,10 @@ MoleculeModal.propTypes = {
    */
   onAnimationEnd: PropTypes.func,
   /**
+   * If true children won't be wrapped with content
+   */
+  isContentless: PropTypes.bool,
+  /**
    * Container id element to be used to render the portal. If not available, it will be created for you.
    */
   portalContainerId: PropTypes.string,

--- a/components/molecule/modal/src/index.scss
+++ b/components/molecule/modal/src/index.scss
@@ -1,5 +1,7 @@
 @import '~@s-ui/theme/lib/index';
 @import './settings';
+@import './Content/index';
+@import './Footer/index';
 
 %modal-position {
   bottom: 0;
@@ -126,6 +128,15 @@ body.is-MoleculeModal-open {
       margin: $m-molecule-modal-dialog-mobile;
       max-height: calc(100% - #{$m-molecule-modal-dialog} * 2);
       width: initial;
+    }
+
+    @each $key-size, $size in $s-molecule-modal-dialog {
+      &--#{$key-size} {
+        @include media-breakpoint-up(xs) {
+          width: 100%;
+          max-width: $size;
+        }
+      }
     }
   }
 

--- a/demo/molecule/modal/demo/ContentlessModal.js
+++ b/demo/molecule/modal/demo/ContentlessModal.js
@@ -1,0 +1,44 @@
+/* eslint react/prop-types: 0 */
+/* eslint no-console: 0 */
+import {useState} from 'react'
+import MoleculeModal from '../../../../components/molecule/modal/src'
+import {IconClose} from './helperComponents'
+import Lorem from 'react-lorem-component'
+
+const ContentlessModal = () => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const handleClick = () => {
+    setIsOpen(true)
+  }
+
+  const handleClose = () => {
+    setIsOpen(false)
+  }
+
+  return (
+    <div>
+      <button type="button" onClick={handleClick}>
+        Open modal
+      </button>
+      <MoleculeModal
+        isOpen={isOpen}
+        closeOnOutsideClick
+        closeOnEscKeyDown
+        iconClose={<IconClose />}
+        header="Title"
+        onClose={handleClose}
+        isContentless
+        fitContent
+      >
+        <MoleculeModal.Content>
+          <Lorem count={30} />
+        </MoleculeModal.Content>
+
+        <MoleculeModal.Footer>Footer</MoleculeModal.Footer>
+      </MoleculeModal>
+    </div>
+  )
+}
+
+export default ContentlessModal

--- a/demo/molecule/modal/demo/ContentlessModal.js
+++ b/demo/molecule/modal/demo/ContentlessModal.js
@@ -17,7 +17,7 @@ const ContentlessModal = () => {
   }
 
   return (
-    <div>
+    <>
       <button type="button" onClick={handleClick}>
         Open modal
       </button>
@@ -37,7 +37,7 @@ const ContentlessModal = () => {
 
         <MoleculeModal.Footer>Footer</MoleculeModal.Footer>
       </MoleculeModal>
-    </div>
+    </>
   )
 }
 

--- a/demo/molecule/modal/demo/SizeModal.js
+++ b/demo/molecule/modal/demo/SizeModal.js
@@ -1,0 +1,40 @@
+import {useState} from 'react'
+import Button from '../../../../components/atom/button'
+import Modal, {MODAL_SIZES} from '../../../../components/molecule/modal/src'
+
+const SizeModal = () => {
+  const [size, setSize] = useState('')
+  const isOpen = !!size
+
+  const handleClick = size => () => {
+    setSize(size)
+  }
+
+  const handleClose = () => {
+    setSize('')
+  }
+
+  return (
+    <>
+      {Object.values(MODAL_SIZES).map(size => (
+        <Button key="size" onClick={handleClick(size)}>
+          Open {size} modal
+        </Button>
+      ))}
+
+      <Modal
+        isOpen={isOpen}
+        size={size}
+        onClose={handleClose}
+        closeOnOutsideClick
+        closeOnEscKeyDown
+        isContentless
+      >
+        <Modal.Content>Content</Modal.Content>
+        <Modal.Footer>Footer</Modal.Footer>
+      </Modal>
+    </>
+  )
+}
+
+export default SizeModal

--- a/demo/molecule/modal/demo/SizeModal.js
+++ b/demo/molecule/modal/demo/SizeModal.js
@@ -1,6 +1,7 @@
 import {useState} from 'react'
-import Button from '../../../../components/atom/button'
-import Modal, {MODAL_SIZES} from '../../../../components/molecule/modal/src'
+import MoleculeModal, {
+  MODAL_SIZES
+} from '../../../../components/molecule/modal/src'
 
 const SizeModal = () => {
   const [size, setSize] = useState('')
@@ -17,12 +18,12 @@ const SizeModal = () => {
   return (
     <>
       {Object.values(MODAL_SIZES).map(size => (
-        <Button key="size" onClick={handleClick(size)}>
+        <button key="size" onClick={handleClick(size)}>
           Open {size} modal
-        </Button>
+        </button>
       ))}
 
-      <Modal
+      <MoleculeModal
         isOpen={isOpen}
         size={size}
         onClose={handleClose}
@@ -30,9 +31,9 @@ const SizeModal = () => {
         closeOnEscKeyDown
         isContentless
       >
-        <Modal.Content>Content</Modal.Content>
-        <Modal.Footer>Footer</Modal.Footer>
-      </Modal>
+        <MoleculeModal.Content>Content</MoleculeModal.Content>
+        <MoleculeModal.Footer>Footer</MoleculeModal.Footer>
+      </MoleculeModal>
     </>
   )
 }

--- a/demo/molecule/modal/demo/index.js
+++ b/demo/molecule/modal/demo/index.js
@@ -1,5 +1,7 @@
 /* eslint react/prop-types: 0 */
 import ScrollModal from './ScrollModal'
+import ContentlessModal from './ContentlessModal'
+import SizeModal from './SizeModal'
 import NoScrollModal from './NoScrollModal'
 import NoHeaderModal from './NoHeaderModal'
 import WithoutIndentationModal from './WithoutIndentationModal'
@@ -64,6 +66,14 @@ const Demo = () => (
           close himself
         </p>
         <WithUrlStateModal />
+      </div>
+      <h2>Contentless Modal</h2>
+      <div style={fieldStyle}>
+        <ContentlessModal />
+      </div>
+      <h2>Size Modal</h2>
+      <div style={fieldStyle}>
+        <SizeModal />
       </div>
     </div>
   </div>

--- a/demo/molecule/modal/demo/package.json
+++ b/demo/molecule/modal/demo/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "react-lorem-component": "0",
     "@s-ui/react-atom-icon": "1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "fs-extra": "9.0.1",
     "globby": "11.0.1",
     "husky": "4.3.0",
-    "react-lorem-component": "^0.13.0",
     "validate-commit-msg": "2.12.2",
     "walker": "1.0.7"
   },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "fs-extra": "9.0.1",
     "globby": "11.0.1",
     "husky": "4.3.0",
+    "react-lorem-component": "^0.13.0",
     "validate-commit-msg": "2.12.2",
     "walker": "1.0.7"
   },


### PR DESCRIPTION
## Molecule/Modal
**TASK**: None

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [x] Refactor

### Description, Motivation and Context
This PR adds footer and size support. My ideal API for the modal would be something like this using compound components pattern:
```jsx
<Modal isOpen={isOpen} onClose={onClose}>
  <ModalHeader>Title</ModalHeader>
  
  <ModalCloseButton />

  <ModalContent>
    <Lorem count={2} />
  </ModalContent>

  <ModalFooter>
    <Button onClick={onClose}>
      Close
    </Button>
  </ModalFooter>
</Modal>
```

These changes could be a first iteration to reach that point opening the API to use composition using `isContentless` prop. I wanted to **avoid breaking changes** that's the reason why used that prop. Let me know if you think that would be better to create a major.

```jsx
<Modal header="Title" isOpen={isOpen} onClose={onClose} size="medium" isContentless>
  <Modal.Content>
    <Lorem count={2} />
  </Modal.Content>

  <Modal.Footer>
    <Button onClick={onClose}>
      Close
    </Button>
  </Modal.Footer>
</Modal>
```

🚨 Is you use the modal as contentless, you will need to set `enableContentScroll` and `withoutIndentation` props in the `Modal.Content` component instead of `Modal` just to keep it simple I didn't want to create a context for the modal yet.

Use `size` prop to choose a max width. If it's not set it will be like it was. 

### Screenshots - Animations

Scroll with footer

![Screenshot 2020-12-10 at 11 37 54](https://user-images.githubusercontent.com/6877967/101761331-4896f180-3adc-11eb-9842-b29ad75b1389.png)

