### PR TITLE
feat(molecule/modal): export a modal variation with disabled animation

### DIFF
--- a/components/molecule/modal/README.md
+++ b/components/molecule/modal/README.md
@@ -13,6 +13,14 @@ $ npm install @s-ui/react-molecule-modal --save
 
 ## Usage
 
+⚠️ By default, import will take `MoleculeModalWithAnimation`, if you want to import an speciffic modal, just use named imports.
+
+Those are the named exports enabled:
+- MoleculeModal
+- MoleculeModalWithUrlState
+- MoleculeModalWithAnimation
+- MoleculeModalWithoutAnimation
+
 ### Basic usage
 ```js
 import MoleculeModal from '@s-ui/react-molecule-modal'

--- a/components/molecule/modal/README.md
+++ b/components/molecule/modal/README.md
@@ -13,7 +13,7 @@ $ npm install @s-ui/react-molecule-modal --save
 
 ## Usage
 
-⚠️ By default, import will take `MoleculeModalWithAnimation`, if you want to import an speciffic modal, just use named imports.
+⚠️ By default, import will take `MoleculeModalWithAnimation`, if you want to import a speciffic modal, just use named imports.
 
 Those are the named exports enabled:
 - MoleculeModal

--- a/components/molecule/modal/src/HoC/WithoutAnimation.js
+++ b/components/molecule/modal/src/HoC/WithoutAnimation.js
@@ -1,0 +1,19 @@
+import {forwardRef} from 'react'
+import PropTypes from 'prop-types'
+
+export default BaseComponent => {
+  const displayName = BaseComponent.displayName
+
+  const WithoutAnimation = forwardRef(({...rest}, ref) => {
+    return <BaseComponent ref={ref} withAnimation={false} {...rest} />
+  })
+
+  WithoutAnimation.displayName = `WithoutAnimation(${displayName})`
+  WithoutAnimation.contextTypes = BaseComponent.contextTypes
+  WithoutAnimation.propTypes = {
+    onClose: PropTypes.func,
+    onAnimationEnd: PropTypes.func
+  }
+
+  return WithoutAnimation
+}

--- a/components/molecule/modal/src/index.js
+++ b/components/molecule/modal/src/index.js
@@ -18,6 +18,7 @@ import {HeaderRender} from './HeaderRender'
 import MoleculeModalContent from './Content'
 import MoleculeModalFooter from './Footer'
 import WithAnimation from './HoC/WithAnimation'
+import withoutAnimation from './HoC/WithoutAnimation'
 import WithUrlState from './HoC/WithUrlState'
 
 export const MODAL_SIZES = {
@@ -51,7 +52,8 @@ const MoleculeModal = forwardRef(
       portalContainerId = 'modal-react-portal',
       usePortal = true,
       withoutIndentation = false,
-      isContentless
+      isContentless,
+      withAnimation = true
     },
     forwardedRef
   ) => {
@@ -119,6 +121,7 @@ const MoleculeModal = forwardRef(
 
     const renderModal = () => {
       const wrapperClassName = cx(suitClass(), {
+        'is-static': !withAnimation,
         'is-MoleculeModal-open': isOpen,
         [suitClass({element: 'out'})]: isClosing
       })
@@ -265,18 +268,28 @@ MoleculeModal.propTypes = {
    * The function that manages when the modal open. It'll be executed for open
    * MoleculeModalWithUrlState on pop state changes
    */
-  openModalTrigger: PropTypes.func // eslint-disable-line react/no-unused-prop-types
+  openModalTrigger: PropTypes.func, // eslint-disable-line react/no-unused-prop-types
+  /**
+   * Determines if modal has open/close animation
+   */
+  withAnimation: PropTypes.bool
 }
 
 MoleculeModal.displayName = 'MoleculeModal'
 
 const MoleculeModalWithAnimation = WithAnimation(MoleculeModal)
 const MoleculeModalWithUrlState = WithUrlState(MoleculeModalWithAnimation)
+const MoleculeModalWithoutAnimation = withoutAnimation(MoleculeModal)
 
 MoleculeModalWithAnimation.displayName = 'MoleculeModal'
 
 MoleculeModalWithAnimation.Content = MoleculeModalContent
 MoleculeModalWithAnimation.Footer = MoleculeModalFooter
 
-export {MoleculeModalWithUrlState, MoleculeModalWithAnimation}
+export {
+  MoleculeModal,
+  MoleculeModalWithUrlState,
+  MoleculeModalWithAnimation,
+  MoleculeModalWithoutAnimation
+}
 export default MoleculeModalWithAnimation

--- a/components/molecule/modal/src/index.scss
+++ b/components/molecule/modal/src/index.scss
@@ -78,6 +78,14 @@ body.is-MoleculeModal-open {
     animation: modal-overlay-out 0.25s both;
   }
 
+  &.is-static::before {
+    display: block;
+  }
+
+  &-out.is-static::before {
+    display: none;
+  }
+
   &.is-MoleculeModal-open {
     display: flex;
     justify-content: center;
@@ -139,6 +147,11 @@ body.is-MoleculeModal-open {
         }
       }
     }
+  }
+
+  &.is-static::before,
+  &.is-static &-dialog {
+    animation-name: none;
   }
 
   &-header {

--- a/demo/molecule/modal/demo/WithoutAnimationModal.js
+++ b/demo/molecule/modal/demo/WithoutAnimationModal.js
@@ -1,0 +1,53 @@
+/* eslint react/prop-types: 0 */
+/* eslint no-console: 0 */
+import {Component} from 'react'
+import {MoleculeModalWithoutAnimation} from '../../../../components/molecule/modal/src'
+import {Content, LoremIpsumParagraph, IconClose} from './helperComponents'
+
+class WithoutAnimationModal extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      open: false
+    }
+  }
+
+  handleOpenModal = () => {
+    this.setState({
+      open: true
+    })
+  }
+
+  handleCloseModal = () => {
+    this.setState({
+      open: false
+    })
+  }
+
+  render() {
+    return (
+      <div>
+        <button type="button" onClick={this.handleOpenModal}>
+          Open modal
+        </button>
+        <MoleculeModalWithoutAnimation
+          isOpen={this.state.open}
+          closeOnOutsideClick
+          closeOnEscKeyDown
+          iconClose={<IconClose />}
+          fitWindow
+          header="My new brand modal"
+          onClose={this.handleCloseModal}
+        >
+          <Content>
+            {[...Array(1).keys()].map(index => (
+              <LoremIpsumParagraph key={index} />
+            ))}
+          </Content>
+        </MoleculeModalWithoutAnimation>
+      </div>
+    )
+  }
+}
+
+export default WithoutAnimationModal

--- a/demo/molecule/modal/demo/index.js
+++ b/demo/molecule/modal/demo/index.js
@@ -10,6 +10,7 @@ import NoHeaderNoCloseButtonModal from './NoHeaderNoCloseButtonModal'
 import MobileFitContentModal from './MobileFitContentModal'
 import ScrollableChildrenModal from './ScrollableChildrenModal'
 import WithUrlStateModal from './WithUrlStateModal'
+import WithoutAnimationModal from './WithoutAnimationModal'
 
 const fieldStyle = {
   border: '1px solid rgb(204, 204, 204)',
@@ -26,6 +27,10 @@ const Demo = () => (
       <h2>Scroll Modal</h2>
       <div style={fieldStyle}>
         <ScrollModal />
+      </div>
+      <h2>WithoutAnimationModal</h2>
+      <div style={fieldStyle}>
+        <WithoutAnimationModal />
       </div>
       <h2>No Scroll Modal</h2>
       <div style={fieldStyle}>


### PR DESCRIPTION
## molecule/modal

### Types of changes
- [X] New feature (non-breaking change which adds functionality)
- [X] Documentation

### Description, Motivation and Context
Add a variation of Molecule Modal without animation.
We have seen that in some cases it could be interesting do not to use animation. For example in modals that should be opened automatically when the page loads.

We have tested how removing a modal animation could affect to performance and we have seen very good results:
![image](https://user-images.githubusercontent.com/5390428/116405307-ca8b7b00-a82f-11eb-88a9-88f6fb61a44c.png)

This PR enables us to use a Modal without animation, just importing that:
```
import {MoleculeModalWithoutAnimation} from '@s-ui/react-molecule-modal'
```