### PR TITLE
Fix/molecule/photouploader error when save image endpoint fails

### DIFF
--- a/components/molecule/photoUploader/src/config.js
+++ b/components/molecule/photoUploader/src/config.js
@@ -24,6 +24,8 @@ export const DEFAULT_FILE_TYPES_ACCEPTED =
   'image/jpeg, image/gif, image/png, image/webp, image/bmp'
 export const DEFAULT_MAX_FILE_SIZE_ACCEPTED = 5e7
 export const DEFAULT_NOTIFICATION_ERROR = {isError: false, text: ''}
+export const DEFAULT_SAVE_IMAGE_ERROR =
+  'An error has occurred, please try again'
 export const DEFAULT_HAS_ERRORS_STATUS = false
 
 export const DRAG_STATE_STATUS_ACCEPTED = 'accepted'

--- a/components/molecule/photoUploader/src/fileTools.js
+++ b/components/molecule/photoUploader/src/fileTools.js
@@ -110,6 +110,7 @@ export const prepareFiles = ({
   currentFiles,
   defaultFormatToBase64Options,
   errorCorruptedPhotoUploadedText,
+  errorSaveImageEndpoint,
   handlePhotosRejected,
   newFiles,
   setCorruptedFileError,
@@ -152,22 +153,26 @@ export const prepareFiles = ({
               blob,
               callbackUploadPhoto
             )
-            currentFiles.push({
-              blob,
-              file,
-              hasErrors,
-              isModified: false,
-              isNew: true,
-              originalBase64,
-              properties: {
-                path: nextFile.path,
-                size: nextFile.size,
-                lastModified: nextFile.lastModified
-              },
-              preview: croppedBase64,
-              rotation,
-              url
-            })
+            if (!url) {
+              setCorruptedFileError(errorSaveImageEndpoint)
+            } else {
+              currentFiles.push({
+                blob,
+                file,
+                hasErrors,
+                isModified: false,
+                isNew: true,
+                originalBase64,
+                properties: {
+                  path: nextFile.path,
+                  size: nextFile.size,
+                  lastModified: nextFile.lastModified
+                },
+                preview: croppedBase64,
+                rotation,
+                url
+              })
+            }
           }
         }
       )

--- a/components/molecule/photoUploader/src/index.js
+++ b/components/molecule/photoUploader/src/index.js
@@ -28,6 +28,7 @@ import {
   DEFAULT_FILE_TYPES_ACCEPTED,
   DEFAULT_MAX_FILE_SIZE_ACCEPTED,
   DEFAULT_NOTIFICATION_ERROR,
+  DEFAULT_SAVE_IMAGE_ERROR,
   DRAG_STATE_STATUS_REJECTED,
   ROTATION_DIRECTION,
   REJECT_FILES_REASONS,
@@ -62,7 +63,7 @@ const MoleculePhotoUploader = forwardRef(
       errorFileExcededMaxSizeText,
       errorFormatPhotoUploadedText,
       errorInitialPhotoDownloadErrorText,
-      errorSaveImageEndpoint,
+      errorSaveImageEndpoint = DEFAULT_SAVE_IMAGE_ERROR,
       infoIcon = noop,
       initialPhotos = [],
       limitPhotosUploadedText,
@@ -437,7 +438,7 @@ MoleculePhotoUploader.propTypes = {
   errorInitialPhotoDownloadErrorText: PropTypes.string.isRequired,
 
   /** Text showed at error notification when the saveImages endpoint returns an error  */
-  errorSaveImageEndpoint: PropTypes.string.isRequired,
+  errorSaveImageEndpoint: PropTypes.string,
 
   /** Info icon */
   infoIcon: PropTypes.func.isRequired,

--- a/components/molecule/photoUploader/src/index.js
+++ b/components/molecule/photoUploader/src/index.js
@@ -62,6 +62,7 @@ const MoleculePhotoUploader = forwardRef(
       errorFileExcededMaxSizeText,
       errorFormatPhotoUploadedText,
       errorInitialPhotoDownloadErrorText,
+      errorSaveImageEndpoint,
       infoIcon = noop,
       initialPhotos = [],
       limitPhotosUploadedText,
@@ -205,6 +206,7 @@ const MoleculePhotoUploader = forwardRef(
         newFiles: validFiles,
         defaultFormatToBase64Options: DEFAULT_FORMAT_TO_BASE_64_OPTIONS,
         errorCorruptedPhotoUploadedText,
+        errorSaveImageEndpoint,
         setCorruptedFileError: errorText => {
           setNotificationError({
             isError: true,
@@ -433,6 +435,9 @@ MoleculePhotoUploader.propTypes = {
 
   /** Text showed at error notification when some file of the initialPhotos fails */
   errorInitialPhotoDownloadErrorText: PropTypes.string.isRequired,
+
+  /** Text showed at error notification when the saveImages endpoint returns an error  */
+  errorSaveImageEndpoint: PropTypes.string.isRequired,
 
   /** Info icon */
   infoIcon: PropTypes.func.isRequired,


### PR DESCRIPTION
## MOLECULE/PHOTOUPLOADER
**TASK**: <!--- No jira -->


### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
Actually, when the user uploads a picture and the endpoint returns an error, this component doesn't show any error to the user.
With this change, the user will be noticed about the error, and the picture wouldn't be shown in the photo grid.

### Screenshots - Animations
<img width="622" alt="Captura de pantalla 2021-12-17 a las 12 51 30" src="https://user-images.githubusercontent.com/17734680/146540797-02826085-670b-4eed-8b50-4ea6e9881bc8.png">