### PR TITLE
fix(atom/tag): fix secondary icon position

### DIFF
--- a/components/atom/tag/src/index.scss
+++ b/components/atom/tag/src/index.scss
@@ -13,7 +13,9 @@
   @if $type == 'icon' {
     margin: 0 $m-s 0 (-$m-m);
   } @else if $type == 'icon-secondary' {
+    display: inline-block;
     margin: 0 (-$m-m) 0 $m-m;
+    vertical-align: middle;
   }
 }
 


### PR DESCRIPTION
## [ATOM]/[TAG]


### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Description, Motivation and Context
The previous change that has been uploaded to solve a problem with the positioning of the main icons, has caused an unexpected behavior with the positioning of the secondary icons.

### Screenshots - Animations
#### BEFORE
![image](https://user-images.githubusercontent.com/31726966/113284743-5de19700-92ea-11eb-897a-82c1eb282022.png)

#### AFTER
![image](https://user-images.githubusercontent.com/31726966/113284790-72259400-92ea-11eb-9751-e9e56882be4b.png)


