### PR TITLE
fix(molecule/rating): fix missing background color

### DIFF
--- a/components/molecule/rating/src/index.scss
+++ b/components/molecule/rating/src/index.scss
@@ -42,6 +42,7 @@ $class-label-link: '#{$class-label}Link';
   }
 
   svg {
+    fill: currentColor;
     height: 100%;
     width: 100%;
   }


### PR DESCRIPTION
## [MOLECULE]/[RATING]
**TASK**: [MMAA-18337](https://jira.scmspain.com/browse/MMAA-18337)

### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
This tries to fix the missing background color from the SVGs. The bug was introduced with the changes from this PR [1380](https://github.com/SUI-Components/sui-components/pull/1380/files#diff-364a7c3f28308228c14898936bd71cb8e4cfbcb2f4f626edf52313e6a929117dL37)

### Screenshots - Animations
The icon color should be yellow instead. 
![image](https://user-images.githubusercontent.com/6487058/105733711-1f1e1200-5f32-11eb-9274-b25221f64cda.png)

