### PR TITLE
fix(components/molecule/textareaField): use empty string for null values

### DIFF
--- a/components/molecule/textareaField/src/index.js
+++ b/components/molecule/textareaField/src/index.js
@@ -37,7 +37,7 @@ const MoleculeTextareaField = ({
 
   const {disabled} = props
 
-  const [internalValue, setInternalValue] = useState(value)
+  const [internalValue, setInternalValue] = useState(value ?? '')
 
   useEffect(() => {
     setInternalValue(value)


### PR DESCRIPTION
## molecule/textareaField

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
When the passed value is `null`, the component break while trying to access the length property and compute the helpText.
Even if null shouldn't be passed as value, it's better to prevent this error and initialize the internal value to an empty string.
