### PR TITLE
feat(components/molecule/photoUploader): treat initialPhotos as an object and extract it an id

### DIFF
--- a/components/molecule/photoUploader/README.md
+++ b/components/molecule/photoUploader/README.md
@@ -12,6 +12,8 @@ Every modification of the list will return a list of Blobs (jpeg encoded!) to be
 
 > `url` (String) if the image is one of the initially passed by props will contain an url, if it's undefined, it's a new image.
 
+> `id` (String) you could pass an id to identify each image that was initially passed
+
 > `isNew` (Boolean) if it's a new uploaded image, will be true, if not, will be false and it will have an `url`.
 
 > `isModified` (Boolean): if an image of the initialPhotos, has been rotated, will be `isModified: true`
@@ -68,15 +70,15 @@ import MoleculePhotoUploader from '@s-ui/react-molecule-photo-uploader'
   // Not required props
   callbackPhotosRejected={rejectedPhotos => console.log(rejectedPhotos)}
   callbackPhotosUploaded={acceptedPhotos => console.log(acceptedPhotos)}
-  callbackUploadPhoto= {(file,oldUrl) => console.log(file,oldUrl)}
+  callbackUploadPhoto={(file, oldUrl) => console.log(file, oldUrl)}
   limitPhotosUploadedText={_limitPhotosUploaded}
   limitPhotosUploadedNotification={_limitPhotosUploadedNotification}
   mainPhotoLabel={'PRINCIPAL'}
   maxPhotos={10}
   rotationDirection={'clockwise'}
   initialPhotos={[
-    'https://images.net/image1.jpg',
-    'https://images.net/image2.jpg'
+    {'https://images.net/image1.jpg'},
+    {'https://images.net/image2.jpg}'
   ]}
 />
 ```

--- a/components/molecule/photoUploader/README.md
+++ b/components/molecule/photoUploader/README.md
@@ -77,7 +77,7 @@ import MoleculePhotoUploader from '@s-ui/react-molecule-photo-uploader'
   maxPhotos={10}
   rotationDirection={'clockwise'}
   initialPhotos={[
-    {url: 'https://images.net/image1.jpg'},
+    {url: 'https://images.net/image1.jpg', id: '6c7ee3d8-97db-4142-8520-5136fccfc40b'},
     {url: 'https://images.net/image2.jpg}'
   ]}
 />

--- a/components/molecule/photoUploader/README.md
+++ b/components/molecule/photoUploader/README.md
@@ -77,8 +77,8 @@ import MoleculePhotoUploader from '@s-ui/react-molecule-photo-uploader'
   maxPhotos={10}
   rotationDirection={'clockwise'}
   initialPhotos={[
-    {'https://images.net/image1.jpg'},
-    {'https://images.net/image2.jpg}'
+    {url: 'https://images.net/image1.jpg'},
+    {url: 'https://images.net/image2.jpg}'
   ]}
 />
 ```

--- a/components/molecule/photoUploader/demo/playground
+++ b/components/molecule/photoUploader/demo/playground
@@ -30,8 +30,14 @@ const _uploadingPhotosText = 'Subiendo imágenes...'
 const _rotationDirection = MoleculePhotoUploaderRotationDirection.clockwise
 
 const initialPhotos = [
-  {url: 'https://picsum.photos/seed/---all---/200/200'},
-  {url: 'https://picsum.photos/seed/--your---/800/300'},
+  {
+    url: 'https://picsum.photos/seed/---all---/200/200',
+    id: '9cded3e2-7fc6-4999-acc5-1fd42d6ea49a'
+  },
+  {
+    url: 'https://picsum.photos/seed/--your---/800/300',
+    id: '6c7ee3d8-97db-4142-8520-5136fccfc40b'
+  },
   {url: 'https://FAILUM.FAILED/FAIL/--base---/200/800'},
   {url: 'https://picsum.photos/seed/---are---/800/600'},
   {url: 'https://picsum.photos/seed/--belong-/200/300'},

--- a/components/molecule/photoUploader/demo/playground
+++ b/components/molecule/photoUploader/demo/playground
@@ -1,5 +1,5 @@
 const demoStyles = {
-  margin:'auto',
+  margin: 'auto',
   marginTop: 20
 }
 
@@ -18,36 +18,39 @@ const _dragDelay = 0
 const _dragPhotoTextInitialContent = 'Arrastra las fotos aquí'
 const _limitPhotosUploaded = 'Ha alcanzado el límite de fotografías'
 const _limitPhotosUploadedNotification = 'Máximo de fotografias alcanzado'
-const _errorFormatPhotoUploaded = 'Las fotografías deben tener formato JPEG, PNG, GIF, BMP o WEBP'
+const _errorFormatPhotoUploaded =
+  'Las fotografías deben tener formato JPEG, PNG, GIF, BMP o WEBP'
 const _errorCorruptedPhotoUploaded = 'Archivo %{filepath} ha fallado'
 const _errorInitialPhotoDownloadError = 'Error al descargar imágenes'
-const _errorFileExcededMaxSize = 'Las fotografías deben tener un peso máximo de 50 MB'
-const _notificationErrorFormatPhotoUploaded = 'Sólo se aceptan los formatos: formato JPEG, PNG, GIF, BMP o WEBP'
+const _errorFileExcededMaxSize =
+  'Las fotografías deben tener un peso máximo de 50 MB'
+const _notificationErrorFormatPhotoUploaded =
+  'Sólo se aceptan los formatos: formato JPEG, PNG, GIF, BMP o WEBP'
 const _uploadingPhotosText = 'Subiendo imágenes...'
 const _rotationDirection = MoleculePhotoUploaderRotationDirection.clockwise
 
 const initialPhotos = [
-  "https://picsum.photos/seed/---all---/200/200",
-  "https://picsum.photos/seed/--your---/800/300",
-  "https://FAILUM.FAILED/FAIL/--base---/200/800",
-  "https://picsum.photos/seed/---are---/800/600",
-  "https://picsum.photos/seed/--belong-/200/300",
-  "https://picsum.photos/seed/---to----/200/300",
-  "https://picsum.photos/seed/---us----/200/300"
+  {url: 'https://picsum.photos/seed/---all---/200/200'},
+  {url: 'https://picsum.photos/seed/--your---/800/300'},
+  {url: 'https://FAILUM.FAILED/FAIL/--base---/200/800'},
+  {url: 'https://picsum.photos/seed/---are---/800/600'},
+  {url: 'https://picsum.photos/seed/--belong-/200/300'},
+  {url: 'https://picsum.photos/seed/---to----/200/300'},
+  {url: 'https://picsum.photos/seed/---us----/200/300'}
 ]
 
 const Demo = () => {
-  const _callbackPhotosUploaded = (list) => {
-    console.log("_callbackPhotosUploaded: ", list)
+  const _callbackPhotosUploaded = list => {
+    console.log('_callbackPhotosUploaded: ', list)
   }
-  const _callbackPhotosRejected = (list) => {
-    console.log("_callbackPhotosRejected: ", list)
+  const _callbackPhotosRejected = list => {
+    console.log('_callbackPhotosRejected: ', list)
   }
 
   const _callbackUploadPhoto = (file, oldUrl) => {
-    const url = {url:`https://pre.cdn.coches.net/${Date.now()}`}
+    const url = {url: `https://pre.cdn.coches.net/${Date.now()}`}
     return Promise.resolve(url)
-    }
+  }
 
   const _infoIcon = () => (
     <svg viewBox="0 0 24 24">
@@ -115,21 +118,34 @@ const Demo = () => {
         limitPhotosUploadedNotification={_limitPhotosUploadedNotification}
         mainPhotoLabel={_mainPhotoLabel}
         maxPhotos={_maxPhotos}
-        notificationErrorFormatPhotoUploaded={_notificationErrorFormatPhotoUploaded}
+        notificationErrorFormatPhotoUploaded={
+          _notificationErrorFormatPhotoUploaded
+        }
         rejectPhotosIcon={_rejectPhotosIcon}
         retryIcon={_retryErrorPhotosIcon}
         rotateIcon={_rotateIcon}
         uploadingPhotosText={_uploadingPhotosText}
-
       />
 
       <h1 style={lineStyles}>Molecule PhotoUploader with initialPhotos</h1>
-      <p style={lineStyles}>This example has an array of URLs passed by props, and the third one fails on load, so it shows an error notification.</p>
-      <p style={lineStyles}>Also, in this example we're blocking .bmp images, which are accepted by default.</p>
-      <p style={lineStyles}>Also, rotation direction is set to clockwise. rotateIcon not changed, though :P</p>
-      <p style={lineStyles}>Also, dragDelay time set to 0, it must be 0 to improve user experience in desktop!</p>
+      <p style={lineStyles}>
+        This example has an array of URLs passed by props, and the third one
+        fails on load, so it shows an error notification.
+      </p>
+      <p style={lineStyles}>
+        Also, in this example we're blocking .bmp images, which are accepted by
+        default.
+      </p>
+      <p style={lineStyles}>
+        Also, rotation direction is set to clockwise. rotateIcon not changed,
+        though :P
+      </p>
+      <p style={lineStyles}>
+        Also, dragDelay time set to 0, it must be 0 to improve user experience
+        in desktop!
+      </p>
       <MoleculePhotoUploader
-        acceptedFileTypes='image/jpeg, image/gif, image/png, image/webp'
+        acceptedFileTypes="image/jpeg, image/gif, image/png, image/webp"
         addMorePhotosIcon={_addMorePhotosIcon}
         addPhotoTextButton={_addPhotoTextButton}
         addPhotoTextSkeleton={_addPhotoTextSkeleton}
@@ -151,7 +167,9 @@ const Demo = () => {
         limitPhotosUploadedNotification={_limitPhotosUploadedNotification}
         mainPhotoLabel={_mainPhotoLabel}
         maxPhotos={_maxPhotos}
-        notificationErrorFormatPhotoUploaded={_notificationErrorFormatPhotoUploaded}
+        notificationErrorFormatPhotoUploaded={
+          _notificationErrorFormatPhotoUploaded
+        }
         rejectPhotosIcon={_rejectPhotosIcon}
         retryIcon={_retryErrorPhotosIcon}
         rotateIcon={_rotateIcon}

--- a/components/molecule/photoUploader/src/PhotosPreview.js
+++ b/components/molecule/photoUploader/src/PhotosPreview.js
@@ -102,7 +102,7 @@ const PhotosPreview = ({
     const photoToRetry = _files[index]
 
     formatToBase64({
-      url: photoToRetry.url,
+      item: photoToRetry,
       options: defaultFormatToBase64Options
     }).then(
       ({blob, croppedBase64, url, hasErrors = DEFAULT_HAS_ERRORS_STATUS}) => {

--- a/components/molecule/photoUploader/src/fileTools.js
+++ b/components/molecule/photoUploader/src/fileTools.js
@@ -201,19 +201,17 @@ export const loadInitialPhotos = ({
         url,
         hasErrors = DEFAULT_HAS_ERRORS_STATUS,
         id
-      }) => {
-        return {
-          blob,
-          url,
-          hasErrors,
-          originalBase64: croppedBase64,
-          preview: croppedBase64,
-          rotation: DEFAULT_IMAGE_ROTATION_DEGREES,
-          isNew: false,
-          isModified: false,
-          id
-        }
-      }
+      }) => ({
+        blob,
+        url,
+        hasErrors,
+        originalBase64: croppedBase64,
+        preview: croppedBase64,
+        rotation: DEFAULT_IMAGE_ROTATION_DEGREES,
+        isNew: false,
+        isModified: false,
+        id
+      })
     )
     if (readyPhotos.some(photos => photos.hasErrors)) {
       setInitialDownloadError()

--- a/components/molecule/photoUploader/src/fileTools.js
+++ b/components/molecule/photoUploader/src/fileTools.js
@@ -189,22 +189,31 @@ export const loadInitialPhotos = ({
   _callbackPhotosUploaded,
   setIsLoading
 }) => {
-  const filesWithBase64 = initialPhotos.map(url =>
-    formatToBase64({url, options: defaultFormatToBase64Options})
+  const filesWithBase64 = initialPhotos.map(item =>
+    formatToBase64({item, options: defaultFormatToBase64Options})
   )
 
   Promise.all(filesWithBase64).then(newFiles => {
     const readyPhotos = newFiles.map(
-      ({blob, croppedBase64, url, hasErrors = DEFAULT_HAS_ERRORS_STATUS}) => ({
+      ({
         blob,
+        croppedBase64,
         url,
-        hasErrors,
-        originalBase64: croppedBase64,
-        preview: croppedBase64,
-        rotation: DEFAULT_IMAGE_ROTATION_DEGREES,
-        isNew: false,
-        isModified: false
-      })
+        hasErrors = DEFAULT_HAS_ERRORS_STATUS,
+        id
+      }) => {
+        return {
+          blob,
+          url,
+          hasErrors,
+          originalBase64: croppedBase64,
+          preview: croppedBase64,
+          rotation: DEFAULT_IMAGE_ROTATION_DEGREES,
+          isNew: false,
+          isModified: false,
+          id
+        }
+      }
     )
     if (readyPhotos.some(photos => photos.hasErrors)) {
       setInitialDownloadError()

--- a/components/molecule/photoUploader/src/index.js
+++ b/components/molecule/photoUploader/src/index.js
@@ -125,7 +125,8 @@ const MoleculePhotoUploader = forwardRef(
           isModified,
           hasErrors,
           file,
-          preview
+          preview,
+          id
         } = currentFile
         array.push({
           blob,
@@ -134,7 +135,8 @@ const MoleculePhotoUploader = forwardRef(
           isModified,
           hasErrors,
           file,
-          previewUrl: preview
+          previewUrl: preview,
+          id
         })
         return [...array]
       }, [])

--- a/components/molecule/photoUploader/src/photoTools.js
+++ b/components/molecule/photoUploader/src/photoTools.js
@@ -7,7 +7,7 @@ import {
 
 export function formatToBase64({
   file,
-  url,
+  item,
   options = FORM_IMAGE_UPLOADER_DEFAULT_FORMAT_TO_BASE_64_OPTIONS
 }) {
   if (file) {
@@ -66,6 +66,7 @@ export function formatToBase64({
       }
     })
   } else {
+    const {url, id} = item
     return new Promise((resolve, reject) => {
       cropAndRotateImage({
         imageURL: url,
@@ -76,11 +77,12 @@ export function formatToBase64({
           resolve({
             url,
             blob,
-            croppedBase64: base64
+            croppedBase64: base64,
+            id
           })
         })
         .catch(e => {
-          resolve({url, hasErrors: true})
+          resolve({item, hasErrors: true})
         })
     })
   }

--- a/components/molecule/photoUploader/src/photoTools.js
+++ b/components/molecule/photoUploader/src/photoTools.js
@@ -82,7 +82,7 @@ export function formatToBase64({
           })
         })
         .catch(e => {
-          resolve({item, hasErrors: true})
+          resolve({url, id, hasErrors: true})
         })
     })
   }


### PR DESCRIPTION
## BREAKING CHANGES:

initialPhotos is an array of objects instead of array of strings

## molecule/photoUploader

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
Since we need to identify an item inside of photoUploader we've to pass an array of objects instead of strings. That will be fine because allows to improve if it's needed in a future. 
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->