### PR TITLE
fix(components/molecule/tabs): Fix scroll into active tab breaking when is out of the viewport

### DIFF
--- a/components/molecule/tabs/src/components/MoleculeTab.js
+++ b/components/molecule/tabs/src/components/MoleculeTab.js
@@ -1,4 +1,4 @@
-import {useEffect} from 'react'
+import {useEffect, useRef} from 'react'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import {useOnScreen} from '@s-ui/react-hooks'
@@ -23,6 +23,7 @@ const MoleculeTab = ({
   numTab
 }) => {
   const [isIntersecting, outerRef] = useOnScreen()
+  const innerRef = useRef()
 
   const handleChange = ev => {
     !disabled && onChange(ev, {numTab})
@@ -30,20 +31,29 @@ const MoleculeTab = ({
 
   useEffect(() => {
     if (active && isIntersecting) {
-      outerRef.current.scrollIntoView({
+      innerRef.current.scrollIntoView({
         behavior: 'smooth',
         block: 'nearest',
         inline: 'start'
       })
     }
-  }, [active, outerRef, isIntersecting])
+  }, [active, innerRef, isIntersecting])
 
   const className = cx(CLASS_TAB, {
     [CLASS_TAB_ACTIVE]: active,
     [CLASS_TAB_DISABLED]: disabled
   })
   return (
-    <li className={className} onClick={handleChange} ref={outerRef}>
+    <li
+      className={className}
+      onClick={handleChange}
+      ref={el => {
+        if (el) {
+          innerRef.current = el
+          outerRef.current = el.parentElement
+        }
+      }}
+    >
       {icon && <span className={CLASS_TAB_ICON}>{icon}</span>}
       {!isNaN(count) && <span className={CLASS_TAB_COUNT}>{count}</span>}
       <span>{label}</span>

--- a/components/molecule/tabs/src/components/MoleculeTab.js
+++ b/components/molecule/tabs/src/components/MoleculeTab.js
@@ -2,6 +2,7 @@ import {useEffect, useRef} from 'react'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import {useOnScreen} from '@s-ui/react-hooks'
+import useMergeRefs from '@s-ui/react-hooks/lib/useMergeRefs'
 
 const BASE_CLASS = `sui-MoleculeTabs`
 
@@ -47,12 +48,7 @@ const MoleculeTab = ({
     <li
       className={className}
       onClick={handleChange}
-      ref={el => {
-        if (el) {
-          innerRef.current = el
-          outerRef.current = el.parentElement
-        }
-      }}
+      ref={useMergeRefs(innerRef, outerRef)}
     >
       {icon && <span className={CLASS_TAB_ICON}>{icon}</span>}
       {!isNaN(count) && <span className={CLASS_TAB_COUNT}>{count}</span>}


### PR DESCRIPTION
## MOLECULE/TABS

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

This PR fixes scrolling into active tab breaking when is out of the viewport.

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
Now it works as expected:

<img src="https://user-images.githubusercontent.com/6487058/142843184-230f1b82-dd59-40c6-9cc2-3742f6c6d996.gif" width="250" height="500"/>