### PR TITLE
Feat molecule/accordion controlled state

### DIFF
--- a/components/molecule/accordion/demo/index.js
+++ b/components/molecule/accordion/demo/index.js
@@ -1,3 +1,4 @@
+import {useState} from 'react'
 import PropTypes from 'prop-types'
 
 import MoleculeAccordion from '../src/index.js'
@@ -19,6 +20,7 @@ DemoWrapper.propTypes = {
 }
 
 export default () => {
+  const [openedTabs, setOpenedTabs] = useState([1])
   const text =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam dictum magna non diam euismod blandit et eu ex. Vivamus pulvinar sodales tincidunt. Proin venenatis tristique quam, quis vehicula eros volutpat sed. Etiam sed tristique ante. Aenean commodo erat quis pulvinar luctus. Pellentesque ultricies lorem vitae ante euismod, at imperdiet est euismod. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. In dignissim porttitor sem, a varius nisl ullamcorper ut. Vivamus lacinia, quam eu placerat tempus, velit massa vulputate turpis, sit amet bibendum risus massa sit amet urna. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Praesent finibus lobortis blandit. Vivamus scelerisque blandit purus a suscipit. Nunc mi elit, condimentum eget pulvinar eu, lacinia vitae ligula. Sed sit amet eros auctor ipsum tincidunt hendrerit ac mollis justo. Ut ac sagittis ipsum.'
 
@@ -50,6 +52,46 @@ export default () => {
       <h1>Accordion</h1>
       <DemoWrapper>
         <Demo>
+          <div
+            style={{
+              backgroundColor: '#fff',
+              fontSize: 14,
+              padding: 16,
+              textAlign: 'left'
+            }}
+          >
+            <button onClick={() => setOpenedTabs([])}>Close Tabs</button>
+            <MoleculeAccordion
+              maxHeight={100}
+              openedTabs={openedTabs}
+              withAutoClose
+              withTransition
+              icon={icon}
+              onToggleTab={(e, {index, openedTabs}) => {
+                setOpenedTabs(openedTabs)
+                console.log('tab toggled:', index) // eslint-disable-line no-console
+              }}
+            >
+              <div label="Title 1">
+                <p style={{margin: 0}}>{text}</p>
+              </div>
+              <div label="Title 2">
+                <p style={{margin: 0}}>{text}</p>
+                <p style={{margin: 0}}>{text}</p>
+                <p style={{margin: 0}}>{text}</p>
+              </div>
+              <div label="Title 3">
+                <p style={{margin: 0}}>{text}</p>
+                <p style={{margin: 0}}>{text}</p>
+                <p style={{margin: 0}}>{text}</p>
+              </div>
+              <div label="Title 4">
+                <p style={{margin: 0}}>{text}</p>
+                <p style={{margin: 0}}>{text}</p>
+                <p style={{margin: 0}}>{text}</p>
+              </div>
+            </MoleculeAccordion>
+          </div>
           <h2>
             Accordion with transition, autoclose, max height and onToggleTab
             handler

--- a/components/molecule/accordion/demo/index.js
+++ b/components/molecule/accordion/demo/index.js
@@ -52,6 +52,10 @@ export default () => {
       <h1>Accordion</h1>
       <DemoWrapper>
         <Demo>
+          <h2>Accordion with opened tabs state managed via prop</h2>
+          <p>
+            Opened tabs: {openedTabs?.length ? openedTabs.join(',') : 'none'}
+          </p>
           <div
             style={{
               backgroundColor: '#fff',
@@ -64,10 +68,11 @@ export default () => {
             <MoleculeAccordion
               maxHeight={100}
               openedTabs={openedTabs}
-              withAutoClose
+              withAutoClose={false}
               withTransition
               icon={icon}
               onToggleTab={(e, {index, openedTabs}) => {
+                console.log({openedTabs})
                 setOpenedTabs(openedTabs)
                 console.log('tab toggled:', index) // eslint-disable-line no-console
               }}

--- a/components/molecule/accordion/src/Tab/index.js
+++ b/components/molecule/accordion/src/Tab/index.js
@@ -58,7 +58,9 @@ const Tab = ({
         </button>
       </div>
       <div
+        {...(isOpen ? {'aria-expanded': true} : {'aria-hidden': true})}
         className={contentClassName}
+        role="tab"
         style={{maxHeight: `${containerHeight}`}}
       >
         <div className={CONTENT_CLASS}>{children}</div>

--- a/components/molecule/accordion/test/index.test.js
+++ b/components/molecule/accordion/test/index.test.js
@@ -131,5 +131,38 @@ describe(json.name, () => {
       // Then
       sinon.assert.called(spy)
     })
+
+    it('should show the second and third tab open', () => {
+      // Given
+      const spy = sinon.spy()
+      const props = {
+        children: [
+          <div key={0} label="label 1">
+            element 1
+          </div>,
+          <div key={1} label="label 2">
+            element 2
+          </div>,
+          <div key={2} label="label 3">
+            element 3
+          </div>
+        ],
+        icon: <svg />,
+        onToggleTab: spy,
+        openedTabs: [1, 2]
+      }
+      const {getAllByRole} = setup(props)
+
+      // When
+      const tabs = getAllByRole('tab')
+
+      // Then
+      tabs.forEach((tab, index) => {
+        expect(Boolean(tab.hasAttribute('aria-expanded'))).to.be.true
+        expect(Boolean(tab.hasAttribute('aria-hidden'))).to.be.false
+        expect(['element 2', 'element 3'].some(text => tab.innerText === text))
+          .to.be.true
+      })
+    })
   })
 })

--- a/components/molecule/accordion/test/index.test.js
+++ b/components/molecule/accordion/test/index.test.js
@@ -132,7 +132,7 @@ describe(json.name, () => {
       sinon.assert.called(spy)
     })
 
-    it('should show the second and third tab open', () => {
+    it('should show the second and third tab open when set via openedTabs prop', () => {
       // Given
       const spy = sinon.spy()
       const props = {


### PR DESCRIPTION
## MOLECULE/ACCORDION
**TASK**: N/A

We're adding a new prop `openedTabs` to allow us for full control over which tabs are open on the `molecule/accordion` component from a parent component.

Also added component test and component demo for this new feature.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
In some cases, we need to be able to force our `molecule/accordion` component to either close all its open tabs or to open the ones we require to be open. This `PR` addresses this.

### Screenshots - Animations
N/A