### PR TITLE
feat(atom/panel): add the ability to set box-shadow to panel through a prop

### DIFF
--- a/components/atom/panel/src/ColorPanel.js
+++ b/components/atom/panel/src/ColorPanel.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import {ALPHA, COLORS, BORDER_RADIUS, BOX_SHADOW} from './constants'
+import {ALPHA, COLORS, BORDER_RADIUS, ELEVATION} from './constants'
 
-const getClassNames = function({color, alpha, rounded, boxShadow}) {
+const getClassNames = function({color, alpha, rounded, elevation}) {
   const BASE_CLASS = 'sui-atom-panel'
   const COLOR_PANEL_CLASS = 'sui-atom-panel-color'
   return cx(
@@ -10,7 +10,7 @@ const getClassNames = function({color, alpha, rounded, boxShadow}) {
     rounded !== BORDER_RADIUS.NONE && `${BASE_CLASS}--rounded-${rounded}`,
     COLOR_PANEL_CLASS,
     color && `${COLOR_PANEL_CLASS}--${color}-${alpha}`,
-    boxShadow !== BOX_SHADOW.NONE && `${BASE_CLASS}--box-shadow-${boxShadow}`
+    elevation !== ELEVATION.NONE && `${BASE_CLASS}--elevation-${elevation}`
   )
 }
 
@@ -25,7 +25,7 @@ ColorPanel.propTypes = {
   color: PropTypes.string,
   alpha: PropTypes.string,
   rounded: PropTypes.oneOf(Object.values(BORDER_RADIUS)),
-  boxShadow: PropTypes.oneOf(Object.values(BOX_SHADOW))
+  elevation: PropTypes.oneOf(Object.values(ELEVATION))
 }
 
 ColorPanel.defaultProps = {

--- a/components/atom/panel/src/ColorPanel.js
+++ b/components/atom/panel/src/ColorPanel.js
@@ -1,15 +1,16 @@
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import {ALPHA, COLORS, BORDER_RADIUS} from './constants'
+import {ALPHA, COLORS, BORDER_RADIUS, BOX_SHADOW} from './constants'
 
-const getClassNames = function({color, alpha, rounded}) {
+const getClassNames = function({color, alpha, rounded, boxShadow}) {
   const BASE_CLASS = 'sui-atom-panel'
   const COLOR_PANEL_CLASS = 'sui-atom-panel-color'
   return cx(
     BASE_CLASS,
     rounded !== BORDER_RADIUS.NONE && `${BASE_CLASS}--rounded-${rounded}`,
     COLOR_PANEL_CLASS,
-    color && `${COLOR_PANEL_CLASS}--${color}-${alpha}`
+    color && `${COLOR_PANEL_CLASS}--${color}-${alpha}`,
+    boxShadow !== BOX_SHADOW.NONE && `${BASE_CLASS}--box-shadow-${boxShadow}`
   )
 }
 
@@ -23,7 +24,8 @@ ColorPanel.propTypes = {
   children: PropTypes.node,
   color: PropTypes.string,
   alpha: PropTypes.string,
-  rounded: PropTypes.oneOf(Object.values(BORDER_RADIUS))
+  rounded: PropTypes.oneOf(Object.values(BORDER_RADIUS)),
+  boxShadow: PropTypes.oneOf(Object.values(BOX_SHADOW))
 }
 
 ColorPanel.defaultProps = {

--- a/components/atom/panel/src/ImagePanel.js
+++ b/components/atom/panel/src/ImagePanel.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import {COLORS, ALPHA, BORDER_RADIUS, BOX_SHADOW} from './constants'
+import {COLORS, ALPHA, BORDER_RADIUS, ELEVATION} from './constants'
 
 const HORIZONTAL_ALIGNMENTS = {
   LEFT: 'left',
@@ -25,7 +25,7 @@ const getClassNames = function({
   overlayAlpha,
   color,
   rounded,
-  boxShadow
+  elevation
 }) {
   const BASE_CLASS = 'sui-atom-panel'
   const IMAGE_PANEL_CLASS = `${BASE_CLASS}-image`
@@ -41,7 +41,7 @@ const getClassNames = function({
       `${BASE_CLASS}--${overlayColorValue}-overlay-${overlayAlphaValue}`,
     `${BASE_CLASS}-color--${color}`,
     resized && `${IMAGE_PANEL_CLASS}--resized`,
-    boxShadow !== BOX_SHADOW.NONE && `${BASE_CLASS}--box-shadow-${boxShadow}`
+    elevation !== ELEVATION.NONE && `${BASE_CLASS}--elevation-${elevation}`
   )
 }
 
@@ -80,7 +80,7 @@ ImagePanel.propTypes = {
    */
   verticalAlign: PropTypes.oneOf(Object.values(VERTICAL_ALIGNMENTS)),
   rounded: PropTypes.oneOf(Object.values(BORDER_RADIUS)),
-  boxShadow: PropTypes.oneOf(Object.values(BOX_SHADOW))
+  elevation: PropTypes.oneOf(Object.values(ELEVATION))
 }
 
 ImagePanel.defaultProps = {

--- a/components/atom/panel/src/ImagePanel.js
+++ b/components/atom/panel/src/ImagePanel.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import {COLORS, ALPHA, BORDER_RADIUS} from './constants'
+import {COLORS, ALPHA, BORDER_RADIUS, BOX_SHADOW} from './constants'
 
 const HORIZONTAL_ALIGNMENTS = {
   LEFT: 'left',
@@ -24,7 +24,8 @@ const getClassNames = function({
   overlayColor,
   overlayAlpha,
   color,
-  rounded
+  rounded,
+  boxShadow
 }) {
   const BASE_CLASS = 'sui-atom-panel'
   const IMAGE_PANEL_CLASS = `${BASE_CLASS}-image`
@@ -39,7 +40,8 @@ const getClassNames = function({
     overlayColor &&
       `${BASE_CLASS}--${overlayColorValue}-overlay-${overlayAlphaValue}`,
     `${BASE_CLASS}-color--${color}`,
-    resized && `${IMAGE_PANEL_CLASS}--resized`
+    resized && `${IMAGE_PANEL_CLASS}--resized`,
+    boxShadow !== BOX_SHADOW.NONE && `${BASE_CLASS}--box-shadow-${boxShadow}`
   )
 }
 
@@ -77,7 +79,8 @@ ImagePanel.propTypes = {
    * Background position y
    */
   verticalAlign: PropTypes.oneOf(Object.values(VERTICAL_ALIGNMENTS)),
-  rounded: PropTypes.oneOf(Object.values(BORDER_RADIUS))
+  rounded: PropTypes.oneOf(Object.values(BORDER_RADIUS)),
+  boxShadow: PropTypes.oneOf(Object.values(BOX_SHADOW))
 }
 
 ImagePanel.defaultProps = {

--- a/components/atom/panel/src/constants.js
+++ b/components/atom/panel/src/constants.js
@@ -24,10 +24,11 @@ const BORDER_RADIUS = {
   XL: 'xl'
 }
 
-const BOX_SHADOW = {
+const ELEVATION = {
   NONE: 'none',
+  S: 's',
   M: 'm',
   L: 'l'
 }
 
-export {COLORS, ALPHA, BORDER_RADIUS, BOX_SHADOW}
+export {COLORS, ALPHA, BORDER_RADIUS, ELEVATION}

--- a/components/atom/panel/src/constants.js
+++ b/components/atom/panel/src/constants.js
@@ -24,4 +24,10 @@ const BORDER_RADIUS = {
   XL: 'xl'
 }
 
-export {COLORS, ALPHA, BORDER_RADIUS}
+const BOX_SHADOW = {
+  NONE: 'none',
+  M: 'm',
+  L: 'l'
+}
+
+export {COLORS, ALPHA, BORDER_RADIUS, BOX_SHADOW}

--- a/components/atom/panel/src/index.js
+++ b/components/atom/panel/src/index.js
@@ -4,7 +4,7 @@ import ImagePanel, {
   HORIZONTAL_ALIGNMENTS,
   VERTICAL_ALIGNMENTS
 } from './ImagePanel'
-import {COLORS, ALPHA, BORDER_RADIUS} from './constants'
+import {COLORS, ALPHA, BORDER_RADIUS, BOX_SHADOW} from './constants'
 
 const isImagePanel = function({src}) {
   return !!src
@@ -37,13 +37,18 @@ AtomPanel.propTypes = {
   /**
    * Specify the border-radius of the panel
    */
-  rounded: PropTypes.oneOf(Object.values(BORDER_RADIUS))
+  rounded: PropTypes.oneOf(Object.values(BORDER_RADIUS)),
+  /**
+   * Specify the box-shadow of the panel
+   */
+  boxShadow: PropTypes.oneOf(Object.values(BOX_SHADOW))
 }
 
 AtomPanel.defaultProps = {
   horizontalAlign: HORIZONTAL_ALIGNMENTS.CENTER,
   verticalAlign: VERTICAL_ALIGNMENTS.CENTER,
-  rounded: BORDER_RADIUS.NONE
+  rounded: BORDER_RADIUS.NONE,
+  boxShadow: BOX_SHADOW.NONE
 }
 
 export default AtomPanel
@@ -52,5 +57,6 @@ export {
   VERTICAL_ALIGNMENTS as atomPanelVerticalAlign,
   COLORS as atomPanelColors,
   ALPHA as atomPanelAlpha,
-  BORDER_RADIUS as atomPanelRounded
+  BORDER_RADIUS as atomPanelRounded,
+  BOX_SHADOW as atomPanelBoxShadow
 }

--- a/components/atom/panel/src/index.js
+++ b/components/atom/panel/src/index.js
@@ -4,7 +4,7 @@ import ImagePanel, {
   HORIZONTAL_ALIGNMENTS,
   VERTICAL_ALIGNMENTS
 } from './ImagePanel'
-import {COLORS, ALPHA, BORDER_RADIUS, BOX_SHADOW} from './constants'
+import {COLORS, ALPHA, BORDER_RADIUS, ELEVATION} from './constants'
 
 const isImagePanel = function({src}) {
   return !!src
@@ -41,14 +41,14 @@ AtomPanel.propTypes = {
   /**
    * Specify the box-shadow of the panel
    */
-  boxShadow: PropTypes.oneOf(Object.values(BOX_SHADOW))
+  elevation: PropTypes.oneOf(Object.values(ELEVATION))
 }
 
 AtomPanel.defaultProps = {
   horizontalAlign: HORIZONTAL_ALIGNMENTS.CENTER,
   verticalAlign: VERTICAL_ALIGNMENTS.CENTER,
   rounded: BORDER_RADIUS.NONE,
-  boxShadow: BOX_SHADOW.NONE
+  elevation: ELEVATION.NONE
 }
 
 export default AtomPanel
@@ -58,5 +58,5 @@ export {
   COLORS as atomPanelColors,
   ALPHA as atomPanelAlpha,
   BORDER_RADIUS as atomPanelRounded,
-  BOX_SHADOW as atomPanelBoxShadow
+  ELEVATION as atomPanelElevation
 }

--- a/components/atom/panel/src/index.scss
+++ b/components/atom/panel/src/index.scss
@@ -5,7 +5,8 @@ $bdrs-atom-panel-rounded: (
   'l': $bdrs-m * 2,
   'xl': $bdrs-m * 3
 ) !default;
-$bxsh-atom-panel: (
+$bxsh-atom-panel-elevation: (
+  's': $bxsh-s,
   'm': $bxsh-m,
   'l': $bxsh-l
 ) !default;
@@ -36,8 +37,8 @@ $vertical-alignments-atom-panel: ('top', 'center', 'bottom') !default;
     }
   }
 
-  @each $type, $attr in $bxsh-atom-panel {
-    &--box-shadow-#{$type} {
+  @each $type, $attr in $bxsh-atom-panel-elevation {
+    &--elevation-#{$type} {
       box-shadow: $attr;
     }
   }

--- a/components/atom/panel/src/index.scss
+++ b/components/atom/panel/src/index.scss
@@ -5,6 +5,10 @@ $bdrs-atom-panel-rounded: (
   'l': $bdrs-m * 2,
   'xl': $bdrs-m * 3
 ) !default;
+$bxsh-atom-panel: (
+  'm': $bxsh-m,
+  'l': $bxsh-l
+) !default;
 $bgc-atom-panel: color-variation($c-gray, -2) !default;
 $bgc-panels: (
   'canvas': $c-white,
@@ -29,6 +33,12 @@ $vertical-alignments-atom-panel: ('top', 'center', 'bottom') !default;
   @each $type, $attr in $bdrs-atom-panel-rounded {
     &--rounded-#{$type} {
       border-radius: $attr;
+    }
+  }
+
+  @each $type, $attr in $bxsh-atom-panel {
+    &--box-shadow-#{$type} {
+      box-shadow: $attr;
     }
   }
 

--- a/demo/atom/panel/playground
+++ b/demo/atom/panel/playground
@@ -65,7 +65,7 @@ return (
         )
       }
       </div>
-      <h3>With box-shadow</h3>
+      <h3>Elevated</h3>
       <div style={{
         backgroundColor: 'white',
         display: 'flex',
@@ -73,12 +73,12 @@ return (
         justifyContent: 'center'
       }}>
       {
-        Object.keys(atomPanelBoxShadow).map((boxShadow, idx) =>
+        Object.keys(atomPanelElevation).map((elevation, idx) =>
           <div key={idx} style={{flex: '0 0 auto', textAlign: 'center', margin: '15px'}}>
-            <AtomPanel boxShadow={atomPanelBoxShadow[boxShadow]} floating>
+            <AtomPanel elevation={atomPanelElevation[elevation]} floating>
               <div style={{height: '100px', width: '100px'}} />
             </AtomPanel>
-            <span style={{color: 'grey'}}>{atomPanelBoxShadow[boxShadow]}</span>
+            <span style={{color: 'grey'}}>{atomPanelElevation[elevation]}</span>
           </div>
         )
       }
@@ -152,7 +152,7 @@ return (
         )
       }
       </div>
-      <h3>With box-shadow</h3>
+      <h3>Elevated</h3>
       <div style={{
         backgroundColor: 'white',
         display: 'flex',
@@ -160,12 +160,12 @@ return (
         justifyContent: 'center'
       }}>
       {
-        Object.keys(atomPanelBoxShadow).map((boxShadow, idx) =>
+        Object.keys(atomPanelElevation).map((elevation, idx) =>
           <div key={idx} style={{flex: '0 0 auto', textAlign: 'center', margin: '15px'}}>
-            <AtomPanel src={'https://picsum.photos/250/200'} boxShadow={atomPanelBoxShadow[boxShadow]} floating>
+            <AtomPanel src={'https://picsum.photos/250/200'} elevation={atomPanelElevation[elevation]} floating>
               <div style={{height: '100px', width: '100px'}} />
             </AtomPanel>
-            <span style={{color: 'grey'}}>{atomPanelBoxShadow[boxShadow]}</span>
+            <span style={{color: 'grey'}}>{atomPanelElevation[elevation]}</span>
           </div>
         )
       }

--- a/demo/atom/panel/playground
+++ b/demo/atom/panel/playground
@@ -65,6 +65,24 @@ return (
         )
       }
       </div>
+      <h3>With box-shadow</h3>
+      <div style={{
+        backgroundColor: 'white',
+        display: 'flex',
+        flexWrap: 'wrap',
+        justifyContent: 'center'
+      }}>
+      {
+        Object.keys(atomPanelBoxShadow).map((boxShadow, idx) =>
+          <div key={idx} style={{flex: '0 0 auto', textAlign: 'center', margin: '15px'}}>
+            <AtomPanel boxShadow={atomPanelBoxShadow[boxShadow]} floating>
+              <div style={{height: '100px', width: '100px'}} />
+            </AtomPanel>
+            <span style={{color: 'grey'}}>{atomPanelBoxShadow[boxShadow]}</span>
+          </div>
+        )
+      }
+      </div>
       <h3>Container example</h3>
       <div style={flexWrapper}>
         <div style={flexItem}>
@@ -130,6 +148,24 @@ return (
               <div style={{height: '100px', width: '100px'}} />
             </AtomPanel>
             <span style={{color: 'grey'}}>{atomPanelRounded[rounded]}</span>
+          </div>
+        )
+      }
+      </div>
+      <h3>With box-shadow</h3>
+      <div style={{
+        backgroundColor: 'white',
+        display: 'flex',
+        flexWrap: 'wrap',
+        justifyContent: 'center'
+      }}>
+      {
+        Object.keys(atomPanelBoxShadow).map((boxShadow, idx) =>
+          <div key={idx} style={{flex: '0 0 auto', textAlign: 'center', margin: '15px'}}>
+            <AtomPanel src={'https://picsum.photos/250/200'} boxShadow={atomPanelBoxShadow[boxShadow]} floating>
+              <div style={{height: '100px', width: '100px'}} />
+            </AtomPanel>
+            <span style={{color: 'grey'}}>{atomPanelBoxShadow[boxShadow]}</span>
           </div>
         )
       }


### PR DESCRIPTION
## atom/panel

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
Add the posibility to set box shadow to panel using a new prop called boxShadow. 
It will use the box shadow values defined in the sui-theme (m and l)

### Screenshots - Animations
![Captura de pantalla 2021-03-18 a las 10 25 10](https://user-images.githubusercontent.com/10154499/111603072-44155f80-87d4-11eb-9c80-dc1276f07c95.png)


