### PR TITLE
feat(components/molecule/notification): allow show left icon on mobil…

### DIFF
--- a/components/molecule/notification/demo/index.js
+++ b/components/molecule/notification/demo/index.js
@@ -49,6 +49,22 @@ const Demo = () => {
       </MoleculeNotification>
       <br />
 
+      <h2>Show Left Icon on Mobile</h2>
+      <MoleculeNotification
+        autoClose="manual"
+        type="info"
+        onClose={logClose}
+        roundedCorners={BRDS_SIZE.medium}
+        showLeftIconMobile
+      >
+        <span>
+          Lorem ipsum dolor sit amet,{' '}
+          <a href="#fistrum">consectetur adipiscing</a> elit. Duis vitae orci
+          consectetur ligula vel.
+        </span>
+      </MoleculeNotification>
+      <br />
+
       <h2>With children content</h2>
       <MoleculeNotification autoClose="manual" type="info" onClose={logClose}>
         <span>
@@ -125,6 +141,7 @@ const Demo = () => {
       >
         {TEXT}
       </MoleculeNotification>
+
       <h2>Override container</h2>
       <MoleculeNotification autoClose="manual" overrideContainer>
         {TEXT}

--- a/components/molecule/notification/src/index.js
+++ b/components/molecule/notification/src/index.js
@@ -36,6 +36,7 @@ const MoleculeNotification = ({
   position = POSITION.relative,
   roundedCorners = null,
   showCloseButton = true,
+  showLeftIconMobile = false,
   text,
   type = TYPES.info,
   variation = VARIATIONS.negative,
@@ -106,6 +107,9 @@ const MoleculeNotification = ({
     [`${CLASS}-children`]: children,
     [`${CLASS}-text`]: text
   })
+  const iconLeftClassName = cx(`${CLASS}-iconLeft`, {
+    [`${CLASS}-iconLeft--show`]: showLeftIconMobile
+  })
 
   if (!show && !delay) {
     return null
@@ -115,7 +119,7 @@ const MoleculeNotification = ({
     return (
       <div className={wrapperClassName}>
         <div className={`${CLASS}-content`}>
-          <div className={`${CLASS}-iconLeft`}>
+          <div className={iconLeftClassName}>
             <span className={`${CLASS}-icon`}>{icon || ICONS[type]}</span>
           </div>
           <div className={innerWrapperClassName}>{children || text}</div>
@@ -183,6 +187,9 @@ MoleculeNotification.propTypes = {
 
   /** Show / hide close button */
   showCloseButton: PropTypes.bool,
+
+  /** Show / hide left icon on mobile */
+  showLeftIconMobile: PropTypes.bool,
 
   /** Content text. Deprecated, use children instead. */
   text: PropTypes.string,

--- a/components/molecule/notification/src/index.scss
+++ b/components/molecule/notification/src/index.scss
@@ -47,6 +47,10 @@ $base-class: '.sui-MoleculeNotification';
       }
       display: none;
       margin-right: $m-m;
+
+      &--show {
+        display: block;
+      }
     }
 
     &Close {


### PR DESCRIPTION
## MOLECULE/NOTIFICATION
**TASK**: <!--- [jira TASK ID](jiraURL) -->


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
Currently `molecule/notification` hides left icon on mobile devices throw CSS. In order to avoid breaking changes, we decide to create a `showLeftIconMobile` prop that will add a new class and force show left icon on mobile devices.

### Screenshots - Animations
![image](https://user-images.githubusercontent.com/3933098/120202223-a5bb6680-c226-11eb-962e-399069ff6abc.png)