### PR TITLE
fix(molecule/modal): add padding to molecule modal content

### DIFF
--- a/components/molecule/modal/src/_settings.scss
+++ b/components/molecule/modal/src/_settings.scss
@@ -48,6 +48,8 @@ $pb-molecule-modal-content: $pt-molecule-modal-content !default;
 $pr-molecule-modal-content: $p-xl !default;
 $pl-molecule-modal-content: $pr-molecule-modal-content !default;
 
+$p-molecule-modal-content: 0 !default;
+
 // maintain backward compatibility in case someone uses any $pX-molecule-modal-content existing variables
 $mt-molecule-modal-content: $pt-molecule-modal-content !default;
 $mb-molecule-modal-content: $pb-molecule-modal-content !default;

--- a/components/molecule/modal/src/index.scss
+++ b/components/molecule/modal/src/index.scss
@@ -189,6 +189,7 @@ body.is-MoleculeModal-open {
     overflow-y: auto;
     margin: $mt-molecule-modal-content $mr-molecule-modal-content 0
       $ml-molecule-modal-content;
+    padding: $p-molecule-modal-content;
     position: relative;
 
     &:after {


### PR DESCRIPTION
## Molecule/Modal


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
In Modal with a large content and a header, margin-top makes that there exists a blank space below header and content scroll goes under that.

### Screenshots - Animations
**Visual bug:**
![image](https://user-images.githubusercontent.com/5390428/102224139-dceec300-3ee5-11eb-9169-51728c3ac4dc.png)
![image](https://user-images.githubusercontent.com/5390428/102224161-e415d100-3ee5-11eb-97c8-56b27c991a11.png)

**(Fix)** Adding a padding we can set margin-top to 0 and add a padding top without fix each component that is using MoleculeModal:
![image](https://user-images.githubusercontent.com/5390428/102223913-9600cd80-3ee5-11eb-8ff6-1c0661f4d077.png)

![image](https://user-images.githubusercontent.com/5390428/102224104-d3fdf180-3ee5-11eb-8f31-77249608b560.png)





