### PR TITLE
fix: autosuggest manage is opened state

### DIFF
--- a/components/molecule/autosuggest/demo/hoc/withDynamicOptions.js
+++ b/components/molecule/autosuggest/demo/hoc/withDynamicOptions.js
@@ -13,11 +13,17 @@ export default (BaseComponent, BaseChildComponent) => getDynamicOptions => {
 
     state = {options: []}
 
+    async componentDidMount() {
+      const {value: query} = this.props
+      const options = await getDynamicOptions({query})
+      this.setState({options})
+    }
+
     async componentDidUpdate({value: prevQuery}) {
       const {value: query} = this.props
       if (query !== prevQuery) {
         const options = await getDynamicOptions({query})
-        this.setState({options}) // eslint-disable-line
+        this.setState({options})
       }
     }
 

--- a/components/molecule/autosuggest/demo/index.js
+++ b/components/molecule/autosuggest/demo/index.js
@@ -73,9 +73,6 @@ const Demo = () => {
             onChange={(_, {value}) => console.log(value)}
             onEnter={() => console.log('Enter pressed')}
             onClear={() => console.log('Clear pressed')}
-            onToggle={(e, {isOpen}) =>
-              console.log('Toggle fired', e.type, isOpen)
-            }
             iconClear={<IconClose />}
           />
         </div>

--- a/components/molecule/autosuggest/demo/index.js
+++ b/components/molecule/autosuggest/demo/index.js
@@ -73,6 +73,9 @@ const Demo = () => {
             onChange={(_, {value}) => console.log(value)}
             onEnter={() => console.log('Enter pressed')}
             onClear={() => console.log('Clear pressed')}
+            onToggle={(e, {isOpen}) =>
+              console.log('Toggle fired', e.type, isOpen)
+            }
             iconClear={<IconClose />}
           />
         </div>

--- a/components/molecule/autosuggest/demo/services/index.js
+++ b/components/molecule/autosuggest/demo/services/index.js
@@ -24,5 +24,5 @@ const delayedFilterOptions = (options, query) =>
 
 export const getAsyncCountriesFromQuery = async ({query}) => {
   const options = countries.map(({name}) => name)
-  return !query ? [] : delayedFilterOptions(options, query)
+  return !query ? options : delayedFilterOptions(options, query)
 }

--- a/components/molecule/autosuggest/src/components/MultipleSelection/index.js
+++ b/components/molecule/autosuggest/src/components/MultipleSelection/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import {useRef} from 'react'
+import {useRef, Children} from 'react'
 import isEqual from 'lodash.isequal'
 
 import MoleculeDropdownList from '@s-ui/react-molecule-dropdown-list'
@@ -10,18 +10,18 @@ import {InputWithClearUI} from '../InputWithClearUI/index.js'
 
 const MoleculeAutosuggestFieldMultiSelection = ({
   allowDuplicates,
-  autoClose,
   autoFocus,
   autoComplete = 'nope',
   children,
   design,
   disabled = false,
+  hasIsOpen,
   iconClear,
   iconCloseTag = <span />,
   id,
   innerRefInput: refInput = {},
   inputMode,
-  isOpen,
+  isOpenState,
   onChange,
   onChangeTags,
   onClear,
@@ -64,21 +64,23 @@ const MoleculeAutosuggestFieldMultiSelection = ({
         value: '',
         tags: newTags
       })
-    autoClose && typeof onToggle === 'function' && onToggle(ev, {isOpen: false})
+    !hasIsOpen &&
+      typeof onToggle === 'function' &&
+      onToggle(ev, {isOpen: false})
     innerRefInput.current && innerRefInput.current.focus()
   }
 
   const handleChangeTags = (ev, {tags, value}) => {
     const isOpen = Boolean(value)
     typeof onChangeTags === 'function' && onChangeTags(ev, {tags})
-    autoClose && typeof onToggle === 'function' && onToggle(ev, {isOpen})
+    !hasIsOpen && typeof onToggle === 'function' && onToggle(ev, {isOpen})
     innerRefInput.current && innerRefInput.current.focus()
   }
 
   const handleChange = (ev, {value}) => {
     const isOpen = Boolean(value)
     typeof onChange === 'function' && onChange(ev, {value})
-    autoClose && typeof onToggle === 'function' && onToggle(ev, {isOpen})
+    !hasIsOpen && typeof onToggle === 'function' && onToggle(ev, {isOpen})
   }
 
   const handleClear = ev => {
@@ -100,7 +102,7 @@ const MoleculeAutosuggestFieldMultiSelection = ({
         id={id}
         innerRefInput={moleculeInputRef}
         inputMode={inputMode}
-        isOpen={isOpen}
+        isOpen={isOpenState}
         isVisibleClear={!disabled && tags.length}
         noBorder
         onChange={handleChange}
@@ -119,18 +121,20 @@ const MoleculeAutosuggestFieldMultiSelection = ({
       >
         <MoleculeInputTags />
       </InputWithClearUI>
-      <MoleculeDropdownList
-        checkbox
-        highlightQuery={value}
-        onSelect={handleMultiSelection}
-        onKeyDown={onKeyDown}
-        size={size}
-        value={tags}
-        visible={isOpen}
-        design={design}
-      >
-        {children}
-      </MoleculeDropdownList>
+      {isOpenState && (
+        <MoleculeDropdownList
+          checkbox
+          highlightQuery={value}
+          onSelect={handleMultiSelection}
+          onKeyDown={onKeyDown}
+          size={size}
+          value={tags}
+          visible={isOpenState && Children.count(children) > 0}
+          design={design}
+        >
+          {children}
+        </MoleculeDropdownList>
+      )}
     </>
   )
 }

--- a/components/molecule/autosuggest/src/components/MultipleSelection/index.js
+++ b/components/molecule/autosuggest/src/components/MultipleSelection/index.js
@@ -15,7 +15,6 @@ const MoleculeAutosuggestFieldMultiSelection = ({
   children,
   design,
   disabled = false,
-  hasIsOpen,
   iconClear,
   iconCloseTag = <span />,
   id,
@@ -64,23 +63,22 @@ const MoleculeAutosuggestFieldMultiSelection = ({
         value: '',
         tags: newTags
       })
-    !hasIsOpen &&
-      typeof onToggle === 'function' &&
-      onToggle(ev, {isOpen: false})
+
+    typeof onToggle === 'function' && onToggle(ev, {isOpen: false})
     innerRefInput.current && innerRefInput.current.focus()
   }
 
   const handleChangeTags = (ev, {tags, value}) => {
     const isOpen = Boolean(value)
     typeof onChangeTags === 'function' && onChangeTags(ev, {tags})
-    !hasIsOpen && typeof onToggle === 'function' && onToggle(ev, {isOpen})
+    typeof onToggle === 'function' && onToggle(ev, {isOpen})
     innerRefInput.current && innerRefInput.current.focus()
   }
 
   const handleChange = (ev, {value}) => {
     const isOpen = Boolean(value)
     typeof onChange === 'function' && onChange(ev, {value})
-    !hasIsOpen && typeof onToggle === 'function' && onToggle(ev, {isOpen})
+    typeof onToggle === 'function' && onToggle(ev, {isOpen})
   }
 
   const handleClear = ev => {

--- a/components/molecule/autosuggest/src/components/MultipleSelection/index.js
+++ b/components/molecule/autosuggest/src/components/MultipleSelection/index.js
@@ -20,7 +20,7 @@ const MoleculeAutosuggestFieldMultiSelection = ({
   id,
   innerRefInput: refInput = {},
   inputMode,
-  isOpenState,
+  isOpen,
   onChange,
   onChangeTags,
   onClear,
@@ -100,7 +100,7 @@ const MoleculeAutosuggestFieldMultiSelection = ({
         id={id}
         innerRefInput={moleculeInputRef}
         inputMode={inputMode}
-        isOpen={isOpenState}
+        isOpen={isOpen}
         isVisibleClear={!disabled && tags.length}
         noBorder
         onChange={handleChange}
@@ -119,7 +119,7 @@ const MoleculeAutosuggestFieldMultiSelection = ({
       >
         <MoleculeInputTags />
       </InputWithClearUI>
-      {isOpenState && (
+      {isOpen && (
         <MoleculeDropdownList
           checkbox
           highlightQuery={value}
@@ -127,7 +127,7 @@ const MoleculeAutosuggestFieldMultiSelection = ({
           onKeyDown={onKeyDown}
           size={size}
           value={tags}
-          visible={isOpenState && Children.count(children) > 0}
+          visible={isOpen && Children.count(children) > 0}
           design={design}
         >
           {children}

--- a/components/molecule/autosuggest/src/components/SingleSelection/index.js
+++ b/components/molecule/autosuggest/src/components/SingleSelection/index.js
@@ -13,7 +13,6 @@ const MoleculeAutosuggestSingleSelection = ({
   children,
   design,
   disabled,
-  hasIsOpen,
   iconClear,
   id,
   innerRefInput: refInput = {},
@@ -42,14 +41,12 @@ const MoleculeAutosuggestSingleSelection = ({
   const handleSelection = (ev, {value}) => {
     typeof onChange === 'function' && onChange(ev, {value})
     typeof onSelect === 'function' && onSelect(ev, {value})
-    !hasIsOpen &&
-      typeof onToggle === 'function' &&
-      onToggle(ev, {isOpen: false})
+    typeof onToggle === 'function' && onToggle(ev, {isOpen: false})
   }
 
   const handleChange = (ev, {value}) => {
     typeof onChange === 'function' && onChange(ev, {value})
-    !hasIsOpen && typeof onToggle === 'function' && onToggle(ev, {isOpen: true})
+    typeof onToggle === 'function' && onToggle(ev, {isOpen: true})
   }
 
   const handleClear = ev => {

--- a/components/molecule/autosuggest/src/components/SingleSelection/index.js
+++ b/components/molecule/autosuggest/src/components/SingleSelection/index.js
@@ -7,18 +7,18 @@ import AtomInput from '@s-ui/react-atom-input'
 import {InputWithClearUI} from '../InputWithClearUI/index.js'
 
 const MoleculeAutosuggestSingleSelection = ({
-  autoClose,
   autoFocus,
   ariaLabel,
   autoComplete = 'nope',
   children,
   design,
   disabled,
+  hasIsOpen,
   iconClear,
   id,
   innerRefInput: refInput = {},
   inputMode,
-  isOpen,
+  isOpenState,
   leftIcon,
   maxLength,
   minLength,
@@ -42,12 +42,14 @@ const MoleculeAutosuggestSingleSelection = ({
   const handleSelection = (ev, {value}) => {
     typeof onChange === 'function' && onChange(ev, {value})
     typeof onSelect === 'function' && onSelect(ev, {value})
-    autoClose && typeof onToggle === 'function' && onToggle(ev, {isOpen: false})
+    !hasIsOpen &&
+      typeof onToggle === 'function' &&
+      onToggle(ev, {isOpen: false})
   }
 
   const handleChange = (ev, {value}) => {
     typeof onChange === 'function' && onChange(ev, {value})
-    autoClose && typeof onToggle === 'function' && onToggle(ev, {isOpen: true})
+    !hasIsOpen && typeof onToggle === 'function' && onToggle(ev, {isOpen: true})
   }
 
   const handleClear = ev => {
@@ -91,11 +93,11 @@ const MoleculeAutosuggestSingleSelection = ({
       >
         <AtomInput />
       </InputWithClearUI>
-      {value && (
+      {(value || isOpenState) && (
         <MoleculeDropdownList
           size={size}
-          visible={isOpen && Children.count(children) > 0}
           onSelect={handleSelection}
+          visible={isOpenState && Children.count(children) > 0}
           value={value}
           highlightQuery={value}
           onKeyDown={onKeyDown}

--- a/components/molecule/autosuggest/src/components/SingleSelection/index.js
+++ b/components/molecule/autosuggest/src/components/SingleSelection/index.js
@@ -17,7 +17,7 @@ const MoleculeAutosuggestSingleSelection = ({
   id,
   innerRefInput: refInput = {},
   inputMode,
-  isOpenState,
+  isOpen,
   leftIcon,
   maxLength,
   minLength,
@@ -90,11 +90,11 @@ const MoleculeAutosuggestSingleSelection = ({
       >
         <AtomInput />
       </InputWithClearUI>
-      {(value || isOpenState) && (
+      {(value || isOpen) && (
         <MoleculeDropdownList
           size={size}
           onSelect={handleSelection}
-          visible={isOpenState && Children.count(children) > 0}
+          visible={isOpen && Children.count(children) > 0}
           value={value}
           highlightQuery={value}
           onKeyDown={onKeyDown}

--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -186,7 +186,7 @@ const MoleculeAutosuggest = ({
     errorState,
     id,
     innerRefInput: refMoleculeAutosuggestInput,
-    isOpenState,
+    isOpen: isOpenState,
     keysCloseList,
     keysSelection,
     onBlur,

--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -53,10 +53,13 @@ const MoleculeAutosuggest = ({
     refMoleculeAutosuggestFromProps
   )
 
-  const [isOpenState, setOpenState] = useState(isOpen)
+  const [isOpenState, setIsOpenState] = useState(!!isOpen)
+  const hasIsOpen = isOpen !== undefined
+
   useEffect(() => {
-    setOpenState(isOpen)
-  }, [isOpen, setOpenState])
+    if (!hasIsOpen) return
+    setIsOpenState(isOpen)
+  }, [isOpen, hasIsOpen, setIsOpenState])
 
   const refsMoleculeAutosuggestOptions = useRef([])
   const innerRefMoleculeAutosuggestInput = useRef()
@@ -67,9 +70,18 @@ const MoleculeAutosuggest = ({
 
   const [focus, setFocus] = useState(false)
 
-  const handleToggle = (event, {isOpen}) => {
-    setOpenState(isOpen === undefined ? !isOpenState : !!isOpen)
-    typeof onToggle === 'function' && onToggle(event, {isOpen})
+  const handleToggle = (ev, {isOpen: nextIsOpenState}) => {
+    const {type} = ev
+
+    if (type !== 'change' && autoClose) {
+      setIsOpenState(nextIsOpenState)
+    } else {
+      if (!isOpenState) {
+        setIsOpenState(nextIsOpenState)
+      }
+    }
+
+    typeof onToggle === 'function' && onToggle(ev, {isOpen: nextIsOpenState})
   }
 
   const extendedChildren = Children.toArray(children)
@@ -94,7 +106,7 @@ const MoleculeAutosuggest = ({
 
   const closeList = ev => {
     const {current: domMoleculeAutosuggest} = innerRefMoleculeAutosuggest
-    handleToggle(ev, {isOpen: false})
+    !hasIsOpen && handleToggle(ev, {isOpen: false})
     if (multiselection && typeof onChange === 'function') {
       onChange(ev, {value: ''})
     }
@@ -186,9 +198,10 @@ const MoleculeAutosuggest = ({
     children: extendedChildren,
     disabled,
     errorState,
+    hasIsOpen,
     id,
     innerRefInput: refMoleculeAutosuggestInput,
-    isOpen: isOpenState,
+    isOpenState,
     keysCloseList,
     keysSelection,
     onBlur,

--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -1,11 +1,4 @@
-import {
-  Children,
-  cloneElement,
-  createRef,
-  useEffect,
-  useRef,
-  useState
-} from 'react'
+import {Children, cloneElement, createRef, useRef, useState} from 'react'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import {moleculeDropdownListSizes as SIZES} from '@s-ui/react-molecule-dropdown-list'
@@ -13,6 +6,7 @@ import {getCurrentElementFocused} from '@s-ui/js/lib/dom'
 import {getTarget} from '@s-ui/js/lib/react'
 import useMergeRefs from '@s-ui/react-hooks/lib/useMergeRefs'
 import {inputTypes, inputShapes} from '@s-ui/react-atom-input'
+import useControlledState from '@s-ui/react-hooks/lib/useControlledState'
 
 import {
   AUTOSUGGEST_STATES,
@@ -53,13 +47,7 @@ const MoleculeAutosuggest = ({
     refMoleculeAutosuggestFromProps
   )
 
-  const [isOpenState, setIsOpenState] = useState(!!isOpen)
-  const hasIsOpen = isOpen !== undefined
-
-  useEffect(() => {
-    if (!hasIsOpen) return
-    setIsOpenState(isOpen)
-  }, [isOpen, hasIsOpen, setIsOpenState])
+  const [isOpenState, setIsOpenState] = useControlledState(isOpen, !!isOpen)
 
   const refsMoleculeAutosuggestOptions = useRef([])
   const innerRefMoleculeAutosuggestInput = useRef()
@@ -73,12 +61,10 @@ const MoleculeAutosuggest = ({
   const handleToggle = (ev, {isOpen: nextIsOpenState}) => {
     const {type} = ev
 
-    if (type !== 'change' && autoClose) {
-      setIsOpenState(nextIsOpenState)
-    } else {
-      if (!isOpenState) {
-        setIsOpenState(nextIsOpenState)
-      }
+    if (type !== 'change') {
+      setIsOpenState(nextIsOpenState, autoClose !== false)
+    } else if (!isOpenState) {
+      setIsOpenState(nextIsOpenState, nextIsOpenState && isOpen !== false)
     }
 
     typeof onToggle === 'function' && onToggle(ev, {isOpen: nextIsOpenState})
@@ -106,7 +92,7 @@ const MoleculeAutosuggest = ({
 
   const closeList = ev => {
     const {current: domMoleculeAutosuggest} = innerRefMoleculeAutosuggest
-    !hasIsOpen && handleToggle(ev, {isOpen: false})
+    handleToggle(ev, {isOpen: false})
     if (multiselection && typeof onChange === 'function') {
       onChange(ev, {value: ''})
     }
@@ -198,7 +184,6 @@ const MoleculeAutosuggest = ({
     children: extendedChildren,
     disabled,
     errorState,
-    hasIsOpen,
     id,
     innerRefInput: refMoleculeAutosuggestInput,
     isOpenState,


### PR DESCRIPTION
## Molecule/Autosuggest
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
`❓ Ask` 

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: #2079 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
isOpen became controlled when autoClose props is false forced
