### PR TITLE
fix(molecule/modal): fix modal for old browser

### DIFF
--- a/components/molecule/modal/src/_settings.scss
+++ b/components/molecule/modal/src/_settings.scss
@@ -1,6 +1,7 @@
 $bg-molecule-modal: $c-black !default;
 $op-molecule-modal: 0.6 !default;
 $z-molecule-modal: $z-modal !default;
+$z-molecule-modal--before: -1 !default;
 
 $bg-molecule-modal-overlay: rgba(
   $bg-molecule-modal,

--- a/components/molecule/modal/src/index.scss
+++ b/components/molecule/modal/src/index.scss
@@ -72,6 +72,7 @@ body.is-MoleculeModal-open {
     animation: modal-overlay-in 5s both;
     background-color: $bg-molecule-modal-overlay;
     content: '';
+    z-index: $z-molecule-modal--before;
   }
 
   &-out::before {


### PR DESCRIPTION
## molecule/modal


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
<!--- Describe your changes in detail -->
Set a -1 z-index in ::before to the class sui-MoleculeModal for older navigators
<!--- Why is this change required? What problem does it solve? -->
![image](https://user-images.githubusercontent.com/10578960/119011901-c9182300-b995-11eb-90c9-
dd82b8575e15.png)
This happens in older versions of Safari (for example Ipad Air 2)
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
Open Fotocasa.es in Ipad Air 2 (we have use browserstack to reproduce it)

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
**after the fix**
![image](https://user-images.githubusercontent.com/10578960/119012769-a0445d80-b996-11eb-82b5-c03a13b0c12d.png)
![image](https://user-images.githubusercontent.com/10578960/119013787-9d963800-b997-11eb-80b7-668ca7557de5.png)

