### PR TITLE
feat(components/atom/icon): allow to inherit display to the main class

### DIFF
--- a/components/atom/icon/src/styles/index.scss
+++ b/components/atom/icon/src/styles/index.scss
@@ -1,6 +1,8 @@
 $base-class: '.sui-AtomIcon';
 
 #{$base-class} {
+  display: inherit;
+
   // Colors
   @each $key, $value in $atom-icon-colors {
     &#{$base-class}--#{$key} svg {


### PR DESCRIPTION
## atom/icon
**TASK**: https://jira.scmspain.com/browse/MMAA-26920


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
If we add an AtomIcon with a 16x16px size, the component will expand as max as possible due to the height of its container, causing a non-wanted resize and alignment issues. 
![Captura de pantalla 2022-03-08 a las 14 50 57](https://user-images.githubusercontent.com/26527612/157251049-b0b85ebb-f12d-415d-aba3-69e68c1a59e8.png)
![Captura de pantalla 2022-03-08 a las 14 53 55](https://user-images.githubusercontent.com/26527612/157251562-0b1a9f2e-57c4-4e26-a5c4-7724dc849969.png)
So, we allow to the AtomIcon class to inherit display and manage it on top.

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
