### PR TITLE
feat(components/atom/tag): pass value and label to onClose event

### DIFF
--- a/components/atom/tag/README.md
+++ b/components/atom/tag/README.md
@@ -116,12 +116,14 @@ $atom-tag-types: (
 
 ### Value
 
-Use the prop value if you want to use this the value on you onClick handler
+Use the prop value if you want to use this value on your onClick/onClose handler.
 
 ```js
 <AtomTag
   label="Tag with value"
   onClick={(_, {value}) => alert('click! this is my value', value)}
+  onClose={(_, {value}) => alert('click! this is my value', value)}
+  iconClose={<IconClose />}
   value={'test}
 />
 ```

--- a/components/atom/tag/README.md
+++ b/components/atom/tag/README.md
@@ -122,9 +122,21 @@ Use the prop value if you want to use this value on your onClick/onClose handler
 <AtomTag
   label="Tag with value"
   onClick={(_, {value}) => alert('click! this is my value', value)}
-  onClose={(_, {value}) => alert('click! this is my value', value)}
-  iconClose={<IconClose />}
-  value={'test}
+  value={42}
+/>
+```
+
+### onClose
+
+The onClose event is triggered when the passed `closeIcon` is clicked.
+It receives the native event as first argument and an object with the passed `label` and `value` as second argument.
+
+```js
+<AtomTag
+  label="Tag with value"
+  value={42}
+  onClose={(_, {value, label}) => alert('Click! These are my value and label', {value, label})}
+  closeIcon={<IconClose />}
 />
 ```
 

--- a/components/atom/tag/demo/index.js
+++ b/components/atom/tag/demo/index.js
@@ -297,6 +297,7 @@ export default () => (
       <AtomTag
         closeIcon={closeIcon}
         label="Close Tag"
+        value="Close Tag"
         onClose={() => window.alert('close!')}
         responsive
       />

--- a/components/atom/tag/demo/index.js
+++ b/components/atom/tag/demo/index.js
@@ -32,6 +32,10 @@ const closeIcon = (
   </AtomIcon>
 )
 
+const handleClose = (_event, data) => {
+  window.alert(`Click on close icon for tag with data: ${JSON.stringify(data)}`)
+}
+
 const BASE_CLASS_DEMO = `DemoAtomTag`
 const CLASS_SECTION = `${BASE_CLASS_DEMO}-section`
 
@@ -298,7 +302,7 @@ export default () => (
         closeIcon={closeIcon}
         label="Close Tag"
         value="Close Tag"
-        onClose={() => window.alert('close!')}
+        onClose={handleClose}
         responsive
       />
     </Article>
@@ -314,7 +318,7 @@ export default () => (
           closeIcon={closeIcon}
           icon={icon}
           label="Icon & Close Tag"
-          onClose={() => window.alert('close!')}
+          onClose={handleClose}
           responsive
           size={atomTagSizes.SMALL}
         />
@@ -330,14 +334,14 @@ export default () => (
           closeIcon={closeIcon}
           icon={icon}
           label="Icon & Close Tag"
-          onClose={() => window.alert('close!')}
+          onClose={handleClose}
           responsive
         />
         <AtomTag
           closeIcon={closeIcon}
           icon={icon}
           label="Icon & Close Tag"
-          onClose={() => window.alert('close!')}
+          onClose={handleClose}
           responsive
           size={atomTagSizes.LARGE}
         />

--- a/components/atom/tag/src/Standard.js
+++ b/components/atom/tag/src/Standard.js
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
-const StandardTag = ({className, closeIcon, icon, label, onClose}) => {
+const StandardTag = ({className, closeIcon, icon, label, onClose, value}) => {
   const classNames = cx(className, closeIcon && 'sui-AtomTag-hasClose')
 
   const handleClick = ev => {
-    onClose(ev)
+    onClose(ev, {value, label})
     ev.stopPropagation()
   }
 
@@ -31,7 +31,8 @@ StandardTag.propTypes = {
   closeIcon: PropTypes.node,
   icon: PropTypes.node,
   label: PropTypes.string.isRequired,
-  className: PropTypes.string
+  className: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 }
 
 StandardTag.propTypes = {

--- a/components/atom/tag/src/constants.js
+++ b/components/atom/tag/src/constants.js
@@ -4,8 +4,7 @@ export const ACTIONABLE_ONLY_PROPS = [
   'target',
   'actionable',
   'linkFactory',
-  'rel',
-  'value'
+  'rel'
 ]
 
 export const STANDARD_ONLY_PROPS = ['closeIcon', 'onClose']


### PR DESCRIPTION
## atom/Tag

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
Pass to the onClose event relevant details such as value and label, in order to use these data to interact with a specific closed item.

