### PR TITLE
feat(components/molecule/dropdownOption): Add a SCSS variable to be able to define color for the dropdown option component

### DIFF
--- a/components/molecule/dropdownOption/src/_settings.scss
+++ b/components/molecule/dropdownOption/src/_settings.scss
@@ -1,3 +1,4 @@
+$c-dropdown-option: inherit !default;
 $c-dropdown-option-disabled: color-variation($c-gray, 3) !default;
 $mih-dropdown-option: 40px !default;
 $h-dropdown-option: $mih-dropdown-option !default; // deprecated

--- a/components/molecule/dropdownOption/src/index.scss
+++ b/components/molecule/dropdownOption/src/index.scss
@@ -26,6 +26,7 @@ $ml-molecule-dropdown-option: 0 !default;
 .sui-MoleculeDropdownOption {
   align-items: center;
   border-radius: $bdrs-molecule-dropdown-option;
+  color: $c-dropdown-option;
   display: flex;
   min-height: $mih-dropdown-option;
   padding: $pt-molecule-dropdown-option $pr-molecule-dropdown-option


### PR DESCRIPTION
## [molecule]/[dropdownOption]
**TASK**:  [#MTR-49167](https://jira.scmspain.com/browse/MTR-49167)

### Types of changes

- [x] New feature (non-breaking change which adds functionality)

### Description, Motivation and Context

We've added a new SCSS variable to the dropdownOption styles, to be able to define the color of dropdownOption components. Before this change, color was not defined, and it was inherited from parent elements.

This change is performed in coches.net rebranding context: We need to define a specific color for dropdown options, and right now seems that the only way to achieve so is by defining the color on parent elements, one by one. With this change, we will now be able to define the color in our theme properties, globally for the application.

### Screenshots - Animations

This is an example of a dropdown option with a customized color:

![image](https://user-images.githubusercontent.com/16169223/149135564-bc1496ec-7648-466a-be5f-cb943a3dc554.png)

(Note that the image is just an example and it doesn't represent the final result)