### PR TITLE
feat(components/atom/icon): Add title prop for accessibility

### DIFF
--- a/components/atom/icon/src/Icon.js
+++ b/components/atom/icon/src/Icon.js
@@ -2,9 +2,21 @@ import PropTypes from 'prop-types'
 
 const IMG_ROLE = 'img'
 
-export default function AtomIcon({className, children, outerRef}) {
+export default function AtomIcon({className, children, outerRef, title}) {
+  const a11yAttributes = title
+    ? {
+        role: IMG_ROLE,
+        ariaLabel: title
+      }
+    : {}
+
   return (
-    <span className={className} role={IMG_ROLE} ref={outerRef}>
+    <span
+      className={className}
+      title={title}
+      ref={outerRef}
+      {...a11yAttributes}
+    >
       {children}
     </span>
   )
@@ -13,5 +25,6 @@ export default function AtomIcon({className, children, outerRef}) {
 AtomIcon.propTypes = {
   className: PropTypes.string,
   children: PropTypes.element,
-  outerRef: PropTypes.func
+  outerRef: PropTypes.func,
+  title: PropTypes.string
 }

--- a/components/atom/icon/src/index.js
+++ b/components/atom/icon/src/index.js
@@ -31,7 +31,8 @@ export default function AtomIcon({
   children,
   color = ATOM_ICON_COLORS.currentColor,
   size = ATOM_ICON_SIZES.small,
-  render = ATOM_ICON_RENDERS.eager
+  render = ATOM_ICON_RENDERS.eager,
+  title
 }) {
   const className = cx(
     BASE_CLASS,
@@ -40,7 +41,11 @@ export default function AtomIcon({
   )
 
   const IconRender = render === ATOM_ICON_RENDERS.eager ? Icon : LazyIcon
-  return <IconRender className={className}>{children}</IconRender>
+  return (
+    <IconRender className={className} title={title}>
+      {children}
+    </IconRender>
+  )
 }
 
 AtomIcon.displayName = 'AtomIcon'
@@ -64,5 +69,9 @@ AtomIcon.propTypes = {
    * 'eager': The icon will be server-side rendered (default)
    * 'lazy': The icon will be loaded on client when visible
    */
-  render: PropTypes.oneOf(Object.values(ATOM_ICON_RENDERS))
+  render: PropTypes.oneOf(Object.values(ATOM_ICON_RENDERS)),
+  /**
+   * Adds a title for accesibility purposes
+   */
+  title: PropTypes.string
 }


### PR DESCRIPTION
## ATOM/ICON

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

This PR is adding the `title` prop for accessibility and adds conditionally the `role="img"` and an `aria-label` when `title` is present. 

Before the `role="img"` was always rendered causing screen readers to read "Unlabelled image" for each icon. With this approach, if the title is not provided it means the icon is purely decorative and it should be hidden from the screen reader.
