### PR TITLE
fix(components/atom/popover): Avoid unexpected renders by not forcing the encapsulation of content inside a function

### DIFF
--- a/components/atom/popover/src/index.js
+++ b/components/atom/popover/src/index.js
@@ -21,7 +21,7 @@ const AtomPopover = forwardRef(
     {
       children,
       closeIcon,
-      content,
+      content: Content,
       onClose,
       onOpen,
       placement = PLACEMENTS.BOTTOM,
@@ -43,9 +43,6 @@ const AtomPopover = forwardRef(
         ? typeof onClose === 'function' && onClose(ev)
         : typeof onOpen === 'function' && onOpen(ev)
     }
-
-    const ContentComponent =
-      typeof content === 'function' ? content : () => content
 
     return (
       <>
@@ -79,8 +76,11 @@ const AtomPopover = forwardRef(
                     {closeIcon}
                   </div>
                 )}
-
-                <ContentComponent update={update} />
+                {typeof Content === 'function' ? (
+                  <Content update={update} />
+                ) : (
+                  Content
+                )}
               </>
             )
           }}


### PR DESCRIPTION
## [atom]/[popover]
**TASK**: [MTR-49439](https://jira.scmspain.com/browse/MTR-49439)

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Description, Motivation and Context

We've recently added a feature to retrieve the `update` function from an AtomPopover. This function allows to force a recalculation of the popover position (more info here 👉  https://github.com/SUI-Components/sui-components/pull/2036).

To support this new feature, we needed to changed the way the popover component is rendered, and accidentally this new way to render the component is causing non-desired renders, which at the end causes a low performance and some visual glitches.

The reason is that the content is being encapsulated inside an arrow function when it is received as a plain JSX. This is causing that every time the AtomPopover is re-rendered by any reason, its content is also re-rendered because the function is re-generated: Although the content may remain identical, a new anonymous function is generated and that executes the render.

**This is a solution proposal, not agreed with an enabler yet. We are looking to talk this with Andres, but will appreciate any improvement suggestion or requirement.**

### Screenshots - Animations

TBD...