### PR TITLE
feat(components/molecule/select): add border color token

### DIFF
--- a/components/molecule/select/src/styles/index.scss
+++ b/components/molecule/select/src/styles/index.scss
@@ -91,7 +91,7 @@ $class-select-atom-input-tags: '#{$class-select-atom-input}--withTags';
 
         .sui-AtomInput-input,
         .sui-AtomInput--withTags {
-          border-color: $bc-molecule-select-input-with-state;
+          border-color: $bdc-molecule-select-input-with-state;
         }
       }
       &#{$base-class}--focus #{$base-class}-inputSelect-container {

--- a/components/molecule/select/src/styles/index.scss
+++ b/components/molecule/select/src/styles/index.scss
@@ -90,7 +90,7 @@ $class-select-atom-input-tags: '#{$class-select-atom-input}--withTags';
 
       .sui-AtomInput-input,
       .sui-AtomInput--withTags {
-        border-color: transparent;
+        border-color: $bc-molecule-select-input-with-state;
       }
     }
   }

--- a/components/molecule/select/src/styles/index.scss
+++ b/components/molecule/select/src/styles/index.scss
@@ -85,12 +85,20 @@ $class-select-atom-input-tags: '#{$class-select-atom-input}--withTags';
   }
 
   @each $state, $color in $states-atom-input {
-    &#{$base-class}--#{$state} #{$base-class}-inputSelect-container {
-      border-color: $color;
+    &#{$base-class}--#{$state} {
+      & #{$base-class}-inputSelect-container {
+        border-color: $color;
 
-      .sui-AtomInput-input,
-      .sui-AtomInput--withTags {
-        border-color: $bc-molecule-select-input-with-state;
+        .sui-AtomInput-input,
+        .sui-AtomInput--withTags {
+          border-color: $bc-molecule-select-input-with-state;
+        }
+      }
+      &#{$base-class}--focus #{$base-class}-inputSelect-container {
+        .sui-AtomInput-input,
+        .sui-AtomInput--withTags {
+          border-color: transparent;
+        }
       }
     }
   }

--- a/components/molecule/select/src/styles/settings.scss
+++ b/components/molecule/select/src/styles/settings.scss
@@ -11,5 +11,6 @@ $bgc-atom-input-disabled: $c-gray-lightest !default;
 $bg-molecule-select-disabled: $bgc-atom-input-disabled !default;
 $bd-molecule-select-disabled: $bd-atom-input-base !default;
 $bd-molecule-select-focus: $bdw-s solid $c-primary !default;
+$bc-molecule-select-input-with-state: transparent !default;
 $c-molecule-select-arrow-disabled: $c-select-list-arrow-fill !default;
 $c-molecule-select-disabled: inherit !default;

--- a/components/molecule/select/src/styles/settings.scss
+++ b/components/molecule/select/src/styles/settings.scss
@@ -11,6 +11,6 @@ $bgc-atom-input-disabled: $c-gray-lightest !default;
 $bg-molecule-select-disabled: $bgc-atom-input-disabled !default;
 $bd-molecule-select-disabled: $bd-atom-input-base !default;
 $bd-molecule-select-focus: $bdw-s solid $c-primary !default;
-$bc-molecule-select-input-with-state: transparent !default;
+$bdc-molecule-select-input-with-state: transparent !default;
 $c-molecule-select-arrow-disabled: $c-select-list-arrow-fill !default;
 $c-molecule-select-disabled: inherit !default;


### PR DESCRIPTION
## [molecule]/[select]
**TASK**: [MTR-49945](https://jira.scmspain.com/browse/MTR-49945)


### Types of changes
- [x ] New feature (non-breaking change which adds functionality)

### Description, Motivation and Context
Some months ago, we lost border color of inputs when it has an error. This is an unwanted feature:
![Captura de pantalla 2022-02-01 a las 12 47 19](https://user-images.githubusercontent.com/37936498/151963092-ae2b722b-66ea-466e-82ee-f7b91870e2d8.png)

With that new token, we can set in our theme to get its inherited value, like we had before:
![Captura de pantalla 2022-02-01 a las 12 48 35](https://user-images.githubusercontent.com/37936498/151963258-10d87d05-d7f8-4921-93ec-900ff3bfe226.png)