### PR TITLE
fix(components/atom/tag): add correct color variables

### DIFF
--- a/components/atom/tag/src/_settings.scss
+++ b/components/atom/tag/src/_settings.scss
@@ -32,7 +32,7 @@ $w-atom-tag-clickable: 32px !default;
 // closable
 $bgc-atom-tag-closable-icon: transparent !default;
 $c-atom-tag-closable-icon: $c-system !default;
-$bgc-atom-tag-closable-icon--hover: $c-system !default;
+$bgc-atom-tag-closable-icon--hover: $c-gray !default;
 $c-atom-tag-closable-icon--hover: $c-gray-light-3 !default;
 
 // types

--- a/components/atom/tag/src/_settings.scss
+++ b/components/atom/tag/src/_settings.scss
@@ -31,9 +31,9 @@ $w-atom-tag-clickable: 32px !default;
 
 // closable
 $bgc-atom-tag-closable-icon: transparent !default;
-$c-atom-tag-closable-icon: transparent !default;
+$c-atom-tag-closable-icon: $c-system !default;
 $bgc-atom-tag-closable-icon--hover: $c-system !default;
-$c-atom-tag-closable-icon--hover: $c-gray !default;
+$c-atom-tag-closable-icon--hover: $c-gray-light-3 !default;
 
 // types
 $atom-tag-types: () !default;

--- a/components/atom/tag/src/index.scss
+++ b/components/atom/tag/src/index.scss
@@ -79,13 +79,13 @@ $base-class: '.sui-AtomTag';
       position: relative;
       border-radius: $bdrs-rounded;
       background-color: $bgc-atom-tag-closable-icon;
-      fill: color-variation($c-atom-tag-closable-icon, 3);
-      color: color-variation($c-atom-tag-closable-icon, 3);
+      fill: $c-atom-tag-closable-icon;
+      color: $c-atom-tag-closable-icon;
 
       &:hover {
         background-color: $bgc-atom-tag-closable-icon--hover;
-        fill: color-variation($c-atom-tag-closable-icon--hover, 3);
-        color: color-variation($c-atom-tag-closable-icon--hover, 3);
+        fill: $c-atom-tag-closable-icon--hover;
+        color: $c-atom-tag-closable-icon--hover;
       }
     }
   }


### PR DESCRIPTION
## ATOM/TAG

**TASK**:  [Github issue](https://github.com/SUI-Components/sui-components/issues/1622)

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context

Color variables were not well defined

### Screenshots - Animations

THEN:
<img width="135" alt="Captura de pantalla 2021-08-04 a las 10 39 25" src="https://user-images.githubusercontent.com/16401219/128150285-0e319950-589a-427a-ae8a-57e9cafe7be3.png">


NOW:
<img width="135" alt="Captura de pantalla 2021-08-04 a las 10 38 46" src="https://user-images.githubusercontent.com/16401219/128150190-2ae20d5a-3af1-4531-961a-0b3a3caf37c3.png">

