### PR TITLE
feat(components/molecule/photoUploader): add overflow hidden to make visible the defined border-radius

### DIFF
--- a/components/molecule/photoUploader/src/styles/index.scss
+++ b/components/molecule/photoUploader/src/styles/index.scss
@@ -137,10 +137,10 @@ $skeleton-class: '#{$base-class}-skeleton';
   box-shadow: $bxsh-photo-uploader-thumb-card;
   cursor: grab;
   display: inline-block;
-  overflow: hidden;
 
   &Card {
     background: $bg-photo-uploader-thumb-card;
+    border-radius: $bdrs-photo-uploader-thumb-card;
     display: flex;
     flex-direction: column;
     min-width: 0;
@@ -173,6 +173,8 @@ $skeleton-class: '#{$base-class}-skeleton';
 
     &-iconContainer {
       background-color: rgba($c-primary, 0.1);
+      border-radius: $bdrs-photo-uploader-thumb-card
+        $bdrs-photo-uploader-thumb-card 0 0;
       display: flex;
       flex-direction: column;
       height: 100%;
@@ -187,6 +189,8 @@ $skeleton-class: '#{$base-class}-skeleton';
     }
 
     &-image {
+      border-radius: $bdrs-photo-uploader-thumb-card
+        $bdrs-photo-uploader-thumb-card 0 0;
       height: 100%;
       object-fit: cover;
       width: $w-photo-uploader-thumb-image;
@@ -201,6 +205,8 @@ $skeleton-class: '#{$base-class}-skeleton';
       }
 
       &Container {
+        border-radius: $bdrs-photo-uploader-thumb-card
+          $bdrs-photo-uploader-thumb-card 0 0;
         display: flex;
         height: 100%;
       }
@@ -222,6 +228,13 @@ $skeleton-class: '#{$base-class}-skeleton';
       justify-content: center;
       padding: $p-photo-uploader-action-buttons;
       width: 50%;
+
+      &:first-of-type {
+        border-radius: 0 0 0 $bdrs-photo-uploader-thumb-card;
+      }
+      &:last-of-type {
+        border-radius: 0 0 $bdrs-photo-uploader-thumb-card 0;
+      }
 
       &:hover {
         @include media-breakpoint-up(m) {

--- a/components/molecule/photoUploader/src/styles/index.scss
+++ b/components/molecule/photoUploader/src/styles/index.scss
@@ -137,6 +137,7 @@ $skeleton-class: '#{$base-class}-skeleton';
   box-shadow: $bxsh-photo-uploader-thumb-card;
   cursor: grab;
   display: inline-block;
+  overflow: hidden;
 
   &Card {
     background: $bg-photo-uploader-thumb-card;


### PR DESCRIPTION
## molecule/PhotoUploader
#### `🔍 Show`

**TASK**: [MTR-53299](https://jira.scmspain.com/browse/MTR-53299)

### Types of changes

- [x] 💄 Styles

### Description, Motivation and Context
Fix to recover the thumb card border-radius defined by theme.

### Screenshots - Animations
BEFORE:
![Captura de Pantalla 2022-05-03 a las 19 05 19](https://user-images.githubusercontent.com/37936498/166503956-81cacd0a-c98a-4d47-b988-84d94b77cc6d.png)

NOW (with dramatic border-radius applied):
![Captura de Pantalla 2022-05-03 a las 19 05 28](https://user-images.githubusercontent.com/37936498/166504003-2a5d3c0d-1451-4ff4-b98a-11147584a2d4.png)

