### PR TITLE
feat(atom/card): add background variable to atom/card media element

### DIFF
--- a/components/atom/card/src/index.scss
+++ b/components/atom/card/src/index.scss
@@ -9,6 +9,8 @@ $bgc-atom-card-link-hover: $bgc-atom-card-hover !default;
 $bxsh-atom-card-hover: none !default;
 $c-atom-card-highlight: $c-highlight !default;
 $bgc-atom-card-highlight-hover: $bgc-atom-card-hover !default; // using $bgc-atom-card-hover to keep styles backwards compatible
+$bgc-atom-card-media: transparent !default;
+$bg-atom-card-media: $bgc-atom-card-media !default;
 $w-atom-card-media: 33% !default;
 $mr-atom-card-media: 0 !default;
 $mq-responsive-breakpoint-name: 'm' !default;
@@ -35,6 +37,7 @@ $class-media: '#{$base-class}-media';
   }
 
   &-media {
+    background: $bg-atom-card-media;
     margin-right: $mr-atom-card-media;
     width: $w-atom-card-media;
   }

--- a/components/atom/card/src/index.scss
+++ b/components/atom/card/src/index.scss
@@ -9,8 +9,7 @@ $bgc-atom-card-link-hover: $bgc-atom-card-hover !default;
 $bxsh-atom-card-hover: none !default;
 $c-atom-card-highlight: $c-highlight !default;
 $bgc-atom-card-highlight-hover: $bgc-atom-card-hover !default; // using $bgc-atom-card-hover to keep styles backwards compatible
-$bgc-atom-card-media: transparent !default;
-$bg-atom-card-media: $bgc-atom-card-media !default;
+$bg-atom-card-media: transparent !default;
 $w-atom-card-media: 33% !default;
 $mr-atom-card-media: 0 !default;
 $mq-responsive-breakpoint-name: 'm' !default;


### PR DESCRIPTION
## atom/card
N/A

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
Introducing a new sass variables so that we can control the background of the `media` element of the `atom/card` component.

### Screenshots - Animations
Overwriting `$bg-atom-card-media` to `white`:
![image](https://user-images.githubusercontent.com/18154356/102867034-7105e080-4438-11eb-814b-39ad76426e67.png)

Overwriting `$bg-atom-card-media` to `lightgray`:
![image](https://user-images.githubusercontent.com/18154356/102867146-a01c5200-4438-11eb-969d-0ecaf0ae7562.png)

