### PR TITLE
feat(components/molecule/autosuggest): adds new prop in order to be a…

### DIFF
--- a/components/molecule/autosuggest/demo/index.js
+++ b/components/molecule/autosuggest/demo/index.js
@@ -48,7 +48,9 @@ const options = [
 const Demo = () => {
   const [tags, setTags] = useState([{key: 1, label: 'Label'}])
   const [value, setValue] = useState()
+  const [keepInputFocus, setKeepInputFocus] = useState(true)
   const [singleValue, setSingleValue] = useState()
+
   return (
     <div className="sui-StudioPreview">
       <div className="sui-StudioPreview-content sui-StudioDemo-preview">
@@ -313,18 +315,60 @@ const Demo = () => {
             ))}
           </MoleculeAutosuggestField>
 
-          <div className={CLASS_DEMO_SECTION}>
-            <h3>with autoFocus</h3>
-            <MoleculeAutosuggestWithStateTags
-              autoFocus
-              placeholder="Type a Country name..."
-              onChangeTags={(_, {tags}) => console.log(tags)}
-              onClear={() => console.log('Clear pressed')}
-              iconCloseTag={<IconClose />}
-              iconClear={<IconClose />}
-              multiselection
-            />
-          </div>
+          <h3>With autoFocus</h3>
+          <MoleculeAutosuggestWithStateTags
+            autoFocus
+            placeholder="Type a Country name..."
+            onChangeTags={(_, {tags}) => console.log(tags)}
+            onClear={() => console.log('Clear pressed')}
+            iconCloseTag={<IconClose />}
+            iconClear={<IconClose />}
+            multiselection
+          />
+
+          <h3>With keepInputFocus</h3>
+
+          <MoleculeAutosuggestField
+            iconClear={<IconClose />}
+            iconCloseTag={<IconClose />}
+            label={
+              <div style={{marginBottom: '12px'}}>
+                <label style={{marginRight: '24px'}}>
+                  Keep input focus when clicking a suggestion
+                </label>
+                <input
+                  type="checkbox"
+                  checked={keepInputFocus}
+                  onChange={ev => {
+                    console.log({ev: ev.target.checked})
+                    setKeepInputFocus(ev.target.checked)
+                  }}
+                />
+              </div>
+            }
+            keepInputFocus={keepInputFocus}
+            allowDuplicates={false}
+            value={singleValue}
+            onChange={(_, {value}) => {
+              console.log('onChange', value)
+              setSingleValue(value)
+            }}
+            onClear={() => {
+              console.log('Clear pressed')
+              setSingleValue(undefined)
+            }}
+            onEnter={() => console.log('onEnter')}
+            onSelect={(_, {value}) => {
+              setSingleValue(value.label)
+            }}
+            placeholder="Selecciona el value a asignar al campo"
+          >
+            {options.map(({key, label}) => (
+              <MoleculeAutosuggestOption key={key} value={{key, label}}>
+                {label}
+              </MoleculeAutosuggestOption>
+            ))}
+          </MoleculeAutosuggestField>
         </div>
       </div>
     </div>

--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -32,6 +32,7 @@ const MoleculeAutosuggest = ({
   errorState,
   id = '',
   isOpen,
+  keepInputFocus = true,
   keysCloseList = CLOSE_KEYS_LIST,
   keysSelection = SELECT_KEYS_LIST,
   multiselection,
@@ -134,7 +135,7 @@ const MoleculeAutosuggest = ({
       else if (isSomeOptionFocused) handleFocusIn(ev)
       if (key === 'Enter') {
         typeof onEnter === 'function' && onEnter(ev)
-        innerRefInput && innerRefInput.focus()
+        keepInputFocus && innerRefInput && innerRefInput.focus()
       }
     }
   }
@@ -178,7 +179,7 @@ const MoleculeAutosuggest = ({
 
   const handleClick = () => {
     const {current: innerRefInput} = innerRefMoleculeAutosuggestInput
-    innerRefInput && innerRefInput.focus()
+    keepInputFocus && innerRefInput && innerRefInput.focus()
   }
 
   const autosuggestSelectionProps = {
@@ -253,6 +254,9 @@ MoleculeAutosuggest.propTypes = {
 
   /** if list of options is displayed or not */
   isOpen: PropTypes.bool,
+
+  /** keep input focus when clicking a suggestion */
+  keepInputFocus: PropTypes.bool,
 
   /** list of key identifiers that will close the list */
   keysCloseList: PropTypes.array,


### PR DESCRIPTION
## molecule/autosuggest

### Types of changes
Adds new prop in order to be able to decide if we want to keep the input focus when clicking a suggestion

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
The current behavior when clicking a suggestion is to keep the focused input and does not allow to apply blur if its want. Adding the new prop (but keeping the current behavior) we could decide this behavior

### Keep focus (current & default behavior):

https://user-images.githubusercontent.com/55990391/150140359-67fb1594-a0a9-4457-8c82-7cb14aa3d91f.mp4


### Not keep focus:

https://user-images.githubusercontent.com/55990391/150140527-3348f1ea-af7a-4cc1-a5e7-3b87be11fb40.mp4



