### PR TITLE
feat(components/atom/button): add new scss variable to custom focus text color on link type buttons

### DIFF
--- a/components/atom/button/src/index.scss
+++ b/components/atom/button/src/index.scss
@@ -351,6 +351,7 @@ $td-atom-button-link: none !default;
       }
       &#{$base-class}--link:not(#{$base-class}--solid):not(#{$base-class}--outline):not(#{$base-class}--flat) {
         $c-atom-button-focused: color-variation($color, -1) !default;
+        $c-atom-button-link-focused: $c-atom-button-focused !default;
         $c-atom-button-focused-invert: color-variation(
           $color-invert,
           -1
@@ -358,7 +359,7 @@ $td-atom-button-link: none !default;
 
         color: $color;
         @include button-focused {
-          color: $c-atom-button-focused;
+          color: $c-atom-button-link-focused;
         }
 
         &#{$base-class}--negative {

--- a/themes/carfactory.scss
+++ b/themes/carfactory.scss
@@ -1,4 +1,5 @@
 // Settings
+@import '~@s-ui/theme/lib/settings';
 //
 
 // Inherit from original theme

--- a/themes/coches.scss
+++ b/themes/coches.scss
@@ -1,4 +1,5 @@
 // Settings
+@import '~@s-ui/theme/lib/settings';
 //
 
 // Inherit from original theme

--- a/themes/motos.scss
+++ b/themes/motos.scss
@@ -1,4 +1,5 @@
 // Settings
+@import '~@s-ui/theme/lib/settings';
 //
 
 // Inherit from original theme


### PR DESCRIPTION
## [atom]/[button]
**TASK**: [MTR-49374](https://jira.scmspain.com/browse/MTR-49374) 


### Types of changes

- [x] New feature (non-breaking change which adds functionality)

### Description, Motivation and Context
Add new scss variable to custom focus text color on link type buttons.
We need it to fit styling with branding refresh we are doing on motor vertical.