### PR TITLE
fix(components/atom/switch): prevent form submit when switch is clicked

### DIFF
--- a/components/atom/switch/src/SwitchType/single.js
+++ b/components/atom/switch/src/SwitchType/single.js
@@ -68,6 +68,7 @@ export const SingleSwitchTypeRender = forwardRef(
             />
           )}
           <button
+            type="button"
             className={cx(suitClass({element: 'inputContainer'}), {
               [suitClass({
                 element: 'inputContainer',

--- a/components/atom/switch/src/SwitchType/toggle.js
+++ b/components/atom/switch/src/SwitchType/toggle.js
@@ -70,6 +70,7 @@ export const ToggleSwitchTypeRender = forwardRef(
             {labelLeft}
           </span>
           <button
+            type="button"
             className={cx(suitClass({element: 'inputContainer'}), {
               [suitClass({
                 element: 'inputContainer',


### PR DESCRIPTION
## ATOM/SWITCH
**TASK**: NO_JIRA


### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

### Description, Motivation and Context
After merging https://github.com/SUI-Components/sui-components/pull/2091 now when the user clicks on the Atom Switch, it cause a Form submit because the button is `type=submit` by default.

