### PR TITLE
Feat/enable secondary color for buttons

### DIFF
--- a/components/atom/button/demo/index.js
+++ b/components/atom/button/demo/index.js
@@ -64,9 +64,15 @@ const starIcon = (
 
 const atomButtonColorsIterator = atomButtonColors
   .filter(color =>
-    ['primary', 'accent', 'neutral', 'success', 'alert', 'error'].includes(
-      color
-    )
+    [
+      'primary',
+      'secondary',
+      'accent',
+      'neutral',
+      'success',
+      'alert',
+      'error'
+    ].includes(color)
   )
   .map((color, index) => [{color}, index])
 const atomButtonSocialColorsIterator = atomButtonColors
@@ -354,7 +360,7 @@ const Demo = () => {
             are solid by default for each <Code>design</Code>.
           </Paragraph>
           <Article>
-            <Grid cols={7} gutter={10}>
+            <Grid cols={8} gutter={10}>
               <Cell />
               {atomButtonColorsIterator.map(([{color}], index) => (
                 <Cell key={index} style={flexCenteredStyle}>
@@ -385,7 +391,7 @@ const Demo = () => {
             dark backgrounds.
           </Paragraph>
           <Article mode="dark">
-            <Grid cols={7} gutter={10}>
+            <Grid cols={8} gutter={10}>
               <Cell />
               {atomButtonColorsIterator.map(([{color}], index) => (
                 <Cell key={index} style={flexCenteredStyle}>

--- a/components/atom/button/src/config.js
+++ b/components/atom/button/src/config.js
@@ -29,6 +29,7 @@ export const ALIGNMENT = {
  */
 export const COLORS = [
   'primary',
+  'secondary',
   'accent',
   'neutral',
   'success',

--- a/components/atom/button/src/index.scss
+++ b/components/atom/button/src/index.scss
@@ -7,6 +7,8 @@ $c-accent-hover: color-variation($c-accent, -1) !default;
 $c-accent-flat-hover: color-variation($c-accent, 4) !default;
 $c-primary-hover: color-variation($c-primary, -1) !default;
 $c-primary-flat-hover: color-variation($c-primary, 4) !default;
+$c-secondary-hover: color-variation($c-secondary, -1) !default;
+$c-secondary-flat-hover: color-variation($c-secondary, 4) !default;
 
 $c-atom-button-colors: (
   'primary': (
@@ -14,6 +16,12 @@ $c-atom-button-colors: (
     $c-white,
     $c-primary-hover,
     $c-primary-flat-hover
+  ),
+  'secondary': (
+    $c-secondary,
+    $c-white,
+    $c-secondary-hover,
+    $c-secondary-flat-hover
   ),
   'accent': (
     $c-accent,


### PR DESCRIPTION
## ATOM/BUTTON
<!--- **TASK**: [jira TASK ID](jiraURL) -->


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

Some verticals use a secondary color for buttons (in addition of the accent one) and most of the times the style is overwritten to achieve a 'secondary' color style instead using the Theme Variables.

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
We can find a quick example in the Fotocasa home page:

![image](https://user-images.githubusercontent.com/66824007/123661646-009baa00-d835-11eb-8a36-b1f6c75b36ac.png)

