### PR TITLE
fix(components/molecule/checkboxField): Fix label color token

### DIFF
--- a/components/molecule/checkboxField/src/index.scss
+++ b/components/molecule/checkboxField/src/index.scss
@@ -5,15 +5,27 @@
 $fw-molecule-checkbox-field-label: $fw-atom-label !default;
 $c-molecule-checkbox-field-label: $c-atom-label !default;
 
+$c-molecule-checkbox-field: (
+  success: $c-success,
+  error: $c-error,
+  alert: $c-alert
+) !default;
+
 .sui-MoleculeCheckboxField {
   input[type='checkbox'] {
     margin: 0;
   }
 
-  label {
+  .sui-AtomLabel {
     cursor: pointer;
     font-weight: $fw-molecule-checkbox-field-label;
     color: $c-molecule-checkbox-field-label;
+
+    @each $colorName, $colorValue in $c-molecule-checkbox-field {
+      &--#{$colorName} {
+        color: $colorValue;
+      }
+    }
   }
 
   &-toggleIcon {


### PR DESCRIPTION
## MOLECULE/CHECKBOXFIELD

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Description, Motivation and Context

At previous [PR](https://github.com/SUI-Components/sui-components/pull/1660), we added a new label color token to allow us personalize checkbox field label color. This change, have caused a new bug. 

On this PR, we cover different Atom Label states and keep each color.