### PR TITLE
fix(molecule/notification): fix useEffect infinte bucle

### DIFF
--- a/components/molecule/notification/src/index.js
+++ b/components/molecule/notification/src/index.js
@@ -75,7 +75,7 @@ const MoleculeNotification = ({
       clearTimeout(autoCloseTimeout.current)
       clearTimeout(transitionTimeout.current)
     }
-  }, [show, triggerAutoClose, effect, autoCloseTimeInSeconds])
+  }, [show, effect, autoCloseTimeInSeconds])
 
   const getButtons = () =>
     buttons


### PR DESCRIPTION
## [MOLECULE]/[NOTIFICATION]

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context

Habia un bucle infinito en el useEffect causado por la dependencia: triggerAutoClose. Para mi no tiene mucho sentido poner una dependencia en el useEffect que sea una funcion que es llamada solo si se cumple una condicion booleana (como en este caso lo es triggerAutoClose que tiene un if), en ese caso, la dependencia que sea la condicion booleana y ya esta, porque puede ocasionar bucles infinitos que llamen todo el rato a ese useEffect, en este caso, parece que pasaba eso
