### PR TITLE
Feat/add label right to atom switch single

### DIFF
--- a/components/atom/switch/demo/index.js
+++ b/components/atom/switch/demo/index.js
@@ -111,23 +111,33 @@ const TypesArticle = () => (
       This package gives 3 different <Code>type</Code> values provided under the{' '}
       <Code>atomSwitchTypes</Code> exported variable
     </Paragraph>
-    <Grid cols={3}>
+    <Grid cols={4}>
       {Object.values(atomSwitchTypes).map((type, index) => (
         <Cell key={index} style={flexCenteredStyle}>
           <Label>{type.toString()}</Label>
         </Cell>
       ))}
+      <Cell key="typeEmptyCell" style={flexCenteredStyle}>
+        <Label>Single right</Label>
+      </Cell>
       {Object.values(atomSwitchTypes).map((type, index) => (
         <Cell key={index} style={flexCenteredStyle}>
           <AtomSwitch
             labelLeft="labelLeft"
-            labelRight="labelRight"
+            labelRight={type !== atomSwitchTypes.SINGLE ? 'labelRight' : ''}
             label={<Small>label</Small>}
             name="name"
             type={type}
           />
         </Cell>
       ))}
+      <Cell key="typeEmptyCellSwitch" style={flexCenteredStyle}>
+        <AtomSwitch
+          labelRight="labelRight"
+          name="name"
+          type={atomSwitchTypes.SINGLE}
+        />
+      </Cell>
     </Grid>
   </Article>
 )

--- a/components/atom/switch/src/SwitchType/single.js
+++ b/components/atom/switch/src/SwitchType/single.js
@@ -12,6 +12,7 @@ export const SingleSwitchTypeRender = forwardRef(
       isFocus,
       isToggle,
       label,
+      labelLeft,
       labelOptionalText,
       labelRight,
       name,
@@ -27,6 +28,8 @@ export const SingleSwitchTypeRender = forwardRef(
     ref
   ) => {
     const isActive = value !== undefined ? value : isToggle
+    const leftLabel = label || labelLeft
+    const rightLabel = labelRight && !label && !labelLeft
 
     return (
       <div
@@ -50,10 +53,10 @@ export const SingleSwitchTypeRender = forwardRef(
           onBlur={onBlur}
           ref={ref}
         >
-          {label && !labelRight && (
+          {leftLabel && (
             <AtomLabel
               name={name}
-              text={label}
+              text={leftLabel}
               optionalText={labelOptionalText}
             />
           )}
@@ -64,7 +67,7 @@ export const SingleSwitchTypeRender = forwardRef(
               })}
             />
           </div>
-          {labelRight && !label && (
+          {rightLabel && (
             <AtomLabel
               name={name}
               text={labelRight}
@@ -88,6 +91,10 @@ SingleSwitchTypeRender.propTypes = {
    * The label itself. Proxy from label
    */
   label: PropTypes.string,
+  /**
+   * The optional left label text. Proxy from label
+   */
+  labelLeft: PropTypes.string,
   /**
    * The optional label text. Proxy from label
    */

--- a/components/atom/switch/src/SwitchType/single.js
+++ b/components/atom/switch/src/SwitchType/single.js
@@ -3,6 +3,8 @@ import cx from 'classnames'
 import AtomLabel from '@s-ui/react-atom-label'
 import {suitClass, switchClassNames} from './helpers'
 import PropTypes from 'prop-types'
+import {LABELS} from '../config'
+const {RIGHT, LEFT} = LABELS
 
 export const SingleSwitchTypeRender = forwardRef(
   (
@@ -28,8 +30,12 @@ export const SingleSwitchTypeRender = forwardRef(
     ref
   ) => {
     const isActive = value !== undefined ? value : isToggle
-    const leftLabel = label || labelLeft
-    const rightLabel = labelRight && !label && !labelLeft
+
+    const defaultLabelLeft = labelLeft === LEFT
+    const defaultLabelRight = labelRight === RIGHT
+
+    const showLabelLeft = Boolean(label) || !defaultLabelLeft
+    const showLabelRight = !label && !defaultLabelRight && defaultLabelLeft
 
     return (
       <div
@@ -53,10 +59,10 @@ export const SingleSwitchTypeRender = forwardRef(
           onBlur={onBlur}
           ref={ref}
         >
-          {leftLabel && (
+          {showLabelLeft && (
             <AtomLabel
               name={name}
-              text={leftLabel}
+              text={defaultLabelLeft ? label : labelLeft}
               optionalText={labelOptionalText}
             />
           )}
@@ -67,7 +73,7 @@ export const SingleSwitchTypeRender = forwardRef(
               })}
             />
           </div>
-          {rightLabel && (
+          {showLabelRight && (
             <AtomLabel
               name={name}
               text={labelRight}

--- a/components/atom/switch/src/SwitchType/single.js
+++ b/components/atom/switch/src/SwitchType/single.js
@@ -8,15 +8,16 @@ export const SingleSwitchTypeRender = forwardRef(
   (
     {
       disabled,
-      isFocus,
       isClick,
+      isFocus,
       isToggle,
       label,
       labelOptionalText,
+      labelRight,
       name,
       onBlur,
-      onFocus,
       onClick,
+      onFocus,
       onKeyDown,
       onToggle,
       size,
@@ -49,7 +50,7 @@ export const SingleSwitchTypeRender = forwardRef(
           onBlur={onBlur}
           ref={ref}
         >
-          {label && (
+          {label && !labelRight && (
             <AtomLabel
               name={name}
               text={label}
@@ -63,6 +64,13 @@ export const SingleSwitchTypeRender = forwardRef(
               })}
             />
           </div>
+          {labelRight && !label && (
+            <AtomLabel
+              name={name}
+              text={labelRight}
+              optionalText={labelOptionalText}
+            />
+          )}
         </div>
       </div>
     )
@@ -84,6 +92,10 @@ SingleSwitchTypeRender.propTypes = {
    * The optional label text. Proxy from label
    */
   labelOptionalText: PropTypes.string,
+  /**
+   * The optional right label text. Proxy from label
+   */
+  labelRight: PropTypes.string,
   /**
    * Size of switch: 'default', 'large'
    */

--- a/components/atom/switch/src/config.js
+++ b/components/atom/switch/src/config.js
@@ -11,4 +11,9 @@ export const TYPES = {
   SINGLE: 'single'
 }
 
+export const LABELS = {
+  LEFT: 'Off',
+  RIGHT: 'On'
+}
+
 export const SUPPORTED_KEYS = [' ', 'Enter', 'Spacebar']

--- a/components/atom/switch/src/index.js
+++ b/components/atom/switch/src/index.js
@@ -2,7 +2,7 @@ import {useState, forwardRef} from 'react'
 import PropTypes from 'prop-types'
 import {ToggleSwitchTypeRender} from './SwitchType/toggle'
 import {SingleSwitchTypeRender} from './SwitchType/single'
-import {SIZES, TYPES, SUPPORTED_KEYS} from './config'
+import {LABELS, SIZES, SUPPORTED_KEYS, TYPES} from './config'
 
 const AtomSwitch = forwardRef((props, ref) => {
   const {initialValue, disabled, onToggle: onToggleCallback, type} = props
@@ -116,8 +116,8 @@ AtomSwitch.propTypes = {
 AtomSwitch.defaultProps = {
   disabled: false,
   initialValue: false,
-  labelLeft: 'Off',
-  labelRight: 'On',
+  labelLeft: LABELS.LEFT,
+  labelRight: LABELS.RIGHT,
   size: SIZES.DEFAULT,
   type: TYPES.TOGGLE
 }

--- a/components/atom/switch/src/index.scss
+++ b/components/atom/switch/src/index.scss
@@ -77,6 +77,9 @@ $atom-switch-transition-time: 0.3s !default;
     .sui-AtomLabel {
       margin-right: $m-l;
     }
+    .sui-AtomSwitch-inputContainer + .sui-AtomLabel {
+      margin-left: $m-l;
+    }
   }
 
   &-text {

--- a/components/atom/switch/src/index.scss
+++ b/components/atom/switch/src/index.scss
@@ -69,7 +69,7 @@ $atom-switch-transition-time: 0.3s !default;
 
   &-toggleType {
     .sui-AtomSwitch-container {
-      margin-top: $p-l;
+      margin-top: $m-l;
     }
   }
 

--- a/components/atom/switch/test/index.test.js
+++ b/components/atom/switch/test/index.test.js
@@ -47,17 +47,31 @@ describe('atom/switch', () => {
     expect(container.innerHTML).to.not.have.lengthOf(0)
   })
 
-  it.skip('example', () => {
-    // Example TO BE DELETED!!!!
-
+  it('should render single type with left label', () => {
     // Given
-    // const props = {}
+    const props = {label: 'label', name: 'name', type: 'single'}
 
     // When
-    // const {getByRole} = setup(props)
+    const {getByText} = setup(props)
 
     // Then
-    // expect(getByRole('button')).to.have.text('HOLA')
-    expect(true).to.be.eql(false)
+    const label = getByText(props.label)
+    const childNodes = label.parentElement.childNodes
+
+    expect(childNodes[0]).to.be.eql(label)
+  })
+
+  it('should render single type with right label', () => {
+    // Given
+    const props = {labelRight: 'labelRight', name: 'name', type: 'single'}
+
+    // When
+    const {getByText} = setup(props)
+
+    // Then
+    const label = getByText(props.labelRight)
+    const childNodes = label.parentElement.childNodes
+
+    expect(childNodes[1]).to.be.eql(label)
   })
 })


### PR DESCRIPTION
## ATOM/SWITCH

### Types of changes

- [x] New feature (non-breaking change which adds functionality)

### Description, Motivation and Context

Add right label to single type switch

### Screenshots - Animations
![Captura de pantalla 2021-08-24 a las 13 05 32](https://user-images.githubusercontent.com/17734680/130606104-89dc30c7-a02a-4c09-9df6-977b120ac0fe.png)