### PR TITLE
feat(molecule/pagination): use left and right icon props from button

### DIFF
--- a/components/molecule/pagination/src/index.js
+++ b/components/molecule/pagination/src/index.js
@@ -8,8 +8,6 @@ import {
 } from './customPropTypes'
 
 const BASE_CLASS = 'sui-MoleculePagination'
-const CLASS_PREV_BUTTON_ICON = 'sui-MoleculePagination-prevButtonIcon'
-const CLASS_NEXT_BUTTON_ICON = 'sui-MoleculePagination-nextButtonIcon'
 const PAGE_NUMBER_HOLDER = '%{pageNumber}'
 const DIVIDER = '···'
 
@@ -117,13 +115,9 @@ const MoleculePagination = ({
             color={prevButtonColor}
             disabled={!prevPage}
             size={size}
+            leftIcon={PrevButtonIcon && <PrevButtonIcon />}
             {...linkProps(prevPage)}
           >
-            {PrevButtonIcon && (
-              <span className={CLASS_PREV_BUTTON_ICON}>
-                <PrevButtonIcon />
-              </span>
-            )}
             {prevButtonText}
           </AtomButton>
         </li>
@@ -224,14 +218,10 @@ const MoleculePagination = ({
             color={nextButtonColor}
             disabled={!nextPage}
             size={size}
+            rightIcon={NextButtonIcon && <NextButtonIcon />}
             {...linkProps(nextPage)}
           >
             {nextButtonText}
-            {NextButtonIcon && (
-              <span className={CLASS_NEXT_BUTTON_ICON}>
-                <NextButtonIcon />
-              </span>
-            )}
           </AtomButton>
         </li>
       )}

--- a/components/molecule/pagination/src/index.scss
+++ b/components/molecule/pagination/src/index.scss
@@ -21,24 +21,4 @@ $c-pagination-button-icon-path: inherit !default;
     justify-content: center;
     margin-left: $m-s;
   }
-
-  &-prevButtonIcon {
-    display: flex;
-    margin-right: $m-m;
-    transform: $trf-pagination-prev-button-icon;
-
-    svg path {
-      fill: $c-pagination-button-icon-path;
-    }
-  }
-
-  &-nextButtonIcon {
-    display: flex;
-    margin-left: $m-m;
-    transform: $trf-pagination-next-button-icon;
-
-    svg path {
-      fill: $c-pagination-button-icon-path;
-    }
-  }
 }


### PR DESCRIPTION
## molecule/pagination

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
This PR uses `leftIcon` and `rightIcon` props from `button` to define custom pagination icons.
- Avoids including not needed css
- Better look and feel out of the box