### PR TITLE
feat(components/atom/actionButton): Add a SCSS token to customize border radius of atom/actionButton

### DIFF
--- a/components/atom/actionButton/src/styles/index.scss
+++ b/components/atom/actionButton/src/styles/index.scss
@@ -7,6 +7,7 @@ $base-class: '.sui-AtomActionButton';
   align-items: center;
   background: none;
   border: none;
+  border-radius: $bdrs-atom-action-button;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;

--- a/components/atom/actionButton/src/styles/settings.scss
+++ b/components/atom/actionButton/src/styles/settings.scss
@@ -61,7 +61,7 @@ $c-atom-action-button-colors: (
   )
 ) !default;
 
-$bdrs-atom-action-button: $bdrs-m !default;
+$bdrs-atom-action-button: initial !default;
 $bdrs-atom-action-button-icon: $bdrs-rounded !default;
 
 $ff-atom-action-button: $ff-sans-serif !default;


### PR DESCRIPTION
## atom/actionButton
**TASK**: [#MTR-50017](https://jira.scmspain.com/browse/MTR-50017)

### Types of changes

- [x] New feature (non-breaking change which adds functionality)

### Description, Motivation and Context

A SCSS token has been added to acionButton, to make the border-radius parameter customizable.
This change is required to comply with coches.net rebranding requirements.

**Important:** Someone has already created the token used to define action button's border radius, but the token wasn't referenced in any file of `sui-components`, seems that it wasn't being used yet. Additionally, I've changed the default value to initial, because until now actionButtons haven't had any border-radius. 

### Screenshots - Animations

**Before**

![image](https://user-images.githubusercontent.com/16169223/152134607-ffd12fd0-0002-430d-b734-008e77a44c10.png)

**After**

![image](https://user-images.githubusercontent.com/16169223/152134731-628046f0-e9ed-4295-8e08-f57577db97c1.png)

Notice that before the change, there weren't border-radius, and after we define 8px of border radius.