### PR TITLE
refactor(components/atom/progressBar): add token for progressBar container border

### DIFF
--- a/components/atom/progressBar/src/LineDoubleProgressBar/index.scss
+++ b/components/atom/progressBar/src/LineDoubleProgressBar/index.scss
@@ -7,6 +7,7 @@ $c-progress-bar-fill: $c-primary !default;
 $trsdu-progress-bar: 500ms !default;
 $trstf-progress-bar: linear !default;
 
+$bd-line-double-progress-container: $bdw-s solid $bc-progress-bar !default;
 $br-progress-container: $bdrs-l !default;
 $br-progress-bar: $bdrs-l !default;
 $h-progress-bar: $m-base !default;
@@ -32,7 +33,7 @@ $trsdu-progress-exrta-bar: 500ms !default;
   &-container {
     background: $bg-progress-bar;
     border-radius: $br-progress-container;
-    border: $bdw-s solid $bc-progress-bar;
+    border: $bd-line-double-progress-container;
     height: $h-progress-bar; /* Can be anything */
     position: relative;
   }

--- a/components/atom/progressBar/src/LineProgressBar/index.scss
+++ b/components/atom/progressBar/src/LineProgressBar/index.scss
@@ -7,6 +7,7 @@ $c-progress-bar-fill: $c-primary !default;
 $trsdu-progress-bar: 500ms !default;
 $trstf-progress-bar: linear !default;
 
+$bd-line-progress-container: $bdw-s solid $bc-progress-bar !default;
 $br-progress-container: $bdrs-l !default;
 $br-progress-bar: $bdrs-l !default;
 $h-progress-bar: $m-base !default;
@@ -28,7 +29,7 @@ $h-progress-bar: $m-base !default;
 
   &-container {
     background: $bg-progress-bar;
-    border: $bdw-s solid $bc-progress-bar;
+    border: $bd-line-progress-container;
     border-radius: $br-progress-container;
     height: $h-progress-bar; /* Can be anything */
     position: relative;


### PR DESCRIPTION
## atom/progressBar

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [x] Refactor

### Description, Motivation and Context
This change is required to be able to set progressBar's border without override it's css properties, just using a token.

### Screenshots - Animations
**Before**
For this change you would have to do something like this in your .scss file:
![image](https://user-images.githubusercontent.com/22194171/128341342-72299477-8854-4bf0-bb26-15380f1dd1e1.png)

**After**
You can just create a `_settings.scss` file and override the variable.
![image](https://user-images.githubusercontent.com/22194171/128341460-2f1f2ec6-bc22-4153-ba7a-392cbebe8506.png)
