### PR TITLE
feat(atom/popover): add prop disableToggle

### DIFF
--- a/components/atom/popover/src/index.js
+++ b/components/atom/popover/src/index.js
@@ -22,6 +22,7 @@ const Popover = lazy(() => import('reactstrap/lib/Popover'))
 function AtomPopover({
   children,
   closeIcon,
+  disableToggle,
   content,
   id,
   onClose = () => {},
@@ -58,6 +59,11 @@ function AtomPopover({
   }
 
   const handleToggle = () => {
+    !disableToggle && setInternalShowPopover(!internalShowPopover)
+    onClose()
+  }
+
+  const handleOnClickCloseIcon = () => {
     setInternalShowPopover(!internalShowPopover)
     onClose()
   }
@@ -82,7 +88,10 @@ function AtomPopover({
             trigger={DEFAULT_TRIGGER}
           >
             {closeIcon && (
-              <div className={`${BASE_CLASS}-closeIcon`} onClick={handleToggle}>
+              <div
+                className={`${BASE_CLASS}-closeIcon`}
+                onClick={handleOnClickCloseIcon}
+              >
                 {closeIcon}
               </div>
             )}
@@ -107,6 +116,8 @@ AtomPopover.propTypes = {
   id: PropTypes.string,
   /** Custom close icon  */
   closeIcon: PropTypes.node,
+  /** Controlled value for disable toggle  */
+  disableToggle: PropTypes.bool,
   /** On close callback */
   onClose: PropTypes.func,
   /** On open callback */

--- a/components/atom/popover/src/index.js
+++ b/components/atom/popover/src/index.js
@@ -59,8 +59,10 @@ function AtomPopover({
   }
 
   const handleToggle = () => {
-    !disableToggle && setInternalShowPopover(!internalShowPopover)
-    onClose()
+    if (!disableToggle) {
+      setInternalShowPopover(!internalShowPopover)
+      onClose()
+    }
   }
 
   const handleOnClickCloseIcon = () => {

--- a/components/atom/popover/src/index.js
+++ b/components/atom/popover/src/index.js
@@ -79,7 +79,7 @@ function AtomPopover({
             placement={placement}
             placementPrefix={PREFIX_PLACEMENT}
             target={id || targetRef.current}
-            toggle={!disableNativeToggle && handleToggle}
+            toggle={!disableNativeToggle ? handleToggle : undefined}
             trigger={DEFAULT_TRIGGER}
           >
             {closeIcon && (

--- a/components/atom/popover/src/index.js
+++ b/components/atom/popover/src/index.js
@@ -22,7 +22,7 @@ const Popover = lazy(() => import('reactstrap/lib/Popover'))
 function AtomPopover({
   children,
   closeIcon,
-  disableToggle,
+  disableNativeToggle,
   content,
   id,
   onClose = () => {},
@@ -59,13 +59,6 @@ function AtomPopover({
   }
 
   const handleToggle = () => {
-    if (!disableToggle) {
-      setInternalShowPopover(!internalShowPopover)
-      onClose()
-    }
-  }
-
-  const handleOnClickCloseIcon = () => {
     setInternalShowPopover(!internalShowPopover)
     onClose()
   }
@@ -86,14 +79,11 @@ function AtomPopover({
             placement={placement}
             placementPrefix={PREFIX_PLACEMENT}
             target={id || targetRef.current}
-            toggle={handleToggle}
+            toggle={!disableNativeToggle && handleToggle}
             trigger={DEFAULT_TRIGGER}
           >
             {closeIcon && (
-              <div
-                className={`${BASE_CLASS}-closeIcon`}
-                onClick={handleOnClickCloseIcon}
-              >
+              <div className={`${BASE_CLASS}-closeIcon`} onClick={handleToggle}>
                 {closeIcon}
               </div>
             )}
@@ -118,8 +108,8 @@ AtomPopover.propTypes = {
   id: PropTypes.string,
   /** Custom close icon  */
   closeIcon: PropTypes.node,
-  /** Controlled value for disable toggle  */
-  disableToggle: PropTypes.bool,
+  /** Controlled value for to disable the native toggle that is passed to the popover component */
+  disableNativeToggle: PropTypes.bool,
   /** On close callback */
   onClose: PropTypes.func,
   /** On open callback */

--- a/demo/atom/popover/demo/index.js
+++ b/demo/atom/popover/demo/index.js
@@ -57,7 +57,7 @@ const Demo = () => {
           checked={showArrow}
           onChange={ev => setShowArrow(ev.target.checked)}
         />
-        <label className="DemoPopover-label">Disable toggle</label>
+        <label className="DemoPopover-label">Disable native toggle </label>
         <input
           type="checkbox"
           checked={disableNativeToggle}

--- a/demo/atom/popover/demo/index.js
+++ b/demo/atom/popover/demo/index.js
@@ -15,6 +15,7 @@ const Demo = () => {
   const [show, setShow] = useState(false)
   const [closeIcon, setCloseIcon] = useState(true)
   const [showArrow, setShowArrow] = useState(true)
+  const [disableToggle, setDisableToggle] = useState(false)
   const [position, setPosition] = useState(atomPopoverPositions.BOTTOM)
 
   const renderContent = () => (
@@ -56,9 +57,16 @@ const Demo = () => {
           checked={showArrow}
           onChange={ev => setShowArrow(ev.target.checked)}
         />
+        <label className="DemoPopover-label">Disable toggle</label>
+        <input
+          type="checkbox"
+          checked={disableToggle}
+          onChange={ev => setDisableToggle(ev.target.checked)}
+        />
 
         <div className="DemoPopover-buttons">
           <AtomPopover
+            disableToggle={disableToggle}
             closeIcon={closeIcon && <IconClose />}
             hideArrow={!showArrow}
             placement={position}
@@ -69,6 +77,7 @@ const Demo = () => {
             <Button>Show Popover in component without "ref"</Button>
           </AtomPopover>
           <AtomPopover
+            disableToggle={disableToggle}
             closeIcon={closeIcon && <IconClose />}
             hideArrow={!showArrow}
             placement={position}

--- a/demo/atom/popover/demo/index.js
+++ b/demo/atom/popover/demo/index.js
@@ -15,7 +15,7 @@ const Demo = () => {
   const [show, setShow] = useState(false)
   const [closeIcon, setCloseIcon] = useState(true)
   const [showArrow, setShowArrow] = useState(true)
-  const [disableToggle, setDisableToggle] = useState(false)
+  const [disableNativeToggle, setDisableNativeToggle] = useState(false)
   const [position, setPosition] = useState(atomPopoverPositions.BOTTOM)
 
   const renderContent = () => (
@@ -60,13 +60,13 @@ const Demo = () => {
         <label className="DemoPopover-label">Disable toggle</label>
         <input
           type="checkbox"
-          checked={disableToggle}
-          onChange={ev => setDisableToggle(ev.target.checked)}
+          checked={disableNativeToggle}
+          onChange={ev => setDisableNativeToggle(ev.target.checked)}
         />
 
         <div className="DemoPopover-buttons">
           <AtomPopover
-            disableToggle={disableToggle}
+            disableNativeToggle={disableNativeToggle}
             closeIcon={closeIcon && <IconClose />}
             hideArrow={!showArrow}
             placement={position}
@@ -77,7 +77,7 @@ const Demo = () => {
             <Button>Show Popover in component without "ref"</Button>
           </AtomPopover>
           <AtomPopover
-            disableToggle={disableToggle}
+            disableNativeToggle={disableNativeToggle}
             closeIcon={closeIcon && <IconClose />}
             hideArrow={!showArrow}
             placement={position}


### PR DESCRIPTION
## ATOM/POPOVER

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
**Problem**
We want to keep the popover visible until the user forces it to close (by clicking the "X").

**Solution**
We disable the native toggle so that it remains visible even if we perform actions both inside and outside the children by forcing the "X" to be pressed to close it.

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
