### PR TITLE
feat(molecule/tabs): update default color

### DIFF
--- a/components/molecule/tabs/src/index.scss
+++ b/components/molecule/tabs/src/index.scss
@@ -11,7 +11,7 @@ $bgc-sui-molecule-tabs-active: transparent !default;
 $bgc-sui-molecule-tabs: transparent !default;
 $bt-sui-molecule-tabs-content: $bdw-sui-molecule-tabs-highlighted solid
   $bdc-sui-molecule-tabs-highlighted !default;
-$c-sui-molecule-tabs: $c-gray-light-1 !default;
+$c-sui-molecule-tabs: $c-gray-dark-3 !default;
 $c-sui-molecule-tabs-active: $c-primary !default;
 $c-sui-molecule-tabs-icon-active: $c-primary !default;
 $c-sui-molecule-tabs-disabled: $c-gray-lightest !default;


### PR DESCRIPTION
## MOLECULE/TABS

Default color is not accessibility contrast compliance.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
Default value for `$c-sui-molecule-tabs` has been updated.

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->

The previous color `#999999` had a very poor contrast ratio:

![image](https://user-images.githubusercontent.com/66824007/102470967-e5194080-4054-11eb-9fc4-23363f5ab597.png)

![image](https://user-images.githubusercontent.com/66824007/102471216-3d504280-4055-11eb-89cf-2e2ec8f5f1c4.png)

The updated value `#353535` performs a much higher ratio:

![image](https://user-images.githubusercontent.com/66824007/102471161-26115500-4055-11eb-9063-ad01f4c1e816.png)

![image](https://user-images.githubusercontent.com/66824007/102471272-50631280-4055-11eb-8de8-d0ed3496d40b.png)


