### PR TITLE
feat(molecule/pagination): add show edges + size

### DIFF
--- a/components/molecule/pagination/src/helpers/pagination/lowRange.js
+++ b/components/molecule/pagination/src/helpers/pagination/lowRange.js
@@ -10,6 +10,7 @@
 const lowRange = ({page, showEdges, showPages, totalPages}) => {
   const lowRangeFixer = Math.floor(showPages / 2)
   let lowRange
+
   if (page % showPages) lowRange = page - (page % showPages)
   else lowRange = page - showPages
 
@@ -18,8 +19,7 @@ const lowRange = ({page, showEdges, showPages, totalPages}) => {
 
     if (lowRange + showPages === page) {
       lowRange = page - lowRangeFixer
-    }
-    if (lowRange === page - 1) {
+    } else if (lowRange === page - 1) {
       lowRange = lowRange - lowRangeFixer
     }
   }

--- a/components/molecule/pagination/src/helpers/pagination/lowRange.js
+++ b/components/molecule/pagination/src/helpers/pagination/lowRange.js
@@ -6,9 +6,25 @@
  * @param {number} params.showPages - Number of pages to display in the range of pages displayed
  * @return {number} lowest number of the assigned range for the page
  */
-const lowRange = ({page, showPages}) => {
-  if (page % showPages) return page - (page % showPages)
-  return page - showPages
+
+const lowRange = ({page, showEdges, showPages, totalPages}) => {
+  const lowRangeFixer = Math.floor(showPages / 2)
+  let lowRange
+  if (page % showPages) lowRange = page - (page % showPages)
+  else lowRange = page - showPages
+
+  if (showEdges) {
+    if (page <= showPages) return 1
+
+    if (lowRange + showPages === page) {
+      lowRange = page - lowRangeFixer
+    }
+    if (lowRange === page - 1) {
+      lowRange = lowRange - lowRangeFixer
+    }
+  }
+
+  return Math.min(lowRange, totalPages - showPages)
 }
 
 export default lowRange

--- a/components/molecule/pagination/src/helpers/pagination/range.js
+++ b/components/molecule/pagination/src/helpers/pagination/range.js
@@ -9,12 +9,19 @@ import highRange from './highRange'
  * @param {number} params.showPages - Number of pages to display in the range of pages displayed
  * @return {number[]} range of page numbers
  */
-const range = ({page, totalPages, showPages}) => {
-  const _lowRange = lowRange({page, showPages})
-  const _highRange = highRange({page, totalPages, showPages})
+const range = ({page, totalPages: totalPagesParam, showEdges, showPages}) => {
+  const totalPages = showEdges ? totalPagesParam - 1 : totalPagesParam
+  const _lowRange = lowRange({page, showEdges, showPages, totalPages})
+  const _highRangeFixer = showPages > totalPages ? totalPages - 1 : showPages
+  const _highRange = showEdges
+    ? _lowRange + _highRangeFixer
+    : highRange({page, totalPages, showPages})
+
   const rangeNumItems =
     _highRange === totalPages ? totalPages - _lowRange : showPages
-  return [...Array.from(new Array(rangeNumItems), (_, i) => _lowRange + i + 1)]
+  return rangeNumItems > 0
+    ? [...Array.from(new Array(rangeNumItems), (_, i) => _lowRange + i + 1)]
+    : []
 }
 
 export default range

--- a/components/molecule/pagination/src/index.js
+++ b/components/molecule/pagination/src/index.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import AtomButton from '@s-ui/react-atom-button'
+import AtomButton, {atomButtonSizes} from '@s-ui/react-atom-button'
 import * as pagination from './helpers/pagination'
 import {
   isValidPage,
@@ -11,6 +11,7 @@ const BASE_CLASS = 'sui-MoleculePagination'
 const CLASS_PREV_BUTTON_ICON = 'sui-MoleculePagination-prevButtonIcon'
 const CLASS_NEXT_BUTTON_ICON = 'sui-MoleculePagination-nextButtonIcon'
 const PAGE_NUMBER_HOLDER = '%{pageNumber}'
+const divider = '···'
 
 const PageButton = ({onSelectPage, page, design, color, ...props}) => {
   const _onSelectPage = e => {
@@ -60,10 +61,12 @@ const MoleculePagination = ({
   compressed = false,
   hideDisabled,
   selectedPageButtonDesign = 'solid',
+  showEdges,
   nonSelectedPageButtonDesign = 'flat',
   prevButtonDesign = 'flat',
   nextButtonDesign = 'flat',
   selectedPageButtonColor = 'primary',
+  size,
   nonSelectedPageButtonColor = 'primary',
   prevButtonColor = 'primary',
   nextButtonColor = 'primary',
@@ -75,7 +78,8 @@ const MoleculePagination = ({
   const paramsPagination = {
     page,
     totalPages,
-    showPages
+    showPages,
+    showEdges
   }
 
   const handleClickNext = e => {
@@ -110,6 +114,7 @@ const MoleculePagination = ({
             design={prevButtonDesign}
             color={prevButtonColor}
             disabled={!prevPage}
+            size={size}
             {...linkProps(prevPage)}
           >
             {PrevButtonIcon && (
@@ -127,31 +132,87 @@ const MoleculePagination = ({
           design={selectedPageButtonDesign}
           color={selectedPageButtonColor}
           onSelectPage={onSelectPage}
+          size={size}
           {...linkProps(page)}
         >
           {page}
         </PageButton>
       ) : (
-        range.map(pageRange => (
-          <PageButton
-            key={pageRange}
-            page={pageRange}
-            design={
-              pageRange === page
-                ? selectedPageButtonDesign
-                : nonSelectedPageButtonDesign
-            }
-            color={
-              pageRange === page
-                ? selectedPageButtonColor
-                : nonSelectedPageButtonColor
-            }
-            onSelectPage={onSelectPage}
-            {...linkProps(pageRange)}
-          >
-            {pageRange}
-          </PageButton>
-        ))
+        <>
+          {showEdges && (
+            <>
+              <PageButton
+                key={1}
+                page={1}
+                design={
+                  page === 1
+                    ? selectedPageButtonDesign
+                    : nonSelectedPageButtonDesign
+                }
+                color={
+                  page === 1
+                    ? selectedPageButtonColor
+                    : nonSelectedPageButtonColor
+                }
+                onSelectPage={onSelectPage}
+                size={size}
+                {...linkProps(1)}
+              >
+                {1}
+              </PageButton>
+              {page > showPages && showPages + 2 < totalPages - 1 && (
+                <li className={`${BASE_CLASS}-divider`}>{divider}</li>
+              )}
+            </>
+          )}
+          {range.map(pageRange => (
+            <PageButton
+              key={pageRange}
+              page={pageRange}
+              design={
+                pageRange === page
+                  ? selectedPageButtonDesign
+                  : nonSelectedPageButtonDesign
+              }
+              color={
+                pageRange === page
+                  ? selectedPageButtonColor
+                  : nonSelectedPageButtonColor
+              }
+              onSelectPage={onSelectPage}
+              size={size}
+              {...linkProps(pageRange)}
+            >
+              {pageRange}
+            </PageButton>
+          ))}
+          {showEdges && totalPages > 1 && (
+            <>
+              {range[range.length - 1] < totalPages - 1 && (
+                <li className={`${BASE_CLASS}-divider`}>{divider}</li>
+              )}
+              <PageButton
+                key={totalPages}
+                page={totalPages}
+                design={
+                  page === totalPages
+                    ? selectedPageButtonDesign
+                    : nonSelectedPageButtonDesign
+                }
+                color={
+                  page === totalPages
+                    ? selectedPageButtonColor
+                    : nonSelectedPageButtonColor
+                }
+                onSelectPage={onSelectPage}
+                size={size}
+                {...linkProps(totalPages)}
+              >
+                {totalPages}
+              </PageButton>
+            </>
+          )}
+        </>
       )}
       {!isHideNext && (
         <li className={`${BASE_CLASS}-item`}>
@@ -160,6 +221,7 @@ const MoleculePagination = ({
             design={nextButtonDesign}
             color={nextButtonColor}
             disabled={!nextPage}
+            size={size}
             {...linkProps(nextPage)}
           >
             {nextButtonText}
@@ -186,6 +248,9 @@ MoleculePagination.propTypes = {
 
   /** Number of pages to be displayed in the range (10 by default) */
   showPages: isValidShowPages,
+
+  /** Size of buttons */
+  size: PropTypes.oneOf(Object.values(atomButtonSizes)),
 
   /** If the pagination should be displayed in compressed mode or not */
   compressed: PropTypes.bool,
@@ -228,6 +293,9 @@ MoleculePagination.propTypes = {
 
   /** Color to be used for the selected page. */
   selectedPageButtonColor: PropTypes.string,
+
+  /** Makes first and last always visible. */
+  showEdges: PropTypes.bool,
 
   /** Color to be used for the selected page. */
   nonSelectedPageButtonColor: PropTypes.string,

--- a/components/molecule/pagination/src/index.js
+++ b/components/molecule/pagination/src/index.js
@@ -11,7 +11,7 @@ const BASE_CLASS = 'sui-MoleculePagination'
 const CLASS_PREV_BUTTON_ICON = 'sui-MoleculePagination-prevButtonIcon'
 const CLASS_NEXT_BUTTON_ICON = 'sui-MoleculePagination-nextButtonIcon'
 const PAGE_NUMBER_HOLDER = '%{pageNumber}'
-const divider = '···'
+const DIVIDER = '···'
 
 const PageButton = ({onSelectPage, page, design, color, ...props}) => {
   const _onSelectPage = e => {
@@ -161,7 +161,7 @@ const MoleculePagination = ({
                 {1}
               </PageButton>
               {page > showPages && showPages + 2 < totalPages - 1 && (
-                <li className={`${BASE_CLASS}-divider`}>{divider}</li>
+                <li className={`${BASE_CLASS}-divider`}>{DIVIDER}</li>
               )}
             </>
           )}
@@ -189,7 +189,7 @@ const MoleculePagination = ({
           {showEdges && totalPages > 1 && (
             <>
               {range[range.length - 1] < totalPages - 1 && (
-                <li className={`${BASE_CLASS}-divider`}>{divider}</li>
+                <li className={`${BASE_CLASS}-divider`}>{DIVIDER}</li>
               )}
               <PageButton
                 key={totalPages}

--- a/components/molecule/pagination/src/index.scss
+++ b/components/molecule/pagination/src/index.scss
@@ -16,10 +16,10 @@ $c-pagination-button-icon-path: inherit !default;
   }
 
   &-divider {
-    margin-left: $m-s;
+    align-items: center;
     display: flex;
     justify-content: center;
-    align-items: center;
+    margin-left: $m-s;
   }
 
   &-prevButtonIcon {

--- a/components/molecule/pagination/src/index.scss
+++ b/components/molecule/pagination/src/index.scss
@@ -15,6 +15,13 @@ $c-pagination-button-icon-path: inherit !default;
     margin-left: $m-s;
   }
 
+  &-divider {
+    margin-left: $m-s;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
   &-prevButtonIcon {
     display: flex;
     margin-right: $m-m;

--- a/demo/molecule/pagination/demo/index.js
+++ b/demo/molecule/pagination/demo/index.js
@@ -46,7 +46,7 @@ const Demo = () => {
           <h3>Large</h3>
           <MoleculePagination totalPages={25} page={17} />
         </div>
-        {/* ------------------------------------------------------------------------------------------------------------- */}
+
         <h2>
           Responsive <code>w/ LayoutMediaQuery</code>
         </h2>
@@ -69,7 +69,7 @@ const Demo = () => {
             }
           </LayoutMediaQuery>
         </div>
-        {/* ------------------------------------------------------------------------------------------------------------- */}
+
         <h2>Dynamic</h2>
         <div className={CLASS_DEMO_SECTION}>
           <h3>Extended Version</h3>
@@ -94,7 +94,7 @@ const Demo = () => {
           <h3>Compressed Version</h3>
           <DynamicMoleculePagination totalPages={25} page={17} compressed />
         </div>
-        {/* ------------------------------------------------------------------------------------------------------------- */}
+
         <h2>Static</h2>
         <h3>Extended Version</h3>
         <div className={CLASS_DEMO_SECTION}>
@@ -210,7 +210,7 @@ const Demo = () => {
           </p>
           <MoleculePagination totalPages={25} page={15} showEdges />
         </div>
-        {/* ------------------------------------------------------------------------------------------------------------- */}
+
         <h3>Compressed Version</h3>
         <div className={CLASS_DEMO_SECTION}>
           <h4>First Page (only next)</h4>

--- a/demo/molecule/pagination/demo/index.js
+++ b/demo/molecule/pagination/demo/index.js
@@ -39,6 +39,14 @@ const Demo = () => {
     <div className="sui-StudioPreview">
       <div className="sui-StudioPreview-content sui-StudioDemo-preview">
         <h1>Pagination</h1>
+        <h2>Size</h2>
+        <div className={CLASS_DEMO_SECTION}>
+          <h3>Small</h3>
+          <MoleculePagination totalPages={25} page={17} size="small" />
+          <h3>Large</h3>
+          <MoleculePagination totalPages={25} page={17} />
+        </div>
+        {/* ------------------------------------------------------------------------------------------------------------- */}
         <h2>
           Responsive <code>w/ LayoutMediaQuery</code>
         </h2>
@@ -61,6 +69,7 @@ const Demo = () => {
             }
           </LayoutMediaQuery>
         </div>
+        {/* ------------------------------------------------------------------------------------------------------------- */}
         <h2>Dynamic</h2>
         <div className={CLASS_DEMO_SECTION}>
           <h3>Extended Version</h3>
@@ -71,6 +80,15 @@ const Demo = () => {
             Extended Version <code>showPages=7</code>
           </h3>
           <DynamicMoleculePagination totalPages={25} page={17} showPages={7} />
+          <h3>
+            Extended Version <code>showEdges</code>
+          </h3>
+          <DynamicMoleculePagination
+            totalPages={25}
+            page={17}
+            showPages={7}
+            showEdges
+          />
         </div>
         <div className={CLASS_DEMO_SECTION}>
           <h3>Compressed Version</h3>
@@ -184,6 +202,13 @@ const Demo = () => {
             {...Texts}
             {...OnClicks}
           />
+        </div>
+        <div className={CLASS_DEMO_SECTION}>
+          <h4>Show edges</h4>
+          <p>
+            <code>totalPages=25 page=15 showEdges</code>
+          </p>
+          <MoleculePagination totalPages={25} page={15} showEdges />
         </div>
         {/* ------------------------------------------------------------------------------------------------------------- */}
         <h3>Compressed Version</h3>


### PR DESCRIPTION
## molecule/pagination
**TASK**: https://jira.scmspain.com/browse/SCMI-52258


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

We have created the prop **size** to control the size of the buttons using the "size" variable of the atomButton.

We have also created the prop **showEdges** to show always the first page and the last one as you have in the picture.

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
**Size**
![image](https://user-images.githubusercontent.com/45338357/104194547-c1fa6a80-5421-11eb-83b8-d5bdcc87585d.png)

**Show edges**
![image](https://user-images.githubusercontent.com/45338357/104195324-c4a98f80-5422-11eb-937c-d9bc82ab8869.png)
![image](https://user-images.githubusercontent.com/45338357/104195407-e1de5e00-5422-11eb-9b00-763f380b4525.png)
![image](https://user-images.githubusercontent.com/45338357/104195306-ba879100-5422-11eb-928a-5605e3323201.png)

