### PR TITLE
feat(components/atom/badge): Allow control badge M individually

### DIFF
--- a/components/atom/badge/src/_config.scss
+++ b/components/atom/badge/src/_config.scss
@@ -5,9 +5,13 @@ $fz-atom-badge-m: $fz-s !default;
 $fz-atom-badge-s: $fz-xs !default;
 $h-atom-badge-l: 24px !default;
 $h-atom-badge-s: 16px !default;
+$h-atom-badge-m: $h-atom-badge-s !default;
 $m-atom-badge-l: $m-m !default;
 $m-atom-badge-s: $m-s !default;
 $p-atom-badge: 0 $p-m !default;
+$p-atom-badge-l: $p-atom-badge !default;
+$p-atom-badge-m: $p-atom-badge !default;
+$p-atom-badge-s: $p-atom-badge !default;
 $ws-atom-badge: nowrap !default;
 
 $sizes-atom-badge: ('small', 'medium', 'large');

--- a/components/atom/badge/src/styles/index.scss
+++ b/components/atom/badge/src/styles/index.scss
@@ -22,20 +22,20 @@ $base-class: '.sui-AtomBadge';
     font-size: $fz-atom-badge-s;
     line-height: $h-atom-badge-s;
     height: $h-atom-badge-s;
-    padding: $p-atom-badge;
+    padding: $p-atom-badge-s;
   }
   &#{$this}-size-medium {
     font-size: $fz-atom-badge-m;
-    line-height: $h-atom-badge-s;
-    height: $h-atom-badge-s;
-    padding: $p-atom-badge;
+    line-height: $h-atom-badge-m;
+    height: $h-atom-badge-m;
+    padding: $p-atom-badge-m;
   }
 
   &#{$this}-size-large {
     font-size: $fz-atom-badge-l;
     line-height: $h-atom-badge-l;
     height: $h-atom-badge-l;
-    padding: $p-atom-badge;
+    padding: $p-atom-badge-l;
   }
 
   &-icon {


### PR DESCRIPTION
## Atom/Badge
**TASK**
Allow to change the settings of the tag size M individually.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
It was not possible yet to control the height and paddings of the tag M, as it was using S values as default.
This change is needed to fine-tune the tags in FC

All values (such as paddings map to `$p-atom-badge`) keep retro-compatibility

### Screenshots - Animations
No visual change introduced