### PR TITLE
fix(components/molecule/select): remove select border when molecule is focused

### DIFF
--- a/components/molecule/select/src/index.scss
+++ b/components/molecule/select/src/index.scss
@@ -95,6 +95,11 @@ $c-molecule-select-disabled: inherit !default;
       &-container {
         @extend %sui-atom-input-select-focus;
         border: $bdw-s solid $c-primary;
+
+        .sui-AtomInput-input,
+        .sui-AtomInput--withTags {
+          border-color: transparent;
+        }
       }
     }
   }


### PR DESCRIPTION
## MOLECULE/SELECT
**TASK**: NOJIRA

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
### Description, Motivation and Context
Remove border of inside select input when select is focused.

### Screenshots - Animations

### 🔙 Before
![image](https://user-images.githubusercontent.com/3933098/133204371-02d98e99-fc25-4d4e-bb78-73e66b2afee3.png)

### 🔜 After
![image](https://user-images.githubusercontent.com/3933098/133205351-b86d7eb5-8b80-43f6-ac8f-424f0bad1911.png)
