### PR TITLE
fix(layout/grid): gutter identation bug

### DIFF
--- a/components/layout/grid/src/_settings.scss
+++ b/components/layout/grid/src/_settings.scss
@@ -20,7 +20,7 @@ $jc-layout-grid: flex-start center flex-end space-between space-around;
 }
 
 @mixin grid-item-gutter($base-class, $m-base, $gutter) {
-  #{$base-class}-item {
+  > #{$base-class}-item {
     padding: 0 $m-base * $gutter;
   }
 }


### PR DESCRIPTION
## LAYOUT/GRID
**TASK**: <!--- [jira TASK ID](jiraURL) -->


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
when using idented grids with gutter definition in both, the inner gutter padding rule of the grid is failing. 
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
