### PR TITLE
fix(components/molecule/dropdownOption): change deprecated color

### DIFF
--- a/components/molecule/dropdownOption/src/_settings.scss
+++ b/components/molecule/dropdownOption/src/_settings.scss
@@ -1,4 +1,4 @@
 $c-dropdown-option-disabled: color-variation($c-gray, 3) !default;
 $mih-dropdown-option: 40px !default;
 $h-dropdown-option: $mih-dropdown-option !default; // deprecated
-$bgc-dropdown-option-hover: $c-gray-lightest !default;
+$bgc-dropdown-option-hover: $c-gray-light-4 !default;


### PR DESCRIPTION
ISSUES CLOSED: #1746

## molecule/dropdownOption
**TASK**: #1746


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
Change the deprecated color of the hover to the right color