### PR TITLE
feat(components/molecule/selectPopover): add fullWidth prop

### DIFF
--- a/components/molecule/selectPopover/demo/index.js
+++ b/components/molecule/selectPopover/demo/index.js
@@ -23,6 +23,7 @@ const Demo = () => {
   const [size, setSize] = useState(selectPopoverSizes.MEDIUM)
   const [placement, setPlacement] = useState(selectPopoverPlacements.RIGHT)
   const [hasEvents, setHasEvents] = useState(false)
+  const [isFullWidth, setIsFullWidth] = useState(false)
   const [actionsAreHidden, setActionsAreHidden] = useState(false)
   const [addCustomButton, setAddCustomButton] = useState(false)
 
@@ -99,6 +100,16 @@ const Demo = () => {
           <label>
             <input
               type="checkbox"
+              checked={isFullWidth}
+              onChange={ev => setIsFullWidth(ev.target.checked)}
+            />
+            Full width
+          </label>
+        </div>
+        <div>
+          <label>
+            <input
+              type="checkbox"
               checked={actionsAreHidden}
               onChange={ev => setActionsAreHidden(ev.target.checked)}
             />
@@ -126,6 +137,7 @@ const Demo = () => {
             negative: false,
             color: 'accent'
           }}
+          fullWidth={isFullWidth}
           hideActions={actionsAreHidden}
           iconArrowDown={IconArrowDown}
           isSelected={isSelected}

--- a/components/molecule/selectPopover/src/index.js
+++ b/components/molecule/selectPopover/src/index.js
@@ -22,6 +22,7 @@ function MoleculeSelectPopover({
   customButtonText,
   customButtonOptions,
   children,
+  fullWidth,
   hideActions,
   iconArrowDown: IconArrowDown,
   isSelected = false,
@@ -108,8 +109,10 @@ function MoleculeSelectPopover({
     setIsOpen(true)
   }
 
+  const classNames = cx(BASE_CLASS, fullWidth && `${BASE_CLASS}--fullWidth`)
+
   return (
-    <div className={BASE_CLASS} title={title}>
+    <div className={classNames} title={title}>
       <div
         ref={selectRef}
         className={selectClassName}
@@ -171,6 +174,7 @@ MoleculeSelectPopover.propTypes = {
     negative: PropTypes.bool
   }),
   children: PropTypes.node.isRequired,
+  fullWidth: PropTypes.bool,
   hideActions: PropTypes.bool,
   iconArrowDown: PropTypes.elementType.isRequired,
   isSelected: PropTypes.bool,

--- a/components/molecule/selectPopover/src/index.scss
+++ b/components/molecule/selectPopover/src/index.scss
@@ -106,7 +106,6 @@ $z-select-popover-select-popover: $z-tooltips !default;
     display: block;
 
     #{$self}-select {
-      width: 100%;
       max-width: none;
     }
   }

--- a/components/molecule/selectPopover/src/index.scss
+++ b/components/molecule/selectPopover/src/index.scss
@@ -21,6 +21,7 @@ $cur-select-popover-select: auto !default;
 $z-select-popover-select-popover: $z-tooltips !default;
 
 .sui-MoleculeSelectPopover {
+  $self: &;
   display: inline-block;
   position: relative;
 
@@ -98,6 +99,15 @@ $z-select-popover-select-popover: $z-tooltips !default;
 
     &--left {
       right: 0;
+    }
+  }
+
+  &--fullWidth {
+    display: block;
+
+    #{$self}-select {
+      width: 100%;
+      max-width: none;
     }
   }
 }


### PR DESCRIPTION
## molecule/selectPopover

### Types of changes
- New feature (non-breaking change which adds functionality)

### Description, Motivation and Context
We just need a full width version of the component so it can be adapted to the parent container without unsupported style overrides.

### Screenshots - Animations
![fullWidth](https://user-images.githubusercontent.com/4168389/122403917-0cf34d80-cf7f-11eb-81c3-0b7aa67ce9aa.gif)

