### PR TITLE
Bugfix: pass onFileSelected callback by reference

### DIFF
--- a/components/atom/upload/src/index.js
+++ b/components/atom/upload/src/index.js
@@ -33,10 +33,6 @@ const AtomUpload = ({
     setReady(true)
   }, [])
 
-  const handleFileSelectionChange = files => {
-    onFilesSelection(files)
-  }
-
   const renderStatusBlock = status => {
     const classNameIcon = `${BASE_CLASS}-icon${capitalize(status)}`
     const IconStatus = props[`icon${capitalize(status)}`]
@@ -46,40 +42,37 @@ const AtomUpload = ({
     const hasButton = Boolean(Button)
     return (
       <div className={cx(BASE_CLASS, `${BASE_CLASS}--${status}`)}>
-        <>
-          <span className={classNameIcon}>{IconStatus}</span>
-          <div className={CLASS_BLOCK_TEXT}>
-            <h4 className={CLASS_BLOCK_TEXT_MAIN}>{textStatus}</h4>
-            {isActive && (hasTextExplanation || hasButton) && (
-              <>
-                {Button}
-                <p className={CLASS_BLOCK_TEXT_SECONDARY}>{textExplanation}</p>
-              </>
-            )}
-          </div>
-        </>
+        <span className={classNameIcon}>{IconStatus}</span>
+        <div className={CLASS_BLOCK_TEXT}>
+          <h4 className={CLASS_BLOCK_TEXT_MAIN}>{textStatus}</h4>
+          {isActive && (hasTextExplanation || hasButton) && (
+            <>
+              {Button}
+              <p className={CLASS_BLOCK_TEXT_SECONDARY}>{textExplanation}</p>
+            </>
+          )}
+        </div>
       </div>
     )
   }
 
   const hasValidStatus = Object.values(STATUSES).includes(status)
+  const shouldRender = hasValidStatus && ready
   return (
-    <>
-      {hasValidStatus && ready && (
-        <Suspense fallback={null}>
-          <Dropzone
-            accept={accept}
-            className={`${BASE_CLASS}-dropzone`}
-            disabled={status !== STATUSES.ACTIVE}
-            maxSize={maxSize}
-            multiple={multiple}
-            onDrop={handleFileSelectionChange}
-          >
-            {renderStatusBlock(status)}
-          </Dropzone>
-        </Suspense>
-      )}
-    </>
+    shouldRender && (
+      <Suspense fallback={null}>
+        <Dropzone
+          accept={accept}
+          className={`${BASE_CLASS}-dropzone`}
+          disabled={status !== STATUSES.ACTIVE}
+          maxSize={maxSize}
+          multiple={multiple}
+          onDrop={onFilesSelection}
+        >
+          {renderStatusBlock(status)}
+        </Dropzone>
+      </Suspense>
+    )
   )
 }
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
     "test": "sui-studio test",
     "test:watch": "sui-studio test --watch"
   },
-  "repository": {},
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SUI-Components/sui-components"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
We want to pass the received prop `onFileSelected` directly into the Dropzone component.
This is necessary in order to expose all the arguments passed to the function which are the array of successful files, the array of failed files and the triggered event.
