### PR TITLE
feat(molecule/radioButtonField): pass fullWidth prop for radio button

### DIFF
--- a/components/molecule/radioButtonField/src/index.js
+++ b/components/molecule/radioButtonField/src/index.js
@@ -15,6 +15,7 @@ const MoleculeRadioButtonField = ({
   helpText,
   onChange,
   onClickLabel,
+  fullWidth,
   ...props
 }) => {
   return (
@@ -29,6 +30,7 @@ const MoleculeRadioButtonField = ({
         helpText={helpText}
         onChange={onChange}
         onClickLabel={onClickLabel}
+        fullWidth={fullWidth}
         inline
         reverse
         isAligned
@@ -70,7 +72,10 @@ MoleculeRadioButtonField.propTypes = {
   helpText: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
 
   /** Boolean to decide if elements should be set inline */
-  inline: PropTypes.bool
+  inline: PropTypes.bool,
+
+  /** Makes nodeLabelContainer full width */
+  fullWidth: PropTypes.bool
 }
 
 export default MoleculeRadioButtonField


### PR DESCRIPTION
## molecule/radioButtonField
**TASK**: Extend the RadioButtonField to accept the fullWidth option.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
This PR allows the RadioButtonField to receive the fullWidth prop and so extend its content to the available space.
It is necessary for a new radio button group where is required to render another component as nodeLabel taking the full space.

### Screenshots - Animations
<img width="688" alt="Screenshot 2021-02-16 at 16 04 43" src="https://user-images.githubusercontent.com/34506779/108080955-b4fc1700-7070-11eb-9858-58dc93f08b4e.png">
