### PR TITLE
[molecule/selectPopover] Add new renderContentWrapper prop

### DIFF
--- a/components/molecule/selectPopover/demo/index.js
+++ b/components/molecule/selectPopover/demo/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import {useState} from 'react'
+import MoleculeModal from '@s-ui/react-molecule-modal'
 import MoleculeSelect from '@s-ui/react-molecule-select'
 import MoleculeSelectOption from '@s-ui/react-molecule-dropdown-option'
 import MoleculeCheckboxField from 'components/molecule/checkboxField/src/'
@@ -26,6 +27,7 @@ const Demo = () => {
   const [isFullWidth, setIsFullWidth] = useState(false)
   const [actionsAreHidden, setActionsAreHidden] = useState(false)
   const [addCustomButton, setAddCustomButton] = useState(false)
+  const [customContentWrapper, setCustomContentWrapper] = useState(false)
 
   const handleChangeItem = event => {
     const {target} = event
@@ -43,6 +45,28 @@ const Demo = () => {
 
   const handleOpen = () => {
     hasEvents && window.alert('Popover opened!')
+  }
+
+  const renderContentWrapper = ({actions, content, isOpen, setIsOpen}) => {
+    const handleClose = () => setIsOpen(false)
+
+    return (
+      <MoleculeModal
+        fitWindow
+        isContentless
+        isOpen={isOpen}
+        onClose={handleClose}
+      >
+        <MoleculeModal.Content withoutIndentation>
+          {content}
+        </MoleculeModal.Content>
+        <MoleculeModal.Footer>
+          <div style={{display: 'flex', justifyContent: 'flex-end'}}>
+            {actions}
+          </div>
+        </MoleculeModal.Footer>
+      </MoleculeModal>
+    )
   }
 
   const checkedItems = items.filter(item => item.checked)
@@ -126,6 +150,16 @@ const Demo = () => {
             Add custom button
           </label>
         </div>
+        <div>
+          <label>
+            <input
+              type="checkbox"
+              checked={customContentWrapper}
+              onChange={ev => setCustomContentWrapper(ev.target.checked)}
+            />
+            Custom content wrapper as a modal
+          </label>
+        </div>
 
         <h3>Component</h3>
         <MoleculeSelectPopover
@@ -137,6 +171,7 @@ const Demo = () => {
             negative: false,
             color: 'accent'
           }}
+          renderContentWrapper={customContentWrapper && renderContentWrapper}
           fullWidth={isFullWidth}
           hideActions={actionsAreHidden}
           iconArrowDown={IconArrowDown}

--- a/components/molecule/selectPopover/demo/index.js
+++ b/components/molecule/selectPopover/demo/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import {useState} from 'react'
+import IconClose from '@s-ui/react-icons/lib/Close'
 import MoleculeModal from '@s-ui/react-molecule-modal'
 import MoleculeSelect from '@s-ui/react-molecule-select'
 import MoleculeSelectOption from '@s-ui/react-molecule-dropdown-option'
@@ -53,6 +54,7 @@ const Demo = () => {
     return (
       <MoleculeModal
         fitWindow
+        iconClose={<IconClose size="medium" />}
         isContentless
         isOpen={isOpen}
         onClose={handleClose}
@@ -60,11 +62,13 @@ const Demo = () => {
         <MoleculeModal.Content withoutIndentation>
           {content}
         </MoleculeModal.Content>
-        <MoleculeModal.Footer>
-          <div style={{display: 'flex', justifyContent: 'flex-end'}}>
-            {actions}
-          </div>
-        </MoleculeModal.Footer>
+        {!actionsAreHidden && (
+          <MoleculeModal.Footer>
+            <div style={{display: 'flex', justifyContent: 'flex-end'}}>
+              {actions}
+            </div>
+          </MoleculeModal.Footer>
+        )}
       </MoleculeModal>
     )
   }

--- a/components/molecule/selectPopover/demo/index.scss
+++ b/components/molecule/selectPopover/demo/index.scss
@@ -1,4 +1,5 @@
 @import '~@s-ui/theme/lib/index';
+@import '~@s-ui/react-molecule-modal/lib/index';
 @import '~@s-ui/react-molecule-select/lib/index';
 @import '~@s-ui/react-molecule-dropdown-option/lib/index';
 @import 'components/molecule/checkboxField/src/index';

--- a/components/molecule/selectPopover/demo/package.json
+++ b/components/molecule/selectPopover/demo/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@s-ui/react-icons": "1",
     "@s-ui/react-molecule-dropdown-option": "1",
     "@s-ui/react-molecule-modal": "1",
     "@s-ui/react-molecule-select": "1"

--- a/components/molecule/selectPopover/demo/package.json
+++ b/components/molecule/selectPopover/demo/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@s-ui/react-molecule-dropdown-option": "1",
+    "@s-ui/react-molecule-modal": "1",
     "@s-ui/react-molecule-select": "1"
   }
 }

--- a/components/molecule/selectPopover/src/index.scss
+++ b/components/molecule/selectPopover/src/index.scss
@@ -109,4 +109,10 @@ $z-select-popover-select-popover: $z-tooltips !default;
       max-width: none;
     }
   }
+
+  &--hasCustomWrapper {
+    #{$self}-selectIcon {
+      transform: rotate(-90deg) !important;
+    }
+  }
 }


### PR DESCRIPTION
## molecule/selectPopover

### Types of changes
- New feature (non-breaking change which adds functionality)

### Description, Motivation and Context

- [x] Add new [render prop](https://es.reactjs.org/docs/render-props.html) `renderContentWrapper` so content can be wrapped into something else while preserving original actions and state.

> NOTE:
> 
> As discussed with @turolopezsanabria this is not SUI compliant, but there's an unsupported implementation running in production so we need support for it.
> 
> `molecule/selectPopover` will be deprecated in the future anyway, as new `select` components will be created following more strict standard guidelines.

### Screenshots - Animations
<img width="360" src="https://user-images.githubusercontent.com/4168389/122537509-eb00d600-d025-11eb-9af8-eb89eddbe2bb.gif">

