### PR TITLE
feat(atom/button): change margin consecutive buttons by variable value

### DIFF
--- a/components/atom/button/src/index.scss
+++ b/components/atom/button/src/index.scss
@@ -92,6 +92,7 @@ $fw-atom-button-large: $fw-semi-bold !default;
 $icon-sz-atom-button-large: $sz-icon-m !default;
 $icon-m-atom-button-large: $m-m !default;
 $p-atom-button-large: $p-l !default;
+$m-consecutive-atom-button: $m-m !default;
 
 $bd-atom-button-group-focused: 1px solid !default;
 $bdrs-atom-button-first: $bdrs-m 0 0 $bdrs-m !default;
@@ -162,7 +163,7 @@ $icon-stroke-color: currentColor !default;
   white-space: nowrap;
 
   & + & {
-    margin-left: $m-m;
+    margin-left: $m-consecutive-atom-button;
   }
 
   &-group {


### PR DESCRIPTION
## ATOM/COMPONENT
**ISSUE**: [1313](https://github.com/SUI-Components/sui-components/issues/1313)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context

Add a variable to set the margin with several atom buttons at the same html level so it can be modified in each vertical
