### PR TITLE
fix(components/atom/tooltip): Fix zindex in atom tooltip

### DIFF
--- a/components/atom/tooltip/src/styles/index.scss
+++ b/components/atom/tooltip/src/styles/index.scss
@@ -25,10 +25,8 @@ $class-target: '#{$base-class}-target';
   // Avoid flick on hover
   pointer-events: none;
 
-  position: absolute;
   // Allow breaking very long words so they don't overflow the tooltip's bounds
   word-wrap: break-word;
-  z-index: $z-atom-tooltip;
 
   // Wrapper for the tooltip content
   #{$class-inner} {
@@ -114,6 +112,8 @@ $class-target: '#{$base-class}-target';
   }
 
   &--auto {
+    z-index: $z-atom-tooltip;
+
     &[x-placement*='top'] {
       @extend #{$base-class}--top;
     }


### PR DESCRIPTION
## ATOM/TOOLTIP


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-  Bug fix (non-breaking change which fixes an issue)

### Description, Motivation and Context
I've noticed that the z-index placed in the class sui-AtomTooltip, in fact, wasn't doing anything. Since the inner div was placing the position absolute, and should be this div the ones to set the z-index.

I've fixed in this PR, I've my doubts if I've resolved in the best way.

This fix a bug we have in FotocasaPro when there is other div with some z-index, so the AtomTooltip is hidden by this div, even if the z-index is lower than $z-atom-tooltip