### PR TITLE
fix(atom/badge): remove margin-right when the icon is on right

### DIFF
--- a/components/atom/badge/src/index.scss
+++ b/components/atom/badge/src/index.scss
@@ -130,6 +130,7 @@ $badge-soft: (
 
     &--iconRight {
       margin-left: $m-atom-badge-s;
+      margin-right: 0;
     }
   }
 


### PR DESCRIPTION
## atom/badge

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context

Remove `margin-right`  to the icon, when the icon is on the right

### Screenshots - Animations

![margin-right](https://user-images.githubusercontent.com/1307927/110320468-a15d2400-8010-11eb-8d9d-61918dee6733.gif)
