### PR TITLE
feat(components/molecule/selectPopover): define default selected bg c…

### DIFF
--- a/components/molecule/selectPopover/src/styles/index.scss
+++ b/components/molecule/selectPopover/src/styles/index.scss
@@ -36,8 +36,7 @@ $base-class: '.sui-MoleculeSelectPopover ';
     }
 
     &:hover,
-    &.is-open,
-    &.is-selected {
+    &.is-open {
       background-color: $bgc-select-popover-hover;
       border-color: $bdc-select-popover-hover;
     }
@@ -51,6 +50,7 @@ $base-class: '.sui-MoleculeSelectPopover ';
     }
 
     &.is-selected {
+      background-color: $bgc-select-popover-selected;
       border-color: $bdc-select-popover-selected;
       color: $c-select-popover-selected;
     }

--- a/components/molecule/selectPopover/src/styles/settings.scss
+++ b/components/molecule/selectPopover/src/styles/settings.scss
@@ -11,6 +11,7 @@ $bgc-select-popover-content: $c-white !default;
 $bd-select-popover-content: solid 1px $c-gray-light-3 !default;
 $bdt-select-popover-action-bar: solid 1px $c-gray-light-3 !default;
 
+$bgc-select-popover-selected: $bgc-select-popover-hover !default;
 $bdc-select-popover-selected: $c-primary !default;
 $c-select-popover-selected: $c-primary !default;
 


### PR DESCRIPTION
## Molecule/SelectPopover

 #### `🔍 Show`

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: [MTR-51782](https://jira.scmspain.com/browse/MTR-51782)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [x] 💄 Styles

### Description, Motivation and Context
Define a new variable _**`$bgc-select-popover-selected`**_ to be able to manage this value independently from the one currently defined as default and that couples it to the hover state (_**`$bgc-select-popover-hover`**_).
