### PR TITLE
Fix/checkbox height in molecule checkbox field

### DIFF
--- a/components/molecule/checkboxField/src/index.scss
+++ b/components/molecule/checkboxField/src/index.scss
@@ -15,8 +15,10 @@ $c-molecule-checkbox-field: (
 
 .sui-MoleculeCheckboxField {
   .sui-AtomCheckbox {
-    width: $w-molecule-checkbox-field-input;
-    height: $h-molecule-checkbox-field-input;
+    &--native {
+      width: $w-molecule-checkbox-field-input;
+      height: $h-molecule-checkbox-field-input;
+    }
     display: flex;
     align-items: center;
 


### PR DESCRIPTION
## MOLECULE/CHECKBOXFIELD

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
Add specificity to molecule checkbox field selector, to fix side effect with the size of the checkbox when it's not the native type.

### Screenshots - Animations
![Captura de pantalla 2021-11-30 a las 12 10 08](https://user-images.githubusercontent.com/17734680/144036833-468f24ef-d071-44f1-9871-7abc443c5c37.png)