### PR TITLE
fix(components/atom/button): add isFitted as Atom Button own props

### DIFF
--- a/components/atom/button/src/config.js
+++ b/components/atom/button/src/config.js
@@ -96,6 +96,7 @@ export const OWN_PROPS = [
   'className',
   'color',
   'design',
+  'isFitted',
   'focused',
   'fullWidth',
   'groupPosition',


### PR DESCRIPTION
## atom/button
**TASK**: N/A


### Types of changes
Just a React warning fix

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
The following warning is showing up when using this component:

### Screenshots - Animations
![image](https://user-images.githubusercontent.com/18154356/145843438-cfb100d5-f99d-4648-b05a-ff9b99002d87.png)
