### PR TITLE
fix(components/atom/popover): fix css selector for show arrows

### DIFF
--- a/components/atom/popover/src/index.scss
+++ b/components/atom/popover/src/index.scss
@@ -92,7 +92,7 @@ $class-arrow: '#{$base-class}-arrow';
     }
   }
 
-  &#{$base-class}--top {
+  &--top {
     margin: $mt-atom-popover 0;
 
     #{$class-arrow} {
@@ -101,7 +101,7 @@ $class-arrow: '#{$base-class}-arrow';
     }
   }
 
-  &#{$base-class}--right {
+  &--right {
     margin: 0 $mr-atom-popover;
 
     #{$class-arrow} {
@@ -110,7 +110,7 @@ $class-arrow: '#{$base-class}-arrow';
     }
   }
 
-  &#{$base-class}--bottom {
+  &--bottom {
     margin: $mb-atom-popover 0;
 
     #{$class-arrow} {
@@ -118,7 +118,7 @@ $class-arrow: '#{$base-class}-arrow';
     }
   }
 
-  &#{$base-class}--left {
+  &--left {
     margin: 0 $ml-atom-popover;
 
     #{$class-arrow} {
@@ -127,7 +127,7 @@ $class-arrow: '#{$base-class}-arrow';
     }
   }
 
-  &#{$base-class}--auto {
+  &--auto {
     &[x-placement^='top'] {
       @extend #{$base-class}--top;
     }


### PR DESCRIPTION
## ATOM/POPOVER
**TASK**: <!--- [jira TASK ID](jiraURL) -->


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
Fix AtomPopover arrow position when `hideArrow` prop is `false`, by default is `true`.

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
**Before:**

![image](https://user-images.githubusercontent.com/11008947/126113898-fdc1d66d-06e9-4e1b-a6af-20da40168b5e.png)


**After:**

![image](https://user-images.githubusercontent.com/11008947/126113941-dc42a756-ecce-41a8-9445-0e2ec75b429b.png)


