### PR TITLE
feat(atom/tag): disable prop in atom tag

### DIFF
--- a/components/atom/tag/src/Actionable/Container.js
+++ b/components/atom/tag/src/Actionable/Container.js
@@ -9,15 +9,25 @@ const ActionableTagContainer = ({
   href,
   target,
   rel,
+  disabled,
   children,
   ...props
 }) => {
-  return href ? (
-    <Link href={href} target={target} rel={rel} {...props}>
+  return href && !disabled ? (
+    <Link
+      role="button"
+      href={href}
+      target={target}
+      rel={rel}
+      disabled={disabled}
+      {...props}
+    >
       {children}
     </Link>
   ) : (
-    <span {...props}>{children}</span>
+    <span role="button" {...props} disabled={disabled}>
+      {children}
+    </span>
   )
 }
 
@@ -26,6 +36,7 @@ ActionableTagContainer.propTypes = {
   href: PropTypes.string,
   target: PropTypes.oneOf(['_self', '_blank', '_parent', '_top']),
   rel: PropTypes.arrayOf(PropTypes.oneOf(Object.values(LINK_TYPES))),
+  disabled: PropTypes.bool,
   children: PropTypes.node.isRequired
 }
 

--- a/components/atom/tag/src/Actionable/index.js
+++ b/components/atom/tag/src/Actionable/index.js
@@ -6,8 +6,12 @@ import {LINK_TYPES} from '../constants'
 const RIGHT_ICON_PLACEMENT = 'right'
 const LEFT_ICON_PLACEMENT = 'left'
 
-const getClassNames = function({className}) {
-  return cx('sui-AtomTag-actionable', className)
+const getClassNames = function({className, disabled}) {
+  return cx(
+    'sui-AtomTag-actionable',
+    disabled && 'sui-AtomTag--disabled',
+    className
+  )
 }
 
 const getLinkTypesString = types => types && types.join(' ')
@@ -22,16 +26,23 @@ const ActionableTag = function({
   rel,
   linkFactory,
   className,
+  disabled,
   value = null
 }) {
   return (
     <ActionableTagContainer
-      className={getClassNames({className})}
+      className={getClassNames({className, disabled})}
       Link={linkFactory}
-      onClick={ev => onClick(ev, {value, label})}
+      onClick={ev => {
+        if (disabled) {
+          return
+        }
+        onClick(ev, {value, label})
+      }}
       href={href}
       target={target}
       rel={rel}
+      disabled={disabled}
     >
       {icon && iconPlacement === LEFT_ICON_PLACEMENT && (
         <span className="sui-AtomTag-icon">{icon}</span>
@@ -48,6 +59,7 @@ const ActionableTag = function({
 
 ActionableTag.propTypes = {
   className: PropTypes.string,
+  disabled: PropTypes.bool,
   label: PropTypes.string.isRequired,
   icon: PropTypes.node,
   href: PropTypes.string,
@@ -61,12 +73,18 @@ ActionableTag.propTypes = {
 
 ActionableTag.defaultProps = {
   // eslint-disable-next-line react/prop-types
-  linkFactory: ({href, target, rel, className, children} = {}) => {
+  linkFactory: ({href, target, rel, className, role, children} = {}) => {
     const optionalProps = {
       ...(rel && {rel: getLinkTypesString(rel)})
     }
     return (
-      <a href={href} target={target} className={className} {...optionalProps}>
+      <a
+        href={href}
+        target={target}
+        className={className}
+        role={role}
+        {...optionalProps}
+      >
         {children}
       </a>
     )

--- a/components/atom/tag/src/index.js
+++ b/components/atom/tag/src/index.js
@@ -46,6 +46,7 @@ const AtomTag = props => {
 AtomTag.displayName = 'AtomTag'
 
 AtomTag.propTypes = {
+  disabled: PropTypes.bool,
   label: PropTypes.string.isRequired,
   icon: PropTypes.node,
   onClose: PropTypes.func,

--- a/components/atom/tag/src/index.scss
+++ b/components/atom/tag/src/index.scss
@@ -103,12 +103,14 @@ $base-class: '.sui-AtomTag';
     fill: $c-atom-tag-actionable;
     text-decoration: none;
 
-    &:hover,
-    &:active {
-      background-color: $bgc-atom-tag-actionable--hover;
-      color: $c-atom-tag-actionable;
-      cursor: pointer;
-      fill: $c-atom-tag-actionable;
+    &:not(#{$base-class}--disabled) {
+      &:hover,
+      &:active {
+        background-color: $bgc-atom-tag-actionable--hover;
+        color: $c-atom-tag-actionable;
+        cursor: pointer;
+        fill: $c-atom-tag-actionable;
+      }
     }
 
     &#{$self}--outline {
@@ -116,11 +118,13 @@ $base-class: '.sui-AtomTag';
       color: $c-atom-tag-actionable-invert;
       fill: $c-atom-tag-actionable-invert;
 
-      &:hover,
-      &:active {
-        background-color: $bgc-atom-tag-actionable-invert--hover;
-        color: $c-atom-tag-actionable-invert--hover;
-        fill: $c-atom-tag-actionable-invert--hover;
+      &:not(#{$base-class}--disabled) {
+        &:hover,
+        &:active {
+          background-color: $bgc-atom-tag-actionable-invert--hover;
+          color: $c-atom-tag-actionable-invert--hover;
+          fill: $c-atom-tag-actionable-invert--hover;
+        }
       }
     }
   }
@@ -179,6 +183,11 @@ $base-class: '.sui-AtomTag';
   &--outline {
     background-color: $bgc-atom-tag-outline;
     border: $bdw-atom-tag-outline solid $bc-atom-tag-outline;
+  }
+
+  &--disabled {
+    cursor: default;
+    opacity: 0.3;
   }
 
   @each $name, $type in $atom-tag-types {

--- a/demo/atom/tag/demo/index.js
+++ b/demo/atom/tag/demo/index.js
@@ -104,6 +104,7 @@ export default () => (
                   icon={icon}
                   label="Icon & Close Tag"
                   size={size}
+                  disabled
                 />
               </Cell>
             </Fragment>
@@ -212,6 +213,39 @@ export default () => (
         iconPlacement="left"
         label="Icon placement left"
         target="_blank"
+      />
+      <Paragraph>–––––</Paragraph>
+      <Paragraph>
+        With <Code>disabled</Code> prop.
+      </Paragraph>
+      <AtomTag
+        design={atomTagDesigns.OUTLINE}
+        label="Navigation Tag"
+        onClick={() => window.alert('click!')}
+        disabled
+      />
+      <AtomTag
+        design={atomTagDesigns.OUTLINE}
+        href="https://sui-components.now.sh/"
+        label="Anchor Tag"
+        target="_blank"
+        disabled
+      />
+      <AtomTag
+        href="https://sui-components.now.sh/"
+        icon={icon}
+        iconPlacement="right"
+        label="Icon placement right"
+        target="_blank"
+        disabled
+      />
+      <AtomTag
+        href="https://sui-components.now.sh/"
+        icon={icon}
+        iconPlacement="left"
+        label="Icon placement left"
+        target="_blank"
+        disabled
       />
       <Paragraph>–––––</Paragraph>
       <H2>With Value prop</H2>

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "fs-extra": "9.0.1",
     "globby": "11.0.1",
     "husky": "4.3.0",
+    "sinon": "10.0.0",
     "validate-commit-msg": "2.12.2",
     "walker": "1.0.7"
   },

--- a/test/atom/tag/index.js
+++ b/test/atom/tag/index.js
@@ -9,6 +9,8 @@ import ReactDOM from 'react-dom'
 
 import chai, {expect} from 'chai'
 import chaiDOM from 'chai-dom'
+import sinon from 'sinon'
+import userEvents from '@testing-library/user-event'
 
 chai.use(chaiDOM)
 
@@ -45,17 +47,16 @@ describe('atom/tag', () => {
     expect(container.innerHTML).to.not.have.lengthOf(0)
   })
 
-  it.skip('example', () => {
-    // Example TO BE DELETED!!!!
+  it('should not trigger click when disabled', () => {
+    const spy = sinon.spy()
+    const {getByRole} = setup({
+      disabled: true,
+      onClick: spy,
+      label: 'Actionable'
+    })
 
-    // Given
-    // const props = {}
-
-    // When
-    // const {getByRole} = setup(props)
-
-    // Then
-    // expect(getByRole('button')).to.have.text('HOLA')
-    expect(true).to.be.eql(false)
+    const tag = getByRole('button', {name: /actionable/i})
+    userEvents.click(tag)
+    sinon.assert.notCalled(spy)
   })
 })


### PR DESCRIPTION
## ATOM/TAG
https://jira.scmspain.com/browse/PI-38501


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
Added disabled behaviour to the actionable AtomTag, since this component can work as button, then makes sense to been able to disabled it.


### Screenshots - Animations

![image](https://user-images.githubusercontent.com/3693800/115843902-a0951b80-a41f-11eb-9ef6-f58589f8d347.png)

