### PR TITLE
feat(atom/input): add password right element

### DIFF
--- a/components/atom/input/src/Password/index.js
+++ b/components/atom/input/src/Password/index.js
@@ -1,4 +1,4 @@
-import {useState} from 'react'
+import {useState, isValidElement, cloneElement} from 'react'
 import PropTypes from 'prop-types'
 import Input from '../Input'
 
@@ -11,7 +11,24 @@ const PASSWORD = 'password'
 const HIDE_LABEL = 'hide'
 const SHOW_LABEL = 'show'
 
-const Password = ({onChange, pwShowLabel, pwHideLabel, ...props}) => {
+const PasswordRightButton = props => {
+  return (
+    <div
+      role="button"
+      tabIndex="0"
+      className={CLASS_PASSWORD_TOGGLE_BUTTON}
+      {...props}
+    />
+  )
+}
+
+const Password = ({
+  onChange,
+  pwShowLabel,
+  pwHideLabel,
+  rightElement,
+  ...props
+}) => {
   const [type, setType] = useState(PASSWORD)
   const [value, setValue] = useState('')
 
@@ -28,14 +45,21 @@ const Password = ({onChange, pwShowLabel, pwHideLabel, ...props}) => {
   return (
     <div className={CLASS_PASSWORD}>
       <Input {...props} onChange={handleChange} value={value} type={type} />
-      <div onClick={toggle} className={CLASS_PASSWORD_TOGGLE_BUTTON}>
-        {type === PASSWORD ? pwShowLabel : pwHideLabel}
-      </div>
+
+      {isValidElement(rightElement) ? (
+        cloneElement(rightElement, {onClick: toggle})
+      ) : (
+        <PasswordRightButton onClick={toggle}>
+          {type === PASSWORD ? pwShowLabel : pwHideLabel}
+        </PasswordRightButton>
+      )}
     </div>
   )
 }
 
 Password.propTypes = {
+  /* Element to be placed to right of the input */
+  rightElement: PropTypes.element,
   /* Text to be shown in order to show the password on click */
   pwShowLabel: PropTypes.string,
   /* Text to be shown in order to hide the password on click */
@@ -53,5 +77,7 @@ Password.defaultProps = {
   pwHideLabel: HIDE_LABEL,
   onChange: () => {}
 }
+
+Password.RightButton = PasswordRightButton
 
 export default Password


### PR DESCRIPTION
## Atom/Input
**TASK**: None


### Types of changes
Add `rightElement` prop to `Password` component

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
I need to be able to add `aria-label` to the button and a custom icon

### Screenshots - Animations

![Mar-19-2021 13-54-02](https://media.github.mpi-internal.com/user/3370/files/9f218200-88ba-11eb-96db-67b6b59446fb)
