### PR TITLE
feat(components/molecule/select): limit the number of posible selected items

### DIFF
--- a/components/atom/tag/src/_settings.scss
+++ b/components/atom/tag/src/_settings.scss
@@ -30,10 +30,10 @@ $c-atom-tag-actionable-invert--hover: $c-white !default;
 $w-atom-tag-clickable: 32px !default;
 
 // closable
-$bgc-atom-tag-closable-icon: $c-system !default;
-$c-atom-tag-closable-icon: $c-gray !default;
-$bgc-atom-tag-closable-icon--hover: $bgc-atom-tag-closable-icon;
-$c-atom-tag-closable-icon--hover: $c-atom-tag-closable-icon;
+$bgc-atom-tag-closable-icon: transparent !default;
+$c-atom-tag-closable-icon: transparent !default;
+$bgc-atom-tag-closable-icon--hover: $c-system !default;
+$c-atom-tag-closable-icon--hover: $c-gray !default;
 
 // types
 $atom-tag-types: () !default;

--- a/components/atom/tag/src/_settings.scss
+++ b/components/atom/tag/src/_settings.scss
@@ -30,8 +30,10 @@ $c-atom-tag-actionable-invert--hover: $c-white !default;
 $w-atom-tag-clickable: 32px !default;
 
 // closable
-$bgc-atom-tag-closable-icon--hover: $c-system !default;
-$c-atom-tag-closable-icon--hover: $c-gray !default;
+$bgc-atom-tag-closable-icon: $c-system !default;
+$c-atom-tag-closable-icon: $c-gray !default;
+$bgc-atom-tag-closable-icon--hover: $bgc-atom-tag-closable-icon;
+$c-atom-tag-closable-icon--hover: $c-atom-tag-closable-icon;
 
 // types
 $atom-tag-types: () !default;

--- a/components/atom/tag/src/index.scss
+++ b/components/atom/tag/src/index.scss
@@ -77,10 +77,13 @@ $base-class: '.sui-AtomTag';
       cursor: pointer;
       line-height: initial;
       position: relative;
+      border-radius: $bdrs-rounded;
+      background-color: $bgc-atom-tag-closable-icon;
+      fill: color-variation($c-atom-tag-closable-icon, 3);
+      color: color-variation($c-atom-tag-closable-icon, 3);
 
       &:hover {
         background-color: $bgc-atom-tag-closable-icon--hover;
-        border-radius: $bdrs-rounded;
         fill: color-variation($c-atom-tag-closable-icon--hover, 3);
         color: color-variation($c-atom-tag-closable-icon--hover, 3);
       }

--- a/components/molecule/select/README.md
+++ b/components/molecule/select/README.md
@@ -18,21 +18,22 @@ import MoleculeSelect, {
 } from '@s-ui/react-molecule-select'
 import MoleculeSelectOption from '@s-ui/react-molecule-dropdown-option'
 
-const IconCloseTag = () => <span>x</span>  
-const IconArrowDown = () => <span>▼</span>  
+const IconCloseTag = () => <span>x</span>
+const IconArrowDown = () => <span>▼</span>
 
-const options = ['John','Paul','George','Ringo']
+const options = ['John', 'Paul', 'George', 'Ringo']
 ```
 
 ### Single Selection
 
 #### Basic usage
+
 ```js
 <MoleculeSelect
-      placeholder="Select a Country..."
-      onChange={(_, {value}) => console.log(value)}
-      iconArrowDown={<IconArrowDown />}
-    >
+  placeholder="Select a Country..."
+  onChange={(_, {value}) => console.log(value)}
+  iconArrowDown={<IconArrowDown />}
+>
   {options.map((option, i) => (
     <MoleculeSelectOption key={i} value={option}>
       {option}
@@ -42,13 +43,14 @@ const options = ['John','Paul','George','Ringo']
 ```
 
 #### With default value
+
 ```js
 <MoleculeSelect
-      placeholder="Select a Country..."
-      onChange={(_, {value}) => console.log(value)}
-      iconArrowDown={<IconArrowDown />}
-      value='John'
-    >
+  placeholder="Select a Country..."
+  onChange={(_, {value}) => console.log(value)}
+  iconArrowDown={<IconArrowDown />}
+  value="John"
+>
   {options.map((option, i) => (
     <MoleculeSelectOption key={i} value={option}>
       {option}
@@ -58,13 +60,14 @@ const options = ['John','Paul','George','Ringo']
 ```
 
 #### Large List
+
 ```js
 <MoleculeSelect
-      placeholder="Select a Country..."
-      onChange={(_, {value}) => console.log(value)}
-      iconArrowDown={<IconArrowDown />}
-      size={moleculeSelectDropdownListSizes.LARGE}
-    >
+  placeholder="Select a Country..."
+  onChange={(_, {value}) => console.log(value)}
+  iconArrowDown={<IconArrowDown />}
+  size={moleculeSelectDropdownListSizes.LARGE}
+>
   {options.map((option, i) => (
     <MoleculeSelectOption key={i} value={option}>
       {option}
@@ -74,15 +77,16 @@ const options = ['John','Paul','George','Ringo']
 ```
 
 #### With state highlight
+
 Can be `success`, `error` or `alert`.
 
 ```js
 <MoleculeSelect
-      placeholder="Select a Country..."
-      onChange={(_, {value}) => console.log(value)}
-      iconArrowDown={<IconArrowDown />}
-      state="success"
-    >
+  placeholder="Select a Country..."
+  onChange={(_, {value}) => console.log(value)}
+  iconArrowDown={<IconArrowDown />}
+  state="success"
+>
   {options.map((option, i) => (
     <MoleculeSelectOption key={i} value={option}>
       {option}
@@ -94,12 +98,31 @@ Can be `success`, `error` or `alert`.
 ### Multiple Selection
 
 #### Basic usage
+
 ```js
- <MoleculeSelect
+<MoleculeSelect
   iconCloseTag={<IconCloseTag />}
   iconArrowDown={<IconArrowDown />}
   multiselection
-  value={['John','Paul']}
+  value={['John', 'Paul']}
+>
+  {options.map((option, i) => (
+    <MoleculeSelectOption key={i} value={option}>
+      {option}
+    </MoleculeSelectOption>
+  ))}
+</MoleculeSelect>
+```
+
+#### With tags limit
+
+```js
+<MoleculeSelect
+  iconCloseTag={<IconCloseTag />}
+  iconArrowDown={<IconArrowDown />}
+  multiselection
+  value={['John', 'Paul']}
+  max={2}
 >
   {options.map((option, i) => (
     <MoleculeSelectOption key={i} value={option}>
@@ -123,7 +146,7 @@ import React, {Component} from 'react'
 import MoleculeSelect from '@s-ui/react-molecule-select'
 import MoleculeSelectOption from '@s-ui/react-molecule-dropdown-option'
 
-const options = ['John','Paul','George','Ringo']
+const options = ['John', 'Paul', 'George', 'Ringo']
 
 export default class SelectSingleWithAsyncOptions extends Component {
   state = {value: ''}
@@ -147,22 +170,20 @@ export default class SelectSingleWithAsyncOptions extends Component {
     )
   }
 }
-
 ```
 
 so then, the `SelectSingleWithAsyncOptions` can used in this way...
 
 ```js
-  <SelectSingleWithAsyncOptions iconClear={<IconClear />} />
+<SelectSingleWithAsyncOptions iconClear={<IconClear />} />
 ```
 
 ### Using the hoc `withStateValue`
 
-There's a hoc called `withStateValue` available at `@s-ui/hoc` 
-that can be used to simplify the use of this component with internal state 
+There's a hoc called `withStateValue` available at `@s-ui/hoc`
+that can be used to simplify the use of this component with internal state
 
 ```js
-
 import MoleculeSelect from '@s-ui/react-molecule-select'
 import MoleculeSelectOption from '@s-ui/react-molecule-dropdown-option'
 
@@ -170,8 +191,7 @@ import withDynamicOptions from './hoc/withDynamicOptions'
 import {withStateValue} from '@s-ui/hoc'
 
 const MoleculeSelectWithState = withStateValue(MoleculeSelect)
-const options = ['John','Paul','George','Ringo']
-
+const options = ['John', 'Paul', 'George', 'Ringo']
 ```
 
 so then, the `MoleculeSelectWithState` can be used in this way...
@@ -245,7 +265,5 @@ so then you can do something like...
   ))}
 </MoleculeSelect>
 ```
-
-
 
 > **Find full description and more examples in the [demo page](https://sui-components.now.sh/workbench/molecule/select/demo).**

--- a/components/molecule/select/README.md
+++ b/components/molecule/select/README.md
@@ -114,7 +114,7 @@ Can be `success`, `error` or `alert`.
 </MoleculeSelect>
 ```
 
-#### With tags limit
+#### With selected items limit
 
 ```js
 <MoleculeSelect

--- a/components/molecule/select/demo/index.js
+++ b/components/molecule/select/demo/index.js
@@ -177,9 +177,10 @@ const Demo = () => (
       </div>
 
       <div className={CLASS_DEMO_SECTION}>
-        <h3>With Placeholder</h3>
+        <h3>With preselected Value</h3>
         <MoleculeSelectWithState
           placeholder="Select some countries..."
+          value={['India', 'Luxembourg']}
           onChange={(_, {value}) => console.log(value)}
           iconCloseTag={<IconCloseTag />}
           iconArrowDown={<IconArrowDown />}
@@ -211,7 +212,7 @@ const Demo = () => (
       </div>
 
       <div className={CLASS_DEMO_SECTION}>
-        <h3>With tags limit</h3>
+        <h3>With selected items limit</h3>
         <MoleculeSelectWithState
           placeholder="Select some countries..."
           value={['India', 'Luxembourg']}

--- a/components/molecule/select/demo/index.js
+++ b/components/molecule/select/demo/index.js
@@ -177,10 +177,9 @@ const Demo = () => (
       </div>
 
       <div className={CLASS_DEMO_SECTION}>
-        <h3>With preselected Value</h3>
+        <h3>With Placeholder</h3>
         <MoleculeSelectWithState
           placeholder="Select some countries..."
-          value={['India', 'Luxembourg']}
           onChange={(_, {value}) => console.log(value)}
           iconCloseTag={<IconCloseTag />}
           iconArrowDown={<IconArrowDown />}
@@ -206,6 +205,25 @@ const Demo = () => (
           {countriesData.map(({name, code}, i) => (
             <MoleculeSelectOption key={i} value={code}>
               {name}
+            </MoleculeSelectOption>
+          ))}
+        </MoleculeSelectWithState>
+      </div>
+
+      <div className={CLASS_DEMO_SECTION}>
+        <h3>With tags limit</h3>
+        <MoleculeSelectWithState
+          placeholder="Select some countries..."
+          value={['India', 'Luxembourg']}
+          onChange={(_, {value}) => console.log(value)}
+          iconCloseTag={<IconCloseTag />}
+          iconArrowDown={<IconArrowDown />}
+          multiselection
+          maxTags={2}
+        >
+          {countriesList.map((country, i) => (
+            <MoleculeSelectOption key={i} value={country}>
+              {country}
             </MoleculeSelectOption>
           ))}
         </MoleculeSelectWithState>

--- a/components/molecule/select/src/components/MultipleSelection.js
+++ b/components/molecule/select/src/components/MultipleSelection.js
@@ -23,25 +23,41 @@ const MoleculeSelectFieldMultiSelection = props => {
     required,
     optionsData = {},
     selectSize,
-    tabIndex
+    tabIndex,
+    maxTags
   } = props
 
+  const tags = values.map(value => optionsData[value])
+
   const handleMultiSelection = (ev, {value: valueOptionSelected}) => {
-    const newValues = values.includes(valueOptionSelected)
-      ? values.filter(value => value !== valueOptionSelected)
-      : [...values, valueOptionSelected]
-    const {key} = ev
-    const isKeySelection = keysSelection.includes(key)
-    onChange(ev, {value: newValues})
-    if (ev.key !== undefined && !isKeySelection) onToggle(ev, {isOpen: false})
+    const handleToggle = ev => {
+      const {key} = ev
+      const isKeySelection = keysSelection.includes(key)
+      if (ev.key !== undefined && !isKeySelection) onToggle(ev, {isOpen: false})
+    }
+
+    const isValueSelectedAlreadySelected = () =>
+      values.includes(valueOptionSelected)
+
+    const removeFromValues = () =>
+      values.filter(value => value !== valueOptionSelected)
+
+    const addToValues = () => [...values, valueOptionSelected]
+
+    const isFull = () => maxTags && tags?.length >= maxTags
+
+    if (isValueSelectedAlreadySelected()) {
+      onChange(ev, {value: removeFromValues()})
+    } else if (!isFull()) {
+      onChange(ev, {value: addToValues()})
+    }
+    handleToggle(ev)
   }
 
   const handleChangeTags = (ev, {tags: value}) => {
     onChange(ev, {value})
     refMoleculeSelect.current.focus()
   }
-
-  const tags = values.map(value => optionsData[value])
 
   return (
     <>
@@ -61,6 +77,7 @@ const MoleculeSelectFieldMultiSelection = props => {
         required={required}
         size={selectSize}
         tabIndex={tabIndex}
+        maxTags={maxTags}
       />
       <MoleculeDropdownList
         checkbox

--- a/components/molecule/select/src/index.js
+++ b/components/molecule/select/src/index.js
@@ -197,6 +197,9 @@ MoleculeSelect.propTypes = {
   /** if select accept single value or multiple values */
   multiselection: PropTypes.bool,
 
+  /** if multiselection, limit the number of selected values */
+  maxTags: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
   /** value selected */
   value: PropTypes.any,
 

--- a/components/molecule/select/src/index.js
+++ b/components/molecule/select/src/index.js
@@ -198,7 +198,7 @@ MoleculeSelect.propTypes = {
   multiselection: PropTypes.bool,
 
   /** if multiselection, limit the number of selected values */
-  maxTags: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  maxTags: PropTypes.number,
 
   /** value selected */
   value: PropTypes.any,


### PR DESCRIPTION
## MOLECULE/SELECT



### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
🆕  New prop **`maxTags`** that limits the numbers of selected items.
🔦  It follows the same API defined for the `MoleculeInputTags` component.

### Screenshots - Animations

In the next example, `maxTags` is 3.

![maxtags](https://user-images.githubusercontent.com/32937662/125459113-fdbaab18-124e-4880-8e78-8a55f1704909.gif)
