### PR TITLE
feat(atom/switch): remove label prop required

### DIFF
--- a/components/atom/switch/src/SwitchType/single.js
+++ b/components/atom/switch/src/SwitchType/single.js
@@ -49,11 +49,13 @@ export const SingleSwitchTypeRender = forwardRef(
           onBlur={onBlur}
           ref={ref}
         >
-          <AtomLabel
-            name={name}
-            text={label}
-            optionalText={labelOptionalText}
-          />
+          {label && (
+            <AtomLabel
+              name={name}
+              text={label}
+              optionalText={labelOptionalText}
+            />
+          )}
           <div className={suitClass({element: 'inputContainer'})}>
             <div
               className={cx(suitClass({element: 'circle'}), {

--- a/components/atom/switch/src/SwitchType/toggle.js
+++ b/components/atom/switch/src/SwitchType/toggle.js
@@ -45,7 +45,13 @@ export const ToggleSwitchTypeRender = forwardRef(
           disabled
         )}
       >
-        <AtomLabel name={name} text={label} optionalText={labelOptionalText} />
+        {label && (
+          <AtomLabel
+            name={name}
+            text={label}
+            optionalText={labelOptionalText}
+          />
+        )}
         <div
           className={cx(suitClass({element: 'container'}))}
           tabIndex="0"

--- a/components/atom/switch/src/index.js
+++ b/components/atom/switch/src/index.js
@@ -95,7 +95,7 @@ AtomSwitch.propTypes = {
   name: PropTypes.string.isRequired,
 
   /** The label itself. Proxy from label */
-  label: PropTypes.string.isRequired,
+  label: PropTypes.string,
 
   /** The optional label text. Proxy from label */
   labelOptionalText: PropTypes.string,

--- a/components/atom/switch/src/index.scss
+++ b/components/atom/switch/src/index.scss
@@ -73,8 +73,8 @@ $atom-switch-transition-time: 0.3s !default;
   }
 
   &-singleType {
-    .sui-AtomSwitch-inputContainer {
-      margin-left: $m-l;
+    .sui-AtomLabel {
+      margin-right: $m-l;
     }
   }
 


### PR DESCRIPTION
## ATOM/SWITCH

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
If we want to use the AtomSwitch component without any type of label, we can't because `label` prop is required. Also, Switch component has a margin-left margin.

Now, `label` prop is not required and the margin is set on the label (if has). 
