### PR TITLE
feat(components/atom/popover): Retrieve scheduleUpdate function when rendering AtomPopover

### DIFF
--- a/components/atom/popover/README.md
+++ b/components/atom/popover/README.md
@@ -33,5 +33,25 @@ import AtomPopover, { atomPopoverPositions } from '@s-ui/react-atom-popover'
 
 ```
 
+Some times you may need to programmatically recalculate the `AtomPopover` position in order to fix visual inconsistencies (i.e. a change on the popover content could change the popover size, and therefore recalculating the position may be needed to ensure that popover is displayed as expected). To do so, it's possible to provide a component in the `AtomPopover`'s `content` property, this component will receive a function inside a property named `update`, calling this function will result on a popover's position recalculation.
+
+```js
+<AtomPopover
+  placement={atomPopoverPositions.BOTTOM}
+  onClose={() => console.log("CLOSE POPOVER!")}
+  content={({update}) =>
+    <>
+      Hello <strong>world</strong>!
+      <button onClick={update}>Click me to recalculate the popover position!</button>
+    </>
+  }
+>
+  <div>
+    Show Popover
+  </div>
+</AtomPopover>
+
+```
+
 
 > **Find full description and more examples in the [demo page](https://sui-components.now.sh/workbench/atom/popover/demo).**

--- a/components/atom/popover/README.md
+++ b/components/atom/popover/README.md
@@ -53,5 +53,7 @@ Some times you may need to programmatically recalculate the `AtomPopover` positi
 
 ```
 
+The `update` prop is a function provided by `Popper` (v1), which is the library in charge of rendering and positioning the popover component. You can get more information about this function here: https://popper.js.org/docs/v1/#Popper.scheduleUpdate
+
 
 > **Find full description and more examples in the [demo page](https://sui-components.now.sh/workbench/atom/popover/demo).**

--- a/components/atom/popover/src/index.js
+++ b/components/atom/popover/src/index.js
@@ -79,7 +79,7 @@ const AtomPopover = forwardRef(
                   </div>
                 )}
 
-                <ContentComponent scheduleUpdate={scheduleUpdate} />
+                <ContentComponent recalculatePopoverLocation={scheduleUpdate} />
               </>
             )
           }}

--- a/components/atom/popover/src/index.js
+++ b/components/atom/popover/src/index.js
@@ -43,6 +43,10 @@ const AtomPopover = forwardRef(
         ? typeof onClose === 'function' && onClose(ev)
         : typeof onOpen === 'function' && onOpen(ev)
     }
+
+    const ContentComponent =
+      typeof content === 'function' ? content : () => content
+
     return (
       <>
         <PopoverExtendChildren ref={targetRef} onToggle={handleToggle}>
@@ -64,10 +68,7 @@ const AtomPopover = forwardRef(
           placement={placement}
           offset={DEFAULT_OFFSET}
         >
-          {({scheduleUpdate}) => {
-            const ContentComponent =
-              typeof content === 'function' ? content : () => content
-
+          {({scheduleUpdate: update}) => {
             return (
               <>
                 {closeIcon && (
@@ -79,7 +80,7 @@ const AtomPopover = forwardRef(
                   </div>
                 )}
 
-                <ContentComponent recalculatePopoverLocation={scheduleUpdate} />
+                <ContentComponent update={update} />
               </>
             )
           }}

--- a/components/atom/popover/src/index.js
+++ b/components/atom/popover/src/index.js
@@ -64,12 +64,25 @@ const AtomPopover = forwardRef(
           placement={placement}
           offset={DEFAULT_OFFSET}
         >
-          {closeIcon && (
-            <div className={`${BASE_CLASS}-closeIcon`} onClick={handleToggle}>
-              {closeIcon}
-            </div>
-          )}
-          {content}
+          {({scheduleUpdate}) => {
+            const ContentComponent =
+              typeof content === 'function' ? content : () => content
+
+            return (
+              <>
+                {closeIcon && (
+                  <div
+                    className={`${BASE_CLASS}-closeIcon`}
+                    onClick={handleToggle}
+                  >
+                    {closeIcon}
+                  </div>
+                )}
+
+                <ContentComponent scheduleUpdate={scheduleUpdate} />
+              </>
+            )
+          }}
         </Popover>
       </>
     )


### PR DESCRIPTION
## ATOM/POPOVER
**TASK**: [MTR-51157](https://jira.scmspain.com/browse/MTR-51157)

### Types of changes

- [x] New feature (non-breaking change which adds functionality)

### Description, Motivation and Context

In coches PRO, we need a way of relocating an AtomPopover when its content changes. We have been investigating and this is one of our main investigation threads. With these changes, `scheduleUpdate` function, from `Popper`'s API, is exposed to the `AtomPopover` content component, in a way that the component is able to force the popover position recalculation.

**Special thanks to @andresin87  and @davidmartin84 **

### Screenshots - Animations

**Before**

![chrome-capture-2022-2-4](https://user-images.githubusercontent.com/16169223/156735195-fcc0a60d-e786-4aa1-afe1-0629cc71c201.gif)

**After**

![chrome-capture-2022-2-4 (1)](https://user-images.githubusercontent.com/16169223/156735407-f390aa36-8b36-489f-b69a-a5db028056fc.gif)

