### PR TITLE
feat(components/molecule/tabs): accept node element as label

### DIFF
--- a/components/molecule/tabs/src/components/MoleculeTab.js
+++ b/components/molecule/tabs/src/components/MoleculeTab.js
@@ -62,7 +62,7 @@ MoleculeTab.propTypes = {
   count: PropTypes.string,
 
   /** text to display */
-  label: PropTypes.string,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 
   /** Tab number */
   numTab: PropTypes.number,


### PR DESCRIPTION
## Molecule/Tabs

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
<!--- Describe your changes in detail -->
The change is just allowing to pass in the label prop a node element to have a more customized tab. In motor (professionals) we need to show a badge counter in the tabs. Despite we know the PropTypes are not being checked since time ago, we just want to document this change.
<!--- Why is this change required? What problem does it solve? -->

It solves this problem:
![image](https://user-images.githubusercontent.com/17437586/139876584-f81d3599-90d5-47d7-acc1-ebcb10715870.png)

