### PR TITLE
feat(components/atom/table): Add token to describe border between rows

### DIFF
--- a/components/atom/table/src/index.scss
+++ b/components/atom/table/src/index.scss
@@ -6,6 +6,7 @@ $bgc-atom-table-row: $c-gray-light-4 !default;
 $bdrs-atom-table: 0 !default;
 $bgc-atom-table-row-actionable--hover: $c-gray-light-4 !default;
 $bgc-atom-table-row-actionable--active: $c-gray-light-3 !default;
+$bd-atom-table-row: $bdw-s solid $c-gray-light-5 !default;
 
 .react-AtomTable {
   background-color: $bgc-atom-table;
@@ -48,7 +49,7 @@ $bgc-atom-table-row-actionable--active: $c-gray-light-3 !default;
 
   &-cell {
     &--borderBottom {
-      border-bottom: $bdw-s solid $c-gray-light-5;
+      border-bottom: $bd-atom-table-row;
     }
 
     &--xs {

--- a/components/atom/table/src/index.scss
+++ b/components/atom/table/src/index.scss
@@ -7,6 +7,7 @@ $bdrs-atom-table: 0 !default;
 $bgc-atom-table-row-actionable--hover: $c-gray-light-4 !default;
 $bgc-atom-table-row-actionable--active: $c-gray-light-3 !default;
 $bd-atom-table-row: $bdw-s solid $c-gray-light-5 !default;
+$c-atom-table-header-cell: $c-gray-dark !default;
 
 .react-AtomTable {
   background-color: $bgc-atom-table;
@@ -25,6 +26,7 @@ $bd-atom-table-row: $bdw-s solid $c-gray-light-5 !default;
     background-color: $bgc-atom-table-header-cell;
     font-weight: $fw-regular;
     text-align: left;
+    color: $c-atom-table-header-cell;    
   }
 
   &-row {

--- a/components/atom/table/src/index.scss
+++ b/components/atom/table/src/index.scss
@@ -26,7 +26,7 @@ $c-atom-table-header-cell: $c-gray-dark !default;
     background-color: $bgc-atom-table-header-cell;
     font-weight: $fw-regular;
     text-align: left;
-    color: $c-atom-table-header-cell;    
+    color: $c-atom-table-header-cell;
   }
 
   &-row {


### PR DESCRIPTION
## ATOM/TABLE
**TASK**: [jira TASK ID](https://jira.scmspain.com/browse/PI-43887)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context

In order to customize the table in the Infojobs theme I needed to two tokens:

- describe the border between the rows,
- describe header cell font color

This way now we can define it properly on the themes of each site.

### Screenshots - Animations

![image](https://user-images.githubusercontent.com/3693800/143423539-1850a4ca-e056-49bf-b98f-a6bb11923081.png)
