### PR TITLE
Feat/fix wrap layout grid

### DIFF
--- a/components/layout/grid/src/index.scss
+++ b/components/layout/grid/src/index.scss
@@ -10,10 +10,15 @@
   @include grid-align-items($ai-layout-grid);
   @include grid-justify-content($jc-layout-grid);
 
+  @include media-breakpoint-up(s) {
+    flex-wrap: nowrap;
+  }
+
   &-item {
     box-sizing: border-box;
     flex-grow: 0;
     margin: 0;
+    min-width: 100%;
     padding: 0 $layout-grid-gap;
     @include grid-item-sizes($breakpoints, $grid-columns);
   }

--- a/components/layout/grid/src/index.scss
+++ b/components/layout/grid/src/index.scss
@@ -15,8 +15,6 @@
   }
 
   &-item {
-    box-sizing: border-box;
-    flex-grow: 0;
     margin: 0;
     min-width: 100%;
     padding: 0 $layout-grid-gap;

--- a/demo/layout/grid/demo/demoBox.js
+++ b/demo/layout/grid/demo/demoBox.js
@@ -1,18 +1,19 @@
 import PropTypes from 'prop-types'
 
-const styles = {
+const styles = ({tiny}) => ({
   background: '#09f',
   color: '#fff',
   borderRadius: '8px',
   padding: '16px',
-  minHeight: '120px',
+  minHeight: tiny ? '60px' : '120px',
   margin: '16px 0'
-}
+})
 
-export default function DemoBox({children}) {
-  return <div style={styles}>{children}</div>
+export default function DemoBox({tiny, children}) {
+  return <div style={styles({tiny})}>{children}</div>
 }
 
 DemoBox.propTypes = {
-  children: PropTypes.node.isRequired
+  children: PropTypes.node.isRequired,
+  tiny: PropTypes.bool
 }

--- a/demo/layout/grid/demo/index.js
+++ b/demo/layout/grid/demo/index.js
@@ -17,18 +17,10 @@ export default () => (
           To implement the grid, you need to use the two components it provides
           <code className="sui-Studio-code">{'<LayoutGrid />'}</code> is used as
           a container, while each{' '}
-          <code className="sui-Studio-code">{'<LayoutGridItem />'}</code> will
-          as a cell to define your grid with the size you specify for each one
-          of them.
+          <code className="sui-Studio-code">{'<LayoutGridItem s={3} />'}</code>{' '}
+          will as a cell to define your grid with the size you specify for each
+          one of them.
         </p>
-        <p className="sui-Studio-p">
-          <strong>Example of use:</strong>
-        </p>
-        <pre>
-          <code className="sui-Studio-code">
-            {`<LayoutGrid><LayoutGridItem s={6} /></LayoutGrid>`}
-          </code>
-        </pre>
         <DemoWrapper>
           <LayoutGrid>
             <LayoutGridItem s={6}>
@@ -37,6 +29,8 @@ export default () => (
             <LayoutGridItem s={6}>
               <DemoBox>s:6</DemoBox>
             </LayoutGridItem>
+          </LayoutGrid>
+          <LayoutGrid>
             <LayoutGridItem s={4}>
               <DemoBox>s:4</DemoBox>
             </LayoutGridItem>
@@ -46,6 +40,8 @@ export default () => (
             <LayoutGridItem s={4}>
               <DemoBox>s:4</DemoBox>
             </LayoutGridItem>
+          </LayoutGrid>
+          <LayoutGrid>
             <LayoutGridItem s={3}>
               <DemoBox>s:3</DemoBox>
             </LayoutGridItem>
@@ -58,6 +54,8 @@ export default () => (
             <LayoutGridItem s={3}>
               <DemoBox>s:3</DemoBox>
             </LayoutGridItem>
+          </LayoutGrid>
+          <LayoutGrid>
             <LayoutGridItem s={2}>
               <DemoBox>s:2</DemoBox>
             </LayoutGridItem>
@@ -88,20 +86,18 @@ export default () => (
                 lOffset:6
               </DemoBox>
             </LayoutGridItem>
+          </LayoutGrid>
+          <LayoutGrid>
             <LayoutGridItem s={6} sOffset={6} lOffset={3}>
               <DemoBox>
                 s:6 | sOffset: 6<br />
                 lOffset:3
               </DemoBox>
             </LayoutGridItem>
+          </LayoutGrid>
+          <LayoutGrid>
             <LayoutGridItem s={6}>
               <DemoBox>s:6</DemoBox>
-            </LayoutGridItem>
-            <LayoutGridItem s={3}>
-              <DemoBox>s:3</DemoBox>
-            </LayoutGridItem>
-            <LayoutGridItem s={3}>
-              <DemoBox>s:3</DemoBox>
             </LayoutGridItem>
             <LayoutGridItem s={3}>
               <DemoBox>s:3</DemoBox>
@@ -123,12 +119,16 @@ export default () => (
                 <LayoutGridItem s={12}>
                   <DemoBox>s:12</DemoBox>
                 </LayoutGridItem>
+              </LayoutGrid>
+              <LayoutGrid>
                 <LayoutGridItem s={6}>
                   <DemoBox>s:6</DemoBox>
                 </LayoutGridItem>
                 <LayoutGridItem s={6}>
                   <DemoBox>s:6</DemoBox>
                 </LayoutGridItem>
+              </LayoutGrid>
+              <LayoutGrid>
                 <LayoutGridItem s={3}>
                   <DemoBox>s:3</DemoBox>
                 </LayoutGridItem>
@@ -157,12 +157,16 @@ export default () => (
                 <LayoutGridItem s={3}>
                   <DemoBox>s:3</DemoBox>
                 </LayoutGridItem>
+              </LayoutGrid>
+              <LayoutGrid>
                 <LayoutGridItem s={6}>
                   <DemoBox>s:6</DemoBox>
                 </LayoutGridItem>
                 <LayoutGridItem s={6}>
                   <DemoBox>s:6</DemoBox>
                 </LayoutGridItem>
+              </LayoutGrid>
+              <LayoutGrid>
                 <LayoutGridItem s={12}>
                   <DemoBox>s:12</DemoBox>
                 </LayoutGridItem>
@@ -222,11 +226,11 @@ export default () => (
             </p>
             <DemoWrapper>
               <LayoutGrid alignItems={alignItems}>
-                <LayoutGridItem s={3}>
-                  <DemoBox>s:2</DemoBox>
+                <LayoutGridItem s={4}>
+                  <DemoBox>s:4</DemoBox>
                 </LayoutGridItem>
-                <LayoutGridItem s={3}>
-                  <DemoBox>s:3</DemoBox>
+                <LayoutGridItem s={4}>
+                  <DemoBox tiny>s:4</DemoBox>
                 </LayoutGridItem>
               </LayoutGrid>
             </DemoWrapper>


### PR DESCRIPTION
## LAYOUT/GRID

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context

Problem with expanding columns by their content, when it shouldn´t be.

Now applied the max width for the grid item, without it being extended by children content.

The responsibility of cells expanded is the <Grid />, not the children content.

### Screenshots - Animations

#### Before
![image](https://user-images.githubusercontent.com/1427623/103907349-75e9b600-5101-11eb-9f91-02757c6d3480.png)

#### After
![image](https://user-images.githubusercontent.com/1427623/103907610-c6f9aa00-5101-11eb-8f01-a2f9ae57cfc9.png)

