### PR TITLE
fix(components/atom/button): margin breaking change

### DIFF
--- a/components/atom/button/src/index.scss
+++ b/components/atom/button/src/index.scss
@@ -166,7 +166,7 @@ $icon-stroke-color: currentColor !default;
   text-transform: $tt-atom-button;
   white-space: nowrap;
 
-  :not(&--fullWidth) + & {
+  & + & {
     margin-left: $m-consecutive-atom-button;
   }
 


### PR DESCRIPTION
## atom/button
**TASK**: None

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
This PR reverts a breaking change in how the margin between buttons works. We will discuss how to handle these cases in the weekly. Thanks @andresin87 for the help

### Screenshots - Animations

![Screenshot 2021-08-31 at 12 34 20](https://user-images.githubusercontent.com/6877967/131487839-ececc9f5-f403-48b9-84ef-3e7de5d97615.png)
