### PR TITLE
feat(components/molecule/avatar): Add muted variant

### DIFF
--- a/components/molecule/avatar/src/AvatarBadge/index.js
+++ b/components/molecule/avatar/src/AvatarBadge/index.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types'
 
 export const AVATAR_BADGE_STATUSES = {
   ERROR: 'error',
-  SUCCESS: 'success'
+  SUCCESS: 'success',
+  MUTED: 'muted'
 }
 
 export const AVATAR_BADGE_PLACEMENTS = {

--- a/components/molecule/avatar/src/AvatarBadge/index.js
+++ b/components/molecule/avatar/src/AvatarBadge/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 export const AVATAR_BADGE_STATUSES = {
   ERROR: 'error',
   SUCCESS: 'success',
+  ALERT: 'alert',
   MUTED: 'muted'
 }
 

--- a/components/molecule/avatar/src/AvatarBadge/index.scss
+++ b/components/molecule/avatar/src/AvatarBadge/index.scss
@@ -16,15 +16,6 @@ $bw-avatar-badge: (
   xsmall: 1px
 ) !default;
 
-$bw-avatar-badge-muted: (
-  xxlarge: 5px,
-  xlarge: 5px,
-  large: 4px,
-  medium: 4px,
-  small: 3px,
-  xsmall: 3px
-) !default;
-
 $bdc-avatar-badge: white !default;
 $bdc-avatar-badge-muted: #d7dcdf !default;
 
@@ -64,16 +55,19 @@ $bdc-avatar-badge-muted: #d7dcdf !default;
       border: $bw solid $bdc-avatar-badge;
     }
     &--#{$key-size}#{&}--muted {
-      border: map-get($bw-avatar-badge-muted, $key-size)
-        solid
-        $bdc-avatar-badge-muted;
-      box-shadow: inset
-          0
-          0
-          0
-          map-get($bw-avatar-badge-muted, $key-size)
-          $bdc-avatar-badge,
-        0 0 0 map-get($bw-avatar-badge-muted, $key-size) $bdc-avatar-badge;
+      background: $bdc-avatar-badge-muted;
+      &::before {
+        background-color: $bdc-avatar-badge;
+        border-radius: $bdrs-rounded;
+        content: '';
+        display: block;
+        height: map-get($s-avatar-badge, $key-size) / 4;
+        left: 50%;
+        position: absolute;
+        top: 50%;
+        transform: translate(-50%, -50%);
+        width: map-get($s-avatar-badge, $key-size) / 4;
+      }
     }
   }
 }

--- a/components/molecule/avatar/src/AvatarBadge/index.scss
+++ b/components/molecule/avatar/src/AvatarBadge/index.scss
@@ -1,3 +1,6 @@
+$bdc-avatar-badge: white !default;
+$bdc-avatar-badge-muted: #d7dcdf !default;
+
 $s-avatar-badge: (
   xxlarge: 20px,
   xlarge: 16px,
@@ -16,8 +19,19 @@ $bw-avatar-badge: (
   xsmall: 1px
 ) !default;
 
-$bdc-avatar-badge: white !default;
-$bdc-avatar-badge-muted: #d7dcdf !default;
+$bgc-avatar-badge: (
+  error: $c-error,
+  success: $c-success,
+  alert: $c-alert,
+  muted: $bdc-avatar-badge
+) !default;
+
+$bxsh-avatar-badge: (
+  error: inset 0 0 0 2px $c-error,
+  success: inset 0 0 0 2px $c-success,
+  alert: inset 0 0 0 2px $c-alert,
+  muted: inset 0 0 0 2px $bdc-avatar-badge-muted
+) !default;
 
 .sui-MoleculeAvatarBadge {
   border-radius: $bdrs-rounded;
@@ -26,20 +40,24 @@ $bdc-avatar-badge-muted: #d7dcdf !default;
   right: 0;
   z-index: 1;
 
-  &--error {
-    background-color: $c-error;
-  }
-
-  &--success {
-    background-color: $c-success;
-  }
-
   &--top {
     top: 0;
   }
 
   &--bottom {
     bottom: 0;
+  }
+
+  @each $key-status, $bgc in $bgc-avatar-badge {
+    &--#{$key-status} {
+      background-color: $bgc;
+    }
+  }
+
+  @each $key-status, $bxsh in $bxsh-avatar-badge {
+    &--#{$key-status} {
+      box-shadow: $bxsh;
+    }
   }
 
   @each $key-size, $size in $s-avatar-badge {
@@ -53,21 +71,6 @@ $bdc-avatar-badge-muted: #d7dcdf !default;
   @each $key-size, $bw in $bw-avatar-badge {
     &--#{$key-size} {
       border: $bw solid $bdc-avatar-badge;
-    }
-    &--#{$key-size}#{&}--muted {
-      background: $bdc-avatar-badge-muted;
-      &::before {
-        background-color: $bdc-avatar-badge;
-        border-radius: $bdrs-rounded;
-        content: '';
-        display: block;
-        height: map-get($s-avatar-badge, $key-size) / 4;
-        left: 50%;
-        position: absolute;
-        top: 50%;
-        transform: translate(-50%, -50%);
-        width: map-get($s-avatar-badge, $key-size) / 4;
-      }
     }
   }
 }

--- a/components/molecule/avatar/src/AvatarBadge/index.scss
+++ b/components/molecule/avatar/src/AvatarBadge/index.scss
@@ -16,7 +16,17 @@ $bw-avatar-badge: (
   xsmall: 1px
 ) !default;
 
+$bw-avatar-badge-muted: (
+  xxlarge: 5px,
+  xlarge: 5px,
+  large: 4px,
+  medium: 4px,
+  small: 3px,
+  xsmall: 3px
+) !default;
+
 $bdc-avatar-badge: white !default;
+$bdc-avatar-badge-muted: #d7dcdf !default;
 
 .sui-MoleculeAvatarBadge {
   border-radius: $bdrs-rounded;
@@ -52,6 +62,18 @@ $bdc-avatar-badge: white !default;
   @each $key-size, $bw in $bw-avatar-badge {
     &--#{$key-size} {
       border: $bw solid $bdc-avatar-badge;
+    }
+    &--#{$key-size}#{&}--muted {
+      border: map-get($bw-avatar-badge-muted, $key-size)
+        solid
+        $bdc-avatar-badge-muted;
+      box-shadow: inset
+          0
+          0
+          0
+          map-get($bw-avatar-badge-muted, $key-size)
+          $bdc-avatar-badge,
+        0 0 0 map-get($bw-avatar-badge-muted, $key-size) $bdc-avatar-badge;
     }
   }
 }


### PR DESCRIPTION
## molecule/avatar

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

This PR adds a new avatar badge variation: `muted`.

This variation will be used for the new avatar theme in Milanuncios. 

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
<img width="792" alt="Screenshot 2021-08-23 at 11 23 52" src="https://user-images.githubusercontent.com/6487058/130424196-f39b67a1-65e9-4c32-af07-52deaf1daac3.png">

