### PR TITLE
Fix/data counter not submit

### DIFF
--- a/components/molecule/dataCounter/src/config.js
+++ b/components/molecule/dataCounter/src/config.js
@@ -1,8 +1,6 @@
 import {atomButtonSizes} from '@s-ui/react-atom-button'
 import {inputSizes} from '@s-ui/react-atom-input'
 
-export const BUTTON_TYPE = 'secondary'
-
 export const BASE_CLASS = `sui-MoleculeDataCounter`
 export const CLASS_INPUT_CONTAINER = `${BASE_CLASS}-container`
 

--- a/components/molecule/dataCounter/src/index.js
+++ b/components/molecule/dataCounter/src/index.js
@@ -2,13 +2,12 @@ import {useState, useEffect, forwardRef} from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
-import AtomButton from '@s-ui/react-atom-button'
+import AtomButton, {atomButtonDesigns} from '@s-ui/react-atom-button'
 import AtomInput, {inputSizes} from '@s-ui/react-atom-input'
 import MoleculeField from '@s-ui/react-molecule-field'
 
 import {
   ACTIONS,
-  BUTTON_TYPE,
   BASE_CLASS,
   CLASS_INPUT_CONTAINER,
   sizeConversor
@@ -139,11 +138,12 @@ const MoleculeDataCounter = forwardRef(
             )}
           >
             <AtomButton
+              design={atomButtonDesigns.OUTLINE}
               disabled={decrementDisabled}
+              isButton
               isLoading={isLoading && lastAction === ACTIONS.LESS}
               onClick={decrementValue}
               size={sizeConversor[size]}
-              type={BUTTON_TYPE}
             >
               {substractIcon}
             </AtomButton>
@@ -163,11 +163,12 @@ const MoleculeDataCounter = forwardRef(
               value={internalValue}
             />
             <AtomButton
+              design={atomButtonDesigns.OUTLINE}
               disabled={incrementDisabled}
+              isButton
               isLoading={isLoading && lastAction === ACTIONS.MORE}
               onClick={incrementValue}
               size={sizeConversor[size]}
-              type={BUTTON_TYPE}
             >
               {addIcon}
             </AtomButton>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint:js": "sui-lint js",
     "lint:sass": "sui-lint sass",
     "install:themes": "node scripts/build-themes.js",
-    "phoenix": "npx @s-ui/mono@2 run 'rm -rf ./node_modules' && rm -rf ./node_modules && npm install",
+    "phoenix": "npx @s-ui/mono@2 run 'rm -rf ./node_modules' && rm -rf ./node_modules package-lock.json && npm install",
     "phoenix:ci": "npm run phoenix -- --no-optional --no-fund --no-audit",
     "release": "sui-mono release",
     "start": "sui-studio start",


### PR DESCRIPTION
## MOLECULE/DATA_COUNTER

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

### Description, Motivation and Context
Currently, if you have **Molecule Data Counter** inside a `form`, the buttons of Molecule Data Counter are firing a form submit when it's not necessary.

With that PR, we ensure Molecule Data Counter buttons are `type=button` and prevent form submit.

Also, we have updated `npm run pheonix` script to ensure we are installing last version of components.