### PR TITLE
feat(components/molecule/progressSteps): add content type

### DIFF
--- a/components/molecule/progressSteps/demo/ContentTypeProgressStepsArticle.js
+++ b/components/molecule/progressSteps/demo/ContentTypeProgressStepsArticle.js
@@ -1,0 +1,145 @@
+import {useState, useCallback} from 'react'
+import PropTypes from 'prop-types'
+import {
+  H2,
+  Paragraph,
+  Article,
+  RadioButton,
+  RadioButtonGroup,
+  Grid,
+  Cell,
+  Code,
+  UnorderedList,
+  ListItem,
+  Bold
+} from '@s-ui/documentation-library'
+
+import MoleculeProgressSteps, {
+  MoleculeProgressStep,
+  moleculeProgressStepsStatuses,
+  MoleculeProgressContentStyle
+} from '../src/index.js'
+import {IconFillCheck} from './Icons/index.js'
+import {configBasic} from './config/index.js'
+
+const getStatus = (step, index) => {
+  if (index + 1 === step) {
+    return moleculeProgressStepsStatuses.ACTIVE
+  } else if (index + 1 < step) {
+    return moleculeProgressStepsStatuses.VISITED
+  }
+  return moleculeProgressStepsStatuses.NORMAL
+}
+
+const getLabel = (index, keys) => {
+  if (index < Math.min(...keys)) {
+    return 'start'
+  } else if (index > Math.max(...keys)) {
+    return 'end'
+  }
+  return `step ${index}`
+}
+
+const DefaultProgressStepsArticle = ({className}) => {
+  const [step, setStep] = useState(1)
+  const [contentType, setContentType] = useState(
+    MoleculeProgressContentStyle.FIXED
+  )
+
+  const setStatus = useCallback(
+    step => {
+      setStep(step)
+    },
+    [setStep]
+  )
+  return (
+    <Article className={className}>
+      <H2>ProgressSteps Content Type</H2>
+      <Paragraph>
+        The progress steps content type can be custom using the{' '}
+        <Code>contentStyle</Code> enum prop. It must be provided using one of
+        the values defined under the <Code>MoleculeProgressContentStyle</Code>{' '}
+        different enum values:
+      </Paragraph>
+      <UnorderedList>
+        <ListItem>
+          Content type values:
+          <UnorderedList>
+            <ListItem>
+              <Bold>FIXED</Bold>: All tabs have the size of the highest tab
+              content
+            </ListItem>
+            <ListItem>
+              <Bold>FLUID</Bold>: Each tab is sized to fit its own content
+            </ListItem>
+          </UnorderedList>
+        </ListItem>
+      </UnorderedList>
+
+      <Grid cols={1} gutter={[8, 8]}>
+        <Cell>
+          <RadioButtonGroup
+            value={step}
+            onChange={(event, value) => setStatus(value || 0)}
+          >
+            {[
+              0,
+              ...Object.keys(configBasic),
+              Object.keys(configBasic).length + 1
+            ].map(stepValue => (
+              <RadioButton
+                key={`step ${parseInt(stepValue)}`}
+                value={parseInt(stepValue)}
+                checked={step === parseInt(stepValue)}
+                label={getLabel(
+                  stepValue,
+                  Object.keys(configBasic).map(v => parseInt(v))
+                )}
+              />
+            ))}
+          </RadioButtonGroup>
+        </Cell>
+        <Cell>
+          <RadioButtonGroup
+            value={contentType}
+            onChange={(event, value) => setContentType(value)}
+          >
+            <RadioButton
+              value={MoleculeProgressContentStyle.FIXED}
+              checked={contentType === MoleculeProgressContentStyle.FIXED}
+              label="Fixed"
+            />
+            <RadioButton
+              value={MoleculeProgressContentStyle.FLUID}
+              checked={contentType === MoleculeProgressContentStyle.FLUID}
+              label="Fluid"
+            />
+          </RadioButtonGroup>
+        </Cell>
+        <Cell>
+          <MoleculeProgressSteps
+            iconStepDone={<IconFillCheck />}
+            contentStyle={contentType}
+          >
+            {Object.values(configBasic).map(({label, content, icon}, index) => (
+              <MoleculeProgressStep
+                key={index}
+                label={label}
+                status={getStatus(step, index)}
+                icon={icon}
+              >
+                {content}
+              </MoleculeProgressStep>
+            ))}
+          </MoleculeProgressSteps>
+        </Cell>
+      </Grid>
+    </Article>
+  )
+}
+
+DefaultProgressStepsArticle.propTypes = {
+  className: PropTypes.string
+}
+
+export default DefaultProgressStepsArticle

--- a/components/molecule/progressSteps/demo/ContentTypeProgressStepsArticle.js
+++ b/components/molecule/progressSteps/demo/ContentTypeProgressStepsArticle.js
@@ -17,7 +17,7 @@ import {
 import MoleculeProgressSteps, {
   MoleculeProgressStep,
   moleculeProgressStepsStatuses,
-  MoleculeProgressContentStyle
+  moleculeProgressContentStyle
 } from '../src/index.js'
 import {IconFillCheck} from './Icons/index.js'
 import {configBasic} from './config/index.js'
@@ -43,7 +43,7 @@ const getLabel = (index, keys) => {
 const DefaultProgressStepsArticle = ({className}) => {
   const [step, setStep] = useState(1)
   const [contentType, setContentType] = useState(
-    MoleculeProgressContentStyle.FIXED
+    moleculeProgressContentStyle.FIXED
   )
 
   const setStatus = useCallback(
@@ -58,7 +58,7 @@ const DefaultProgressStepsArticle = ({className}) => {
       <Paragraph>
         The progress steps content type can be custom using the{' '}
         <Code>contentStyle</Code> enum prop. It must be provided using one of
-        the values defined under the <Code>MoleculeProgressContentStyle</Code>{' '}
+        the values defined under the <Code>moleculeProgressContentStyle</Code>{' '}
         different enum values:
       </Paragraph>
       <UnorderedList>
@@ -105,13 +105,13 @@ const DefaultProgressStepsArticle = ({className}) => {
             onChange={(event, value) => setContentType(value)}
           >
             <RadioButton
-              value={MoleculeProgressContentStyle.FIXED}
-              checked={contentType === MoleculeProgressContentStyle.FIXED}
+              value={moleculeProgressContentStyle.FIXED}
+              checked={contentType === moleculeProgressContentStyle.FIXED}
               label="Fixed"
             />
             <RadioButton
-              value={MoleculeProgressContentStyle.FLUID}
-              checked={contentType === MoleculeProgressContentStyle.FLUID}
+              value={moleculeProgressContentStyle.FLUID}
+              checked={contentType === moleculeProgressContentStyle.FLUID}
               label="Fluid"
             />
           </RadioButtonGroup>

--- a/components/molecule/progressSteps/demo/index.js
+++ b/components/molecule/progressSteps/demo/index.js
@@ -5,6 +5,7 @@ import CustomIconsProgressStepsArticle from './CustomIconsProgressStepsArticle.j
 import VerticalProgressBarArticle from './VerticalProgressBarArticle.js'
 import CompressedProgressBarArticle from './CompressedProgressBarArticle.js'
 import JustifyContentProgressBarArticle from './JustifyContentProgressBarArticle.js'
+import ContentTypeProgressStepsArticle from './ContentTypeProgressStepsArticle.js'
 
 import './index.scss'
 
@@ -25,6 +26,8 @@ const Demo = () => {
         <CustomIconsProgressStepsArticle className={articleClass} />
         <br />
         <JustifyContentProgressBarArticle className={articleClass} />
+        <br />
+        <ContentTypeProgressStepsArticle className={articleClass} />
         <br />
       </div>
     </div>

--- a/components/molecule/progressSteps/src/config.js
+++ b/components/molecule/progressSteps/src/config.js
@@ -9,7 +9,7 @@ export const CONTENT_STYLE = {
 }
 
 export const CLASS_COMPRESSED = `${BASE_CLASS}--compressed`
-export const CLASS_COMPRESSED_INFO = `${CLASS_COMPRESSED}Info`
+export const CLASS_COMPRESSED_INFO = `${BASE_CLASS}-compressedInfo`
 export const CLASS_VERTICAL = `${BASE_CLASS}--vertical`
 
 export const PROGRESS_BAR_JUSTIFY_CONTENT = {

--- a/components/molecule/progressSteps/src/config.js
+++ b/components/molecule/progressSteps/src/config.js
@@ -1,11 +1,16 @@
 export const BASE_CLASS = `sui-MoleculeProgressSteps`
 
 export const CLASS_STEPS = `${BASE_CLASS}-path`
-export const CLASS_CONTENT = `${BASE_CLASS}-content`
-export const CLASS_COMPRESSED_INFO = `${BASE_CLASS}-compressedInfo`
 
-export const CLASS_VERTICAL = `${BASE_CLASS}--vertical`
+export const CLASS_CONTENT = `${BASE_CLASS}-content`
+export const CONTENT_STYLE = {
+  FIXED: `${CLASS_CONTENT}--fixed`,
+  FLUID: `${CLASS_CONTENT}--fluid`
+}
+
 export const CLASS_COMPRESSED = `${BASE_CLASS}--compressed`
+export const CLASS_COMPRESSED_INFO = `${CLASS_COMPRESSED}Info`
+export const CLASS_VERTICAL = `${BASE_CLASS}--vertical`
 
 export const PROGRESS_BAR_JUSTIFY_CONTENT = {
   /** inner-bars are going to be growing for getting 100% of the width **/

--- a/components/molecule/progressSteps/src/index.js
+++ b/components/molecule/progressSteps/src/index.js
@@ -88,7 +88,7 @@ const MoleculeProgressSteps = ({
       return (
         <div
           key={index}
-          className={cx(`${CLASS_CONTENT}-item `, {
+          className={cx(`${CLASS_CONTENT}-item`, {
             [`${CLASS_CONTENT}-item--active`]: status === STATUSES.ACTIVE
           })}
         >
@@ -115,9 +115,7 @@ const MoleculeProgressSteps = ({
       >
         {extendedChildren}
       </div>
-      <div className={`${CLASS_CONTENT} ${contentStyle}`}>
-        {childrenContent}
-      </div>
+      <div className={cx(CLASS_CONTENT, contentStyle)}>{childrenContent}</div>
     </div>
   )
 }
@@ -152,5 +150,5 @@ export {
   STATUSES,
   STATUSES as moleculeProgressStepsStatuses,
   PROGRESS_BAR_JUSTIFY_CONTENT as moleculeProgressStepsJustifyContentBar,
-  CONTENT_STYLE as MoleculeProgressContentStyle
+  CONTENT_STYLE as moleculeProgressContentStyle
 }

--- a/components/molecule/progressSteps/src/index.js
+++ b/components/molecule/progressSteps/src/index.js
@@ -9,7 +9,8 @@ import {
   CLASS_COMPRESSED_INFO,
   CLASS_VERTICAL,
   CLASS_COMPRESSED,
-  PROGRESS_BAR_JUSTIFY_CONTENT
+  PROGRESS_BAR_JUSTIFY_CONTENT,
+  CONTENT_STYLE
 } from './config.js'
 import MoleculeProgressStep, {
   STATUSES
@@ -20,7 +21,8 @@ const MoleculeProgressSteps = ({
   children,
   iconStepDone,
   compressed,
-  progressBarJustifyContent = PROGRESS_BAR_JUSTIFY_CONTENT.LEGACY
+  progressBarJustifyContent = PROGRESS_BAR_JUSTIFY_CONTENT.LEGACY,
+  contentStyle = CONTENT_STYLE.FIXED
 }) => {
   const activeStepContent = useRef()
 
@@ -86,7 +88,7 @@ const MoleculeProgressSteps = ({
       return (
         <div
           key={index}
-          className={cx(`${CLASS_CONTENT}-item`, {
+          className={cx(`${CLASS_CONTENT}-item `, {
             [`${CLASS_CONTENT}-item--active`]: status === STATUSES.ACTIVE
           })}
         >
@@ -113,7 +115,9 @@ const MoleculeProgressSteps = ({
       >
         {extendedChildren}
       </div>
-      <div className={CLASS_CONTENT}>{childrenContent}</div>
+      <div className={`${CLASS_CONTENT} ${contentStyle}`}>
+        {childrenContent}
+      </div>
     </div>
   )
 }
@@ -133,6 +137,9 @@ MoleculeProgressSteps.propTypes = {
   /** Vertical mode */
   vertical: PropTypes.bool,
 
+  /** Fit the content size */
+  contentStyle: PropTypes.oneOf(Object.values(CONTENT_STYLE)),
+
   /** justify the progressbar elements in its area following the element declared **/
   progressBarJustifyContent: PropTypes.oneOf(
     Object.values(PROGRESS_BAR_JUSTIFY_CONTENT)
@@ -144,5 +151,6 @@ export {
   MoleculeProgressStep,
   STATUSES,
   STATUSES as moleculeProgressStepsStatuses,
-  PROGRESS_BAR_JUSTIFY_CONTENT as moleculeProgressStepsJustifyContentBar
+  PROGRESS_BAR_JUSTIFY_CONTENT as moleculeProgressStepsJustifyContentBar,
+  CONTENT_STYLE as MoleculeProgressContentStyle
 }

--- a/components/molecule/progressSteps/src/styles/index.scss
+++ b/components/molecule/progressSteps/src/styles/index.scss
@@ -1,4 +1,5 @@
 $base-class: '.sui-MoleculeProgressSteps';
+$content-class: $base-class + '-content';
 
 #{$base-class} {
   &-path {
@@ -106,17 +107,34 @@ $base-class: '.sui-MoleculeProgressSteps';
     }
   }
   &-compressedInfo,
-  &-content {
-    overflow: hidden;
+  #{$content-class} {
     display: flex;
+    overflow: hidden;
     &-item {
       margin-right: -100%;
-      visibility: hidden;
       flex-basis: 100%;
       flex-shrink: 0;
       &--active {
         margin-right: 0;
-        visibility: inherit;
+      }
+    }
+
+    &--fixed {
+      #{$content-class}-item {
+        visibility: hidden;
+        &--active {
+          visibility: inherit;
+        }
+      }
+    }
+
+    &--fluid {
+      #{$content-class}-item {
+        display: none;
+
+        &--active {
+          display: flex;
+        }
       }
     }
   }

--- a/components/molecule/progressSteps/src/styles/index.scss
+++ b/components/molecule/progressSteps/src/styles/index.scss
@@ -202,11 +202,13 @@ $content-class: $base-class + '-content';
         flex-basis: auto;
         flex-grow: 1;
         flex-shrink: 0;
+        justify-content: space-between;
         &-item {
           display: inline-flex;
+          flex-basis: inherit;
           justify-content: flex-end;
           align-content: flex-start;
-          margin-top: -100%;
+          margin-top: 0;
           margin-right: 0;
           &--active {
             margin-right: 0;

--- a/components/molecule/progressSteps/src/styles/index.scss
+++ b/components/molecule/progressSteps/src/styles/index.scss
@@ -141,8 +141,10 @@ $content-class: $base-class + '-content';
 
   #{$base-class}-compressedInfo {
     &-item {
+      visibility: hidden;
       &--active {
         margin-right: 0;
+        visibility: inherit;
       }
     }
   }

--- a/components/molecule/progressSteps/src/styles/index.scss
+++ b/components/molecule/progressSteps/src/styles/index.scss
@@ -1,5 +1,5 @@
 $base-class: '.sui-MoleculeProgressSteps';
-$content-class: $base-class + '-content';
+$content-class: '#{$base-class}-content';
 
 #{$base-class} {
   &-path {

--- a/components/molecule/progressSteps/test/index.test.js
+++ b/components/molecule/progressSteps/test/index.test.js
@@ -28,6 +28,7 @@ describe(json.name, () => {
       'STATUSES',
       'moleculeProgressStepsStatuses',
       'moleculeProgressStepsJustifyContentBar',
+      'MoleculeProgressContentStyle',
       'default'
     ]
 
@@ -37,6 +38,7 @@ describe(json.name, () => {
       STATUSES,
       moleculeProgressStepsStatuses,
       moleculeProgressStepsJustifyContentBar,
+      MoleculeProgressContentStyle,
       default: MoleculeProgressSteps,
       ...others
     } = library

--- a/components/molecule/progressSteps/test/index.test.js
+++ b/components/molecule/progressSteps/test/index.test.js
@@ -28,7 +28,7 @@ describe(json.name, () => {
       'STATUSES',
       'moleculeProgressStepsStatuses',
       'moleculeProgressStepsJustifyContentBar',
-      'MoleculeProgressContentStyle',
+      'moleculeProgressContentStyle',
       'default'
     ]
 
@@ -38,7 +38,7 @@ describe(json.name, () => {
       STATUSES,
       moleculeProgressStepsStatuses,
       moleculeProgressStepsJustifyContentBar,
-      MoleculeProgressContentStyle,
+      moleculeProgressContentStyle,
       default: MoleculeProgressSteps,
       ...others
     } = library


### PR DESCRIPTION
## MOLECULE/PROGRESSSTEPS

### Types of changes
Added new prop for tab content adjustment

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
When we have a step form, and one step has more content than the others, we need to adjust the tab content

### Screenshots - Animations
THEN:
<img width="442" alt="Captura de pantalla 2022-03-07 a las 11 46 46" src="https://user-images.githubusercontent.com/16401219/157016756-69c411f1-9c47-4c8b-8ca2-a8dd863d561a.png">

NOW
<img width="442" alt="Captura de pantalla 2022-03-07 a las 11 47 08" src="https://user-images.githubusercontent.com/16401219/157016815-6030caec-a89e-4bb8-b667-3fa07d0d5b90.png">

