### PR TITLE
feat(components/molecule/autosuggest): restore the input caret after selecting and option with arrow

### DIFF
--- a/components/molecule/autosuggest/src/components/MultipleSelection.js
+++ b/components/molecule/autosuggest/src/components/MultipleSelection.js
@@ -26,6 +26,7 @@ const MoleculeAutosuggestFieldMultiSelection = ({
   onClear,
   onInputKeyDown,
   onSelect,
+  onKeyDown,
   onToggle,
   placeholder,
   required,
@@ -114,6 +115,7 @@ const MoleculeAutosuggestFieldMultiSelection = ({
         checkbox
         highlightQuery={value}
         onSelect={handleMultiSelection}
+        onKeyDown={onKeyDown}
         size={size}
         value={tags}
         visible={isOpen}

--- a/components/molecule/autosuggest/src/components/SingleSelection.js
+++ b/components/molecule/autosuggest/src/components/SingleSelection.js
@@ -1,9 +1,8 @@
 /* eslint-disable react/prop-types */
-import {Children, useRef} from 'react'
+import {Children} from 'react'
 
 import MoleculeDropdownList from '@s-ui/react-molecule-dropdown-list'
 import AtomInput from '@s-ui/react-atom-input'
-import useMergeRefs from '@s-ui/react-hooks/lib/useMergeRefs'
 
 import withClearUI from '../hoc/withClearUI'
 
@@ -25,6 +24,7 @@ const MoleculeAutosuggestSingleSelection = ({
   onClear,
   onClickRightIcon,
   onInputKeyDown,
+  onKeyDown,
   onSelect,
   onToggle,
   placeholder,
@@ -36,13 +36,10 @@ const MoleculeAutosuggestSingleSelection = ({
   type,
   value = ''
 }) => {
-  const innerRefInput = useRef()
-  const moleculeInputRef = useMergeRefs(innerRefInput, refInput)
   const handleSelection = (ev, {value}) => {
     onChange(ev, {value})
     onSelect(ev, {value})
     autoClose && onToggle(ev, {isOpen: false})
-    innerRefInput.current && innerRefInput.current.focus()
   }
 
   const handleChange = (ev, {value}) => {
@@ -76,7 +73,7 @@ const MoleculeAutosuggestSingleSelection = ({
         onClickRightIcon={handleRightClick}
         onKeyDown={onInputKeyDown}
         placeholder={placeholder}
-        reference={moleculeInputRef}
+        reference={refInput}
         required={required}
         rightIcon={rightIcon}
         tabIndex={tabIndex}
@@ -90,6 +87,7 @@ const MoleculeAutosuggestSingleSelection = ({
           onSelect={handleSelection}
           value={value}
           highlightQuery={value}
+          onKeyDown={onKeyDown}
         >
           {children}
         </MoleculeDropdownList>

--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -112,8 +112,8 @@ const MoleculeAutosuggest = ({
   const handleKeyDown = ev => {
     ev.persist()
     const {current: domInnerInput} = refMoleculeAutosuggestInput
-    const {current: domMoleculeAutosuggest} = innerRefMoleculeAutosuggest
     const {current: optionsFromRef} = refsMoleculeAutosuggestOptions
+    const {current: innerRefInput} = innerRefMoleculeAutosuggestInput
     const {key} = ev
     const options = optionsFromRef.map(getTarget)
 
@@ -122,7 +122,7 @@ const MoleculeAutosuggest = ({
 
     if (isTypeableKey) {
       if (!isSelectionKey) domInnerInput.focus()
-    } else domMoleculeAutosuggest.focus()
+    }
 
     if (isOpen) {
       const currentElementFocused = getCurrentElementFocused()
@@ -131,9 +131,9 @@ const MoleculeAutosuggest = ({
       else if (key === 'ArrowDown' && !isSomeOptionFocused)
         focusFirstOption(ev, {options})
       else if (isSomeOptionFocused) handleFocusIn(ev)
-    } else {
       if (key === 'Enter') {
         onEnter(ev)
+        innerRefInput && innerRefInput.focus()
       }
     }
   }
@@ -177,8 +177,8 @@ const MoleculeAutosuggest = ({
   }
 
   const handleClick = () => {
-    refMoleculeAutosuggestInput?.current &&
-      refMoleculeAutosuggestInput.current.focus()
+    const {current: innerRefInput} = innerRefMoleculeAutosuggestInput
+    innerRefInput && innerRefInput.focus()
   }
 
   const autosuggestSelectionProps = {
@@ -197,6 +197,7 @@ const MoleculeAutosuggest = ({
     onEnter,
     onFocus,
     onInputKeyDown: handleInputKeyDown,
+    onKeyDown: handleKeyDown,
     onSelect,
     onToggle,
     state,


### PR DESCRIPTION
## MOLECULE/AUTOSUGGEST
**TASK**: <!--- [jira TASK ID](jiraURL) -->


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

Use the arrow keys and press 'enter' when having oppened the dropdown and it will realocate the cursor to the input in order to continue using the Multiple and Single autocomplete modes.

Remove the useMergeRefs drilling

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
[Autocomplete](https://sui-components-lghvfg9z3-schibstedspain.vercel.app/workbench/molecule/autosuggest/demo)
