### PR TITLE
fix(molecule/collapsible): use correct height after load children styles

### DIFF
--- a/components/molecule/collapsible/src/index.js
+++ b/components/molecule/collapsible/src/index.js
@@ -40,13 +40,13 @@ const MoleculeCollapsible = ({
     }
   }
 
+  const offsetHeight = childrenContainer?.current?.offsetHeight
+
   useEffect(() => {
-    const {
-      current: {offsetHeight}
-    } = childrenContainer
+    if (!offsetHeight) return
     setShowButton(offsetHeight >= height)
     setMaxHeight(offsetHeight)
-  }, [height])
+  }, [offsetHeight, height])
   const wrapperClassName = cx(`${BASE_CLASS}`, {
     [`${BASE_CLASS}--withGradient`]: withGradient,
     [COLLAPSED_CLASS]: collapsed


### PR DESCRIPTION
## MOLECULE/COLLAPSIBLE

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context

If children have styles like `padding` or `margin` the MoleculeCollapsible is not calculating height right because of first calc height and after the children load its styles.

### Screenshots - Animations

Example with 8 rows:

#### Before

![image](https://user-images.githubusercontent.com/13108014/104910359-80217500-5989-11eb-9cd3-273a050ba137.png)

#### After

![image](https://user-images.githubusercontent.com/13108014/104910158-333d9e80-5989-11eb-9dde-6ddd18a08cd8.png)
