### PR TITLE
fix(molecule/selectPopover): prevent select part from being selected

### DIFF
--- a/components/molecule/selectPopover/src/index.scss
+++ b/components/molecule/selectPopover/src/index.scss
@@ -34,6 +34,7 @@ $cur-select-popover-select: auto !default;
     justify-content: space-between;
     max-width: $mw-select-popover;
     padding: $p-m $p-l;
+    user-select: none;
 
     &Text {
       overflow: hidden;


### PR DESCRIPTION
## molecule/selectPopover

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
The select part of the `molecule/selectPopover` is an interactive element and the user should never be able to select its text. In fact, this can accidentally happen when clicking around, which may be annoying to some people.

### Screenshots - Animations
![Screenshot 2021-03-23 at 14 33 08](https://user-images.githubusercontent.com/4168389/112155213-600a6e00-8be5-11eb-8bc8-f80690ef750b.png)

