### PR TITLE
fix(atom/tag): add text-decoration: none to actionable tags according to UX def

### DIFF
--- a/components/atom/tag/src/index.scss
+++ b/components/atom/tag/src/index.scss
@@ -101,6 +101,7 @@ $base-class: '.sui-AtomTag';
     color: $c-atom-tag-actionable;
     cursor: pointer;
     fill: $c-atom-tag-actionable;
+    text-decoration: none;
 
     &:hover,
     &:active {


### PR DESCRIPTION


## ATOM/TAG
**TASK**: Related to issue https://github.com/SUI-Components/sui-components/issues/1461


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
In agreement with UX, actionable `atom/tag` shouldn't be underlined. 

### Screenshots - Animations
Before:
![image](https://user-images.githubusercontent.com/18154356/114547645-f965f680-9c5e-11eb-8f03-7eb4f2f7c565.png)

After:
![image](https://user-images.githubusercontent.com/18154356/114547689-01be3180-9c5f-11eb-9000-00e01316e2eb.png)


