### PR TITLE
feat(components/molecule/selectPopover): render select can trigger pa…

### DIFF
--- a/components/molecule/selectPopover/src/index.js
+++ b/components/molecule/selectPopover/src/index.js
@@ -158,7 +158,18 @@ function MoleculeSelectPopover({
     }
 
     if (renderSelectProp) {
-      return renderProp(renderSelectProp, {...newSelectProps, isOpen})
+      const newRenderSelectProps = {
+        ...newSelectProps,
+        isOpen,
+        onClick: renderSelectProp.props?.onClick
+          ? ev => {
+              renderSelectProp.props.onClick(ev)
+              handleOpenToggle(ev)
+            }
+          : handleOpenToggle
+      }
+
+      return renderProp(renderSelectProp, newRenderSelectProps)
     }
 
     return (


### PR DESCRIPTION
## molecule/selectPopover

### Types of changes
render select can trigger parent onClick prop

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor


