### PR TITLE
feat(components/molecule/inputTags): add border-radius variable

### DIFF
--- a/components/molecule/inputTags/src/index.scss
+++ b/components/molecule/inputTags/src/index.scss
@@ -9,9 +9,11 @@ $class-input: '#{$base-class}-input';
 
 $sizes-atom-input-paddings: m $p-m, s $p-s !default;
 $bg-input-tag-disable: $c-gray-light-4 !default;
+$bdrs-molecule-input-tags: 0 !default;
 
 #{$class-tags} {
   @extend %sui-atom-input-input;
+  border-radius: $bdrs-molecule-input-tags;
   align-items: center;
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## molecule/inputTags

### Types of changes
Add the scss variable _$bdrs-molecule-input-tags_ to apply a border-radius on the main wrapper.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor