### PR TITLE
feat(components/layout/grid): allow pass custom classNames

### DIFF
--- a/components/layout/grid/src/gridItem/index.js
+++ b/components/layout/grid/src/gridItem/index.js
@@ -7,6 +7,7 @@ import {getColSpanClassNamesTransform} from './settings.js'
 
 export default function LayoutGridItem({
   children,
+  className = '',
   colSpan = 1,
   l,
   lOffset,
@@ -36,7 +37,8 @@ export default function LayoutGridItem({
     mOffset && `${BASE_CLASS}-item--mOffset-${mOffset}`,
     lOffset && `${BASE_CLASS}-item--lOffset-${lOffset}`,
     xlOffset && `${BASE_CLASS}-item--xlOffset-${xlOffset}`,
-    xxlOffset && `${BASE_CLASS}-item--xxlOffset-${xxlOffset}`
+    xxlOffset && `${BASE_CLASS}-item--xxlOffset-${xxlOffset}`,
+    className
   )
 
   return <div className={classNames}>{children}</div>
@@ -49,6 +51,10 @@ LayoutGridItem.propTypes = {
    * The content of the component.
    */
   children: PropTypes.node,
+  /**
+   * Allows you to add extra styles and avoid extra DOM elements to style purposes.
+   */
+  className: PropTypes.string,
   /***
    * Defines the number of columns an item should span
    */

--- a/components/layout/grid/src/index.js
+++ b/components/layout/grid/src/index.js
@@ -38,7 +38,8 @@ function LayoutGrid({
   alignItems,
   children,
   justifyContent,
-  gutter
+  gutter,
+  className = ''
 }) {
   const classNames = cx(
     `${BASE_CLASS}`,
@@ -48,7 +49,8 @@ function LayoutGrid({
       `${BASE_CLASS}--ai-${alignItems}`,
     Object.values(JUSTIFY_CONTENT).includes(justifyContent) &&
       `${BASE_CLASS}--jc-${justifyContent}`,
-    getGutterClassNames(gutter)
+    getGutterClassNames(gutter),
+    className
   )
 
   return <div className={classNames}>{children}</div>
@@ -69,6 +71,10 @@ LayoutGrid.propTypes = {
    * Sets the align-self value on all direct children as a group. It's applied for all screen sizes.
    */
   alignItems: PropTypes.oneOf(Object.values(ALIGN_ITEMS)),
+  /**
+   * Allows you to add extra styles and avoid extra DOM elements to style purposes.
+   */
+  className: PropTypes.string,
   /**
    * Distribute space between and around content items. It's applied for all screen sizes.
    */

--- a/components/layout/grid/test/index.test.js
+++ b/components/layout/grid/test/index.test.js
@@ -75,7 +75,7 @@ describe(json.name, () => {
       expect(container.innerHTML).to.not.have.lengthOf(0)
     })
 
-    it('should NOT extend classNames', () => {
+    it('should allows you to add custom classNames to add styles', () => {
       // Given
       const props = {className: 'extended-classNames'}
       const findSentence = str => string =>
@@ -86,7 +86,7 @@ describe(json.name, () => {
       const findClassName = findSentence(props.className)
 
       // Then
-      expect(findClassName(container.innerHTML)).to.be.null
+      expect(findClassName(container.innerHTML)).to.exist
     })
   })
 

--- a/components/layout/grid/test/index.test.js
+++ b/components/layout/grid/test/index.test.js
@@ -75,7 +75,7 @@ describe(json.name, () => {
       expect(container.innerHTML).to.not.have.lengthOf(0)
     })
 
-    it('should allows you to add custom classNames to add styles', () => {
+    it('should allows you to add custom classNames', () => {
       // Given
       const props = {className: 'extended-classNames'}
       const findSentence = str => string =>


### PR DESCRIPTION
## Layout/Grid

<!-- Uncomment what you need -->
#### `❓ Ask` 

### Types of changes

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context

If we use LayoutGrid or LayoutGridItem and we want customize some element style (for example, background/text color, etc, we need to create extra DOM elements to achieve that. 

Google loves ❤️  clean HTML, so if we let to our developers to add custom classNames, we are empowering them  to write more clean HTML and we keep Google happy! 😃
