### PR TITLE
feat(molecule/inputTags): add a prop to avoid entering the same tag more than once

### DIFF
--- a/components/molecule/inputTags/README.md
+++ b/components/molecule/inputTags/README.md
@@ -1,6 +1,6 @@
 # MoleculeInputTags
 
-`MoleculeInputTags` is an `AtomInput` with the behavior of adding/removing `AtomTag` as a list 
+`MoleculeInputTags` is an `AtomInput` with the behavior of adding/removing `AtomTag` as a list
 
 ## Installation
 
@@ -12,7 +12,7 @@ $ npm install @s-ui/react-molecule-input-tags --save
 
 ```js
 import MoleculeInputTags from '@s-ui/react-molecule-input-tags'
-const closeIcon = () => <span>X</span>  
+const closeIcon = () => <span>X</span>
 ```
 
 ### Basic usage
@@ -39,6 +39,22 @@ All props of `AtomInput` can also be passed to `MoleculeInputTags`
 
 ```js
 <MoleculeInputTags tagsCloseIcon={closeIcon} errorState={true} />
+```
+
+### Just unique values
+
+You can set `allowDuplicates` to false to force unique values
+
+```js
+<MoleculeInputTags allowDuplicates={false} />
+```
+
+### Max tags
+
+use `maxTags` prop to set a number of maximum tags that can be entered, after reaching that number the field gets disabled
+
+```js
+<MoleculeInputTags maxTags={3} />
 ```
 
 

--- a/components/molecule/inputTags/src/index.js
+++ b/components/molecule/inputTags/src/index.js
@@ -70,7 +70,7 @@ const MoleculeInputTags = ({
     ev.preventDefault()
     if (value) {
       const tags = [...tagsFromProps]
-      if (allowDuplicates || (!allowDuplicates && !isDuplicate(tags, value))) {
+      if (allowDuplicates || !isDuplicate(tags, value)) {
         tags.push(value)
       }
       onChangeTags(ev, {tags, name, value: ''})

--- a/components/molecule/inputTags/src/index.js
+++ b/components/molecule/inputTags/src/index.js
@@ -18,6 +18,11 @@ const AtomTagItem = ({onClose = () => {}, id, ...restProps}) => {
   return <AtomTag onClose={handleClose} {...restProps} />
 }
 
+const isDuplicate = (values, newValue) => {
+  const upperTags = values.map(val => val.toUpperCase())
+  return upperTags.includes(newValue.toUpperCase())
+}
+
 const MoleculeInputTags = ({
   errorState,
   innerRefInput,
@@ -31,6 +36,7 @@ const MoleculeInputTags = ({
   maxTags,
   placeholder,
   disabled,
+  allowDuplicates,
   ...restProps
 }) => {
   const [focus, setFocus] = useState(false)
@@ -63,7 +69,10 @@ const MoleculeInputTags = ({
     const {name} = ev.target
     ev.preventDefault()
     if (value) {
-      const tags = [...tagsFromProps, value]
+      const tags = [...tagsFromProps]
+      if (allowDuplicates || (!allowDuplicates && !isDuplicate(tags, value))) {
+        tags.push(value)
+      }
       onChangeTags(ev, {tags, name, value: ''})
     }
   }
@@ -143,7 +152,10 @@ MoleculeInputTags.propTypes = {
   maxTags: PropTypes.number,
 
   /* prop to indicate that the field is disable (will not render the input) */
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+
+  /* prop to determinate if the field allows to introduce duplicate values for the tags (case insensitive) */
+  allowDuplicates: PropTypes.bool
 }
 
 MoleculeInputTags.defaultProps = {
@@ -153,7 +165,8 @@ MoleculeInputTags.defaultProps = {
   onChangeTags: () => {},
   onChange: () => {},
   placeholder: '',
-  disabled: false
+  disabled: false,
+  allowDuplicates: true
 }
 
 export default MoleculeInputTags

--- a/demo/molecule/inputTags/demo/index.js
+++ b/demo/molecule/inputTags/demo/index.js
@@ -184,6 +184,22 @@ const Demo = () => {
             disabled
           />
         </div>
+        <div className={CLASS_DEMO_SECTION}>
+          <h4>with allowDuplicates = false </h4>
+          <MoleculeInputTagsWithState
+            name="inputTagsBeatles1"
+            tagsCloseIcon={<CloseIcon />}
+            onChangeTags={(_, {tags, name}) => {
+              console.log({[`onChangeTags___${name}`]: tags})
+            }}
+            maxTags={5}
+            tags={beatles}
+            value="George Martin"
+            placeHolderText="Placeholder text"
+            innerRefInput={basicInputEl}
+            allowDuplicates={false}
+          />
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## MOLECULE/INPUTTAGS

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
We have the requirement to use this component in a way that we could ensure that the user is not able to enter the same value more than once.
Added a prop with default value true to avoid messing up with current implementation and add a check that if the new value is not duplicate its pushed into the tags array, if not the event its sent with the previous values
Not pretty sure about the naming on the prop/func so any input is welcome