### PR TITLE
feat(components/atom/tag): add border for print mode

### DIFF
--- a/components/atom/tag/src/index.scss
+++ b/components/atom/tag/src/index.scss
@@ -230,4 +230,12 @@ $base-class: '.sui-AtomTag';
       }
     }
   }
+
+  @media print {
+    border: {
+      color: $bgc-atom-tag;
+      style: solid;
+      width: $bdrs-s;
+    }
+  }
 }


### PR DESCRIPTION
## ATOM/TAG

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context

When I print a label on paper, the browser removes the background and the label has no border, there is nothing to visually identify it as a label. A border is added on the printed label.


### Screenshots - Animations
![Captura de pantalla 2021-06-09 a las 14 41 20](https://user-images.githubusercontent.com/16401219/121357130-d049a580-c931-11eb-93a2-c70fb0bf048c.png)
