### PR TITLE
docs(Root): directing to discussions instead of issues

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -4,12 +4,12 @@
 
 ## Contribute
 
-<a href="https://github.com/SUI-Components/sui-components/issues/new?template=report-a-bug---issue.md" target="_blank">Report a bug or issue</a>
+<a href="https://github.com/SUI-Components/sui-components/issues/new?template=report-a-bug---issue.md" target="_blank">Report a bug or defect</a>
 
-<a href="https://github.com/SUI-Components/sui-components/issues/new?template=improve-and-existing-component.md" target="_blank">Improve an existing component</a>
+<a href="https://github.com/SUI-Components/sui-components/discussions/new" target="_blank">Improve an existing component</a>
 
-<a href="https://github.com/SUI-Components/sui-components/issues/new?template=propose-a-new-component.md" target="_blank">Propose a new component</a>
+<a href="https://github.com/SUI-Components/sui-components/discussions/new" target="_blank">Propose a new component</a>
 
 ## Current status
 
-<a href="https://pages.github.mpi-internal.com/scmspain/sui-dashboard/" target="_blank">SUI Dashboard</a> <i>(Restricted to Adevintians)</i>
+<a href="https://pages.github.mpi-internal.com/scmspain/design-systems/sui/index.html" target="_blank">Performance dashboard</a>


### PR DESCRIPTION
## Docs Links in [SUI Components homepage](https://sui-components.vercel.app/)

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Only
- [ ] Refactor

### Description, Motivation and Context

Now that we have [discussions](https://github.com/SUI-Components/sui-components/discussions) we recommend starting conversations there instead of using issues as initial entry point, leaving that for bugs and defects.

### Piggy Bag change

I've updated the link to the Dashboard with the correct url
