### PR TITLE
fix(components/atom/slider): fix align items incorrect value

### DIFF
--- a/components/atom/slider/src/index.scss
+++ b/components/atom/slider/src/index.scss
@@ -67,7 +67,7 @@ $class-tooltip-hidden: '#{$class-tooltip}-hidden';
   }
 
   li {
-    align-items: end;
+    align-items: flex-end;
     background-position-x: center;
     background-position-y: -15px;
     display: flex;


### PR DESCRIPTION
## ATOM/SLIDER

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
Fix `align-items` incorrect value

### Screenshots - Animations

<img width="766" alt="CleanShot 2021-12-10 at 14 08 40@2x" src="https://user-images.githubusercontent.com/1427623/145578918-951dbd44-c7e1-4b51-ab3d-17422fa178d4.png">

