### PR TITLE
feat(molecule/photoUploader): add border for dropzone when is empty d…

### DIFF
--- a/components/molecule/photoUploader/src/index.js
+++ b/components/molecule/photoUploader/src/index.js
@@ -90,6 +90,7 @@ const MoleculePhotoUploader = ({
     maxImageWidth
   }
 
+  const isPhotoUploaderEmpty = !files.length
   const isPhotoUploaderFully = () => files.length >= maxPhotos
 
   useMount(() => {
@@ -225,7 +226,8 @@ const MoleculePhotoUploader = ({
   })
 
   const dropzoneClassName = cx(DROPZONE_CLASS_NAME, {
-    [`${DROPZONE_CLASS_NAME}--disabled`]: isPhotoUploaderFully()
+    [`${DROPZONE_CLASS_NAME}--disabled`]: isPhotoUploaderFully(),
+    [`${DROPZONE_CLASS_NAME}--empty`]: isPhotoUploaderEmpty
   })
 
   const container = getTarget(document.querySelector(`.${BASE_CLASS_NAME}`))
@@ -250,7 +252,7 @@ const MoleculePhotoUploader = ({
       <div className={BASE_CLASS_NAME}>
         <div {...getRootProps({className: dropzoneClassName})}>
           <input {...getInputProps()} />
-          {Boolean(!files.length) && !isDragActive && (
+          {isPhotoUploaderEmpty && !isDragActive && (
             <InitialState
               buttonColor={addPhotoButtonColor}
               buttonDesign={addPhotoButtonDesign}
@@ -261,7 +263,7 @@ const MoleculePhotoUploader = ({
               dividerText={dragPhotoDividerTextInitialContent}
             />
           )}
-          {Boolean(files.length) && (
+          {!isPhotoUploaderEmpty && (
             <PhotosPreview
               _callbackPhotosUploaded={_callbackPhotosUploaded}
               _scrollToBottom={_scrollToBottom}

--- a/components/molecule/photoUploader/src/index.scss
+++ b/components/molecule/photoUploader/src/index.scss
@@ -82,6 +82,7 @@ $maw-photo-uploader-thumb-drag-text: 200px;
     &--empty {
       border: $bd-photo-uploader-dropzone-empty;
     }
+
     &--disabled {
       cursor: no-drop;
     }

--- a/components/molecule/photoUploader/src/index.scss
+++ b/components/molecule/photoUploader/src/index.scss
@@ -35,6 +35,7 @@ $c-photo-uploader-drag-photo-rejected: $c-white !default;
 $c-photo-uploader-skeleton: $c-primary !default;
 $c-photo-uploader-skeleton-hover: $c-white !default;
 $bd-photo-uploader-dropzone: 0 !default;
+$bd-photo-uploader-dropzone-empty: $bd-photo-uploader-dropzone !default;
 $bdrs-photo-uploader-dropzone: $bdrs-l !default;
 $bdrs-photo-uploader-initial-state: $bdrs-l !default;
 $bg-photo-uploader-initial-state: $bg-photo-uploader !default;
@@ -78,6 +79,9 @@ $maw-photo-uploader-thumb-drag-text: 200px;
       padding: $p-photo-uploader-desktop;
     }
 
+    &--empty {
+      border: $bd-photo-uploader-dropzone-empty;
+    }
     &--disabled {
       cursor: no-drop;
     }


### PR DESCRIPTION
## [molecule]/[photoUploader]


### Types of changes
Add a new scss variable to change the border of the dropzone when this is empty so it is not over the initialState border.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

Before
![image](https://user-images.githubusercontent.com/32937662/107520337-9bab2480-6bb1-11eb-914c-150e25155225.png)

After
![image](https://user-images.githubusercontent.com/32937662/107520369-a36ac900-6bb1-11eb-9b23-c85906b76da5.png)

