### PR TITLE
feat(atom/panel): add new background colors: success, alert, error

### DIFF
--- a/components/atom/panel/src/ColorPanel.js
+++ b/components/atom/panel/src/ColorPanel.js
@@ -22,16 +22,10 @@ ColorPanel.displayName = 'ColorPanel'
 
 ColorPanel.propTypes = {
   children: PropTypes.node,
-  color: PropTypes.string,
-  alpha: PropTypes.string,
+  color: PropTypes.oneOf(Object.values(COLORS)),
+  alpha: PropTypes.oneOf(Object.values(ALPHA)),
   rounded: PropTypes.oneOf(Object.values(BORDER_RADIUS)),
   elevation: PropTypes.oneOf(Object.values(ELEVATION))
-}
-
-ColorPanel.defaultProps = {
-  alpha: ALPHA.CONTRAST,
-  color: COLORS.DEFAULT,
-  rounded: BORDER_RADIUS.NONE
 }
 
 export default ColorPanel

--- a/components/atom/panel/src/ImagePanel.js
+++ b/components/atom/panel/src/ImagePanel.js
@@ -22,7 +22,7 @@ const getClassNames = function({
   horizontalAlign,
   resized,
   overlayColor,
-  overlayAlpha,
+  overlayAlpha = DEFAULT_ALPHA,
   color,
   rounded,
   elevation
@@ -81,12 +81,6 @@ ImagePanel.propTypes = {
   verticalAlign: PropTypes.oneOf(Object.values(VERTICAL_ALIGNMENTS)),
   rounded: PropTypes.oneOf(Object.values(BORDER_RADIUS)),
   elevation: PropTypes.oneOf(Object.values(ELEVATION))
-}
-
-ImagePanel.defaultProps = {
-  overlayAlpha: DEFAULT_ALPHA,
-  color: COLORS.DEFAULT,
-  rounded: BORDER_RADIUS.NONE
 }
 
 export default ImagePanel

--- a/components/atom/panel/src/constants.js
+++ b/components/atom/panel/src/constants.js
@@ -6,7 +6,10 @@ const COLORS = {
   CONTRAST: 'contrast',
   CORPORATE: 'corporate',
   DEFAULT: 'default',
-  HIGHLIGHT: 'highlight'
+  HIGHLIGHT: 'highlight',
+  SUCCESS: 'success',
+  ALERT: 'alert',
+  ERROR: 'error'
 }
 
 const ALPHA = {

--- a/components/atom/panel/src/index.js
+++ b/components/atom/panel/src/index.js
@@ -10,11 +10,34 @@ const isImagePanel = function({src}) {
   return !!src
 }
 
-const AtomPanel = function(props) {
-  return isImagePanel(props) ? (
-    <ImagePanel {...props} />
+const AtomPanel = function({
+  alpha = ALPHA.CONTRAST,
+  color = COLORS.DEFAULT,
+  elevation = ELEVATION.NONE,
+  horizontalAlign = HORIZONTAL_ALIGNMENTS.CENTER,
+  rounded = BORDER_RADIUS.NONE,
+  src,
+  verticalAlign = VERTICAL_ALIGNMENTS.CENTER,
+  ...props
+}) {
+  return isImagePanel({src}) ? (
+    <ImagePanel
+      color={color}
+      elevation={elevation}
+      horizontalAlign={horizontalAlign}
+      rounded={rounded}
+      src={src}
+      verticalAlign={verticalAlign}
+      {...props}
+    />
   ) : (
-    <ColorPanel {...props} />
+    <ColorPanel
+      alpha={alpha}
+      color={color}
+      elevation={elevation}
+      rounded={rounded}
+      {...props}
+    />
   )
 }
 
@@ -50,13 +73,6 @@ AtomPanel.propTypes = {
    * Specify the opacity
    */
   alpha: PropTypes.oneOf(Object.values(ALPHA))
-}
-
-AtomPanel.defaultProps = {
-  horizontalAlign: HORIZONTAL_ALIGNMENTS.CENTER,
-  verticalAlign: VERTICAL_ALIGNMENTS.CENTER,
-  rounded: BORDER_RADIUS.NONE,
-  elevation: ELEVATION.NONE
 }
 
 export default AtomPanel

--- a/components/atom/panel/src/index.js
+++ b/components/atom/panel/src/index.js
@@ -41,7 +41,15 @@ AtomPanel.propTypes = {
   /**
    * Specify the box-shadow of the panel
    */
-  elevation: PropTypes.oneOf(Object.values(ELEVATION))
+  elevation: PropTypes.oneOf(Object.values(ELEVATION)),
+  /**
+   * Specify the background-color
+   */
+  color: PropTypes.oneOf(Object.values(COLORS)),
+  /**
+   * Specify the opacity
+   */
+  alpha: PropTypes.oneOf(Object.values(ALPHA))
 }
 
 AtomPanel.defaultProps = {

--- a/components/atom/panel/src/index.scss
+++ b/components/atom/panel/src/index.scss
@@ -19,7 +19,10 @@ $bgc-panels: (
   'base': color-variation($c-gray, 3),
   'dark': color-variation($c-gray, -1),
   'default': $c-gray-lightest,
-  'highlight': color-variation($c-accent, 4)
+  'highlight': color-variation($c-accent, 4),
+  'success': $c-success,
+  'alert': $c-alert,
+  'error': $c-error
 ) !default;
 $c-atom-panel: $c-black !default;
 $horizontal-alignments-atom-panel: ('left', 'center', 'right') !default;


### PR DESCRIPTION
## atom/panel

Add new background colors: success, alert, and error.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context

I add three semantic background colors, existing in sui-theme: $c-success, $c-alert, $c-error.
We have the need to show in the panel the success of the user interaction with some use cases. We don't need alert and error background, but I think I could add them too.

### Screenshots - Animations

![Captura de pantalla 2021-04-19 a las 12 10 31](https://user-images.githubusercontent.com/37936498/115219942-47b84100-a108-11eb-95eb-8c3c95523d68.png)
