### PR TITLE
fix(atom/badge): fix alignment of atom badge icons

### DIFF
--- a/components/atom/badge/src/index.scss
+++ b/components/atom/badge/src/index.scss
@@ -123,6 +123,8 @@ $badge-soft: (
 
   &-icon {
     @include sui-icon--small;
+    align-items: center;
+    display: flex;
     line-height: initial;
     margin-right: $m-atom-badge-s;
     vertical-align: middle;


### PR DESCRIPTION
## ATOM/BADGE
AtomBadge icons are not vertically aligned


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

### Screenshots - Animations
<img width="672" alt="Captura de pantalla 2021-03-04 a las 10 25 13" src="https://user-images.githubusercontent.com/8382981/109942775-ce3dce00-7cd4-11eb-9d3f-2359cda64755.png">
