### PR TITLE
feat(atom/card): add hover class when have onclick prop

### DIFF
--- a/components/atom/card/src/index.js
+++ b/components/atom/card/src/index.js
@@ -17,6 +17,7 @@ const AtomCard = ({
   responsive,
   highlight,
   href,
+  onClick,
   tabIndex
 }) => {
   const redirectToHref = () => {
@@ -34,7 +35,8 @@ const AtomCard = ({
     isVertical && CLASS_VERTICAL,
     responsive && CLASS_RESPONSIVE,
     highlight && CLASS_HIGHLIGHT,
-    href && CLASS_LINK
+    href && CLASS_LINK,
+    onClick && CLASS_LINK
   )
 
   return (
@@ -42,7 +44,7 @@ const AtomCard = ({
       className={classNames}
       tabIndex={tabIndex}
       role="button"
-      onClick={redirectToHref}
+      onClick={onClick ?? redirectToHref}
       onKeyDown={redirectOnEnter}
     >
       {Media && (
@@ -78,7 +80,10 @@ AtomCard.propTypes = {
   href: PropTypes.string,
 
   /** tab order */
-  tabIndex: PropTypes.string
+  tabIndex: PropTypes.string,
+
+  /**  */
+  onClick: PropTypes.func
 }
 
 export default AtomCard

--- a/demo/atom/card/demo/index.js
+++ b/demo/atom/card/demo/index.js
@@ -24,6 +24,7 @@ const DefaultDemo = () => {
   const [content, setContent] = useState(true)
   const [HREF, setHREF] = useState(false)
   const [vertical, setVertical] = useState(false)
+  const [actionable, setActionable] = useState(false)
   const [highlight, setHighlight] = useState(false)
   return (
     <Article>
@@ -55,7 +56,11 @@ const DefaultDemo = () => {
         Card can give a vertical orientation of elements under the{' '}
         <Code>vertical</Code> boolean prop.
       </Paragraph>
-      <Grid cols={5} gutter={[8, 8]}>
+      <Paragraph>
+        Card can be actionable and trigger an event clicking on it under{' '}
+        <Code>onClick</Code> prop.
+      </Paragraph>
+      <Grid cols={6} gutter={[8, 8]}>
         <Cell>
           <Label>Media</Label>
         </Cell>
@@ -70,6 +75,9 @@ const DefaultDemo = () => {
         </Cell>
         <Cell>
           <Label>Vertical</Label>
+        </Cell>
+        <Cell>
+          <Label>Actionable</Label>
         </Cell>
         <Cell>
           <RadioButton
@@ -116,6 +124,16 @@ const DefaultDemo = () => {
             onClick={(target, value) => setVertical(value === 'vertical')}
           />
         </Cell>
+
+        <Cell>
+          <RadioButton
+            label={actionable ? 'true' : 'false'}
+            value="actionable"
+            checked={actionable}
+            fullWidth
+            onClick={(target, value) => setActionable(value === 'actionable')}
+          />
+        </Cell>
       </Grid>
       <br />
       <AtomCard
@@ -141,6 +159,7 @@ const DefaultDemo = () => {
         vertical={vertical}
         href={HREF && 'http://www.google.com'}
         highlight={highlight}
+        onClick={actionable ? () => alert('Hello!') : undefined}
       />
     </Article>
   )

--- a/test/atom/card/index.js
+++ b/test/atom/card/index.js
@@ -46,17 +46,32 @@ describe('atom/card', () => {
     expect(container.innerHTML).to.not.have.lengthOf(0)
   })
 
-  it.skip('example', () => {
-    // Example TO BE DELETED!!!!
+  it('should have link class when having onClick', () => {
+    const props = {
+      onClick: () => console.log('Hello!'),
+      content: () => <span>card with click</span>
+    }
+    const {getByRole} = setup(props)
+    const card = getByRole('button')
+    expect(card).to.have.class('sui-AtomCard-link')
+  })
 
-    // Given
-    // const props = {}
+  it('should have link class when having href', () => {
+    const props = {
+      href: 'http://www.google.com',
+      content: () => <span>card with click</span>
+    }
+    const {getByRole} = setup(props)
+    const card = getByRole('button')
+    expect(card).to.have.class('sui-AtomCard-link')
+  })
 
-    // When
-    // const {getByRole} = setup(props)
-
-    // Then
-    // expect(getByRole('button')).to.have.text('HOLA')
-    expect(true).to.be.eql(false)
+  it('should NOT have link class when not having href or onClick', () => {
+    const props = {
+      content: () => <span>card with click</span>
+    }
+    const {getByRole} = setup(props)
+    const card = getByRole('button')
+    expect(card).to.have.not.class('sui-AtomCard-link')
   })
 })


### PR DESCRIPTION
## ATOM/CARD
**TASK**: [Jira](https://jira.scmspain.com/browse/PI-38581)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
We need a hover when the card has an onclick event
