### PR TITLE
fix(atom/tag): style coloring using type prop with other props combined

### DIFF
--- a/components/atom/tag/src/index.scss
+++ b/components/atom/tag/src/index.scss
@@ -103,6 +103,11 @@ $base-class: '.sui-AtomTag';
     fill: $c-atom-tag-actionable;
     text-decoration: none;
 
+    &#{$base-class}--disabled {
+      cursor: default;
+      opacity: 0.3;
+    }
+
     &:not(#{$base-class}--disabled) {
       &:hover,
       &:active {
@@ -185,11 +190,6 @@ $base-class: '.sui-AtomTag';
     border: $bdw-atom-tag-outline solid $bc-atom-tag-outline;
   }
 
-  &--disabled {
-    cursor: default;
-    opacity: 0.3;
-  }
-
   @each $name, $type in $atom-tag-types {
     $bgc: map-get($type, bgc);
     $c: map-get($type, c);
@@ -199,12 +199,37 @@ $base-class: '.sui-AtomTag';
     &--#{$name} {
       background-color: $bgc;
       color: $c;
+      fill: $c;
+      &#{$self}-actionable {
+        background-color: $bgc;
+        color: $c;
+        fill: $c;
+        &#{$self}--disabled {
+          cursor: default;
+          opacity: 0.3;
+        }
+      }
+      &#{$self}--outline {
+        border-color: $bgc;
+        color: $bgc;
+        background-color: $c;
+        fill: $bgc;
+      }
 
       @if $bgc-hover or $c-hover {
         @media (hover: hover) {
-          &:hover {
-            background-color: $bgc-hover;
-            color: $c-hover;
+          &:not(#{$self}--disabled) {
+            &:hover,
+            &:active {
+              background-color: $bgc-hover;
+              color: $c-hover;
+              &#{$self}--outline {
+                background-color: $bgc;
+                border-color: $bgc;
+                color: $c;
+                fill: $c;
+              }
+            }
           }
         }
       }

--- a/components/atom/tag/src/index.scss
+++ b/components/atom/tag/src/index.scss
@@ -94,7 +94,6 @@ $base-class: '.sui-AtomTag';
   &-secondary-icon {
     @include icon-atom-tag(icon-secondary);
   }
-
   &-actionable {
     background-color: $bgc-atom-tag-actionable;
     border: $bd-atom-tag-actionable;
@@ -204,10 +203,6 @@ $base-class: '.sui-AtomTag';
         background-color: $bgc;
         color: $c;
         fill: $c;
-        &#{$self}--disabled {
-          cursor: default;
-          opacity: 0.3;
-        }
       }
       &#{$self}--outline {
         border-color: $bgc;

--- a/demo/atom/tag/demo/ArticleTypes.js
+++ b/demo/atom/tag/demo/ArticleTypes.js
@@ -1,0 +1,162 @@
+import {useState} from 'react'
+import PropTypes from 'prop-types'
+import {
+  Article,
+  H2,
+  Paragraph,
+  Grid,
+  Cell,
+  RadioButton,
+  Label,
+  Code
+} from '@s-ui/documentation-library'
+import AtomTag, {atomTagDesigns} from '../../../../components/atom/tag/src'
+
+const noop = () => null
+
+const ArticleTypes = ({className, icon: iconProp}) => {
+  const [disabled, setDisabled] = useState(false)
+  const [outlined, setOutlined] = useState(false)
+  const [actionable, setActionable] = useState(false)
+  const [icon, setIcon] = useState(null)
+  return (
+    <Article className={className}>
+      <H2>Types</H2>
+      <Paragraph>
+        Use the <Code>type</Code> in order to color it as desired from a high
+        order component.
+      </Paragraph>
+      <Grid cols={4} gutter={[8, 8]} style={{maxWidth: 500}}>
+        <Cell>
+          <Grid cols={2} gutter={[8, 8]}>
+            <Cell
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'flex-end'
+              }}
+            >
+              <Label>Actionable</Label>
+            </Cell>
+            <Cell>
+              <RadioButton
+                value={actionable}
+                label={`${actionable}`}
+                onClick={() => setActionable(!actionable)}
+                fullWidth
+              />
+            </Cell>
+          </Grid>
+        </Cell>
+        <Cell>
+          <Grid cols={2} gutter={[8, 8]}>
+            <Cell
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'flex-end'
+              }}
+            >
+              <Label>Disabled</Label>
+            </Cell>
+            <Cell>
+              <RadioButton
+                value={disabled}
+                label={`${disabled}`}
+                onClick={() => setDisabled(!disabled)}
+                fullWidth
+              />
+            </Cell>
+          </Grid>
+        </Cell>
+        <Cell>
+          <Grid cols={2} gutter={[8, 8]}>
+            <Cell
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'flex-end'
+              }}
+            >
+              <Label>Outline</Label>
+            </Cell>
+            <Cell>
+              <RadioButton
+                value={outlined}
+                label={`${outlined}`}
+                onClick={() => setOutlined(!outlined)}
+                fullWidth
+              />
+            </Cell>
+          </Grid>
+        </Cell>
+        <Cell>
+          <Grid cols={2} gutter={[8, 8]}>
+            <Cell
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'flex-end'
+              }}
+            >
+              <Label>Icon</Label>
+            </Cell>
+            <Cell>
+              <RadioButton
+                value={!!icon}
+                label={`${!!icon}`}
+                onClick={() => setIcon(icon ? null : iconProp)}
+                fullWidth
+              />
+            </Cell>
+          </Grid>
+        </Cell>
+      </Grid>
+      <br />
+      <br />
+
+      <AtomTag
+        label="Alert"
+        type="alert"
+        disabled={disabled}
+        design={outlined ? atomTagDesigns.OUTLINE : atomTagDesigns.SOLID}
+        icon={icon}
+        {...{...(actionable && {onClick: noop})}}
+      />
+
+      <AtomTag
+        label="Warning"
+        type="warning"
+        disabled={disabled}
+        design={outlined ? atomTagDesigns.OUTLINE : atomTagDesigns.SOLID}
+        icon={icon}
+        {...{...(actionable && {onClick: noop})}}
+      />
+
+      <AtomTag
+        label="Special"
+        type="special"
+        disabled={disabled}
+        design={outlined ? atomTagDesigns.OUTLINE : atomTagDesigns.SOLID}
+        icon={icon}
+        {...{...(actionable && {onClick: noop})}}
+      />
+
+      <AtomTag
+        label="5 min ago"
+        type="date"
+        disabled={disabled}
+        design={outlined ? atomTagDesigns.OUTLINE : atomTagDesigns.SOLID}
+        icon={icon}
+        {...{...(actionable && {onClick: noop})}}
+      />
+    </Article>
+  )
+}
+
+ArticleTypes.propTypes = {
+  className: PropTypes.string,
+  icon: PropTypes.node
+}
+
+export default ArticleTypes

--- a/demo/atom/tag/demo/index.js
+++ b/demo/atom/tag/demo/index.js
@@ -19,6 +19,7 @@ import {
   UnorderedList,
   ListItem
 } from '@s-ui/documentation-library'
+import ArticleTypes from './ArticleTypes'
 
 import './index.scss'
 
@@ -345,17 +346,6 @@ export default () => (
       </div>
     </Article>
     <br />
-    <Article className={CLASS_SECTION}>
-      <H2>Types</H2>
-      <Paragraph>
-        Use the <Code>type</Code> in order to color it as desired from a high
-        order component.
-      </Paragraph>
-      <div>
-        <AtomTag label="Sale" type="warning" />
-        <AtomTag label="Special" type="special" />
-        <AtomTag label="5 min ago" type="date" />
-      </div>
-    </Article>
+    <ArticleTypes className={CLASS_SECTION} icon={icon} />
   </div>
 )

--- a/demo/atom/tag/demo/index.scss
+++ b/demo/atom/tag/demo/index.scss
@@ -1,1 +1,28 @@
 @import '~@s-ui/react-atom-icon/lib/index';
+
+$atom-tag-types: (
+  'alert': (
+    bgc: red,
+    c: white,
+    bgc-hover: color-variation(red, 2),
+    c-hover: white
+  ),
+  'warning': (
+    bgc: orange,
+    c: white,
+    bgc-hover: color-variation(orange, 2),
+    c-hover: white
+  ),
+  'special': (
+    bgc: blue,
+    c: white,
+    bgc-hover: color-variation(blue, 2),
+    c-hover: white
+  ),
+  'date': (
+    bgc: gray,
+    c: white,
+    bgc-hover: color-variation(gray, 2),
+    c-hover: white
+  )
+);


### PR DESCRIPTION
## ATOM/TAG
**TASK**: <!--- [jira TASK ID](jiraURL) -->


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
when type prop uses other combined posible props like actionable disabled outline design icon or many other there exists many different styling bugs.

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
[atom-tag-demo](https://sui-components-oycklobvi-schibstedspain.vercel.app/workbench/atom/tag/demo)