### PR TITLE
fix(molecule/thumbnail): fix boolean ref value 

### DIFF
--- a/components/molecule/thumbnail/src/index.js
+++ b/components/molecule/thumbnail/src/index.js
@@ -61,7 +61,7 @@ const MoleculeThumbnail = props => {
           className={LINK_CLASS}
           href={href}
           target={target}
-          rel={target === '_blank' && 'noopener'}
+          rel={target === '_blank' ? 'noopener' : undefined}
         >
           <ImageCaption />
         </Link>


### PR DESCRIPTION
## molecule/thumbnail

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
Fix boolean ref value when a custom target is passed
It removes the warning about boolean values passed to the ref prop for **a** tags

### Screenshots - Animations
<img width="679" alt="Screenshot 2021-03-09 at 16 22 48" src="https://user-images.githubusercontent.com/34506779/110495792-26216e00-80f5-11eb-913e-de4e9a777094.png">

