### PR TITLE
Feat/popover autoplacement

### DIFF
--- a/components/molecule/selectPopover/demo/index.js
+++ b/components/molecule/selectPopover/demo/index.js
@@ -31,6 +31,7 @@ const Demo = () => {
   const [addCustomButton, setAddCustomButton] = useState(false)
   const [customContentWrapper, setCustomContentWrapper] = useState(false)
   const [renderSelect, setRenderSelect] = useState(false)
+  const [autoPlacement, setAutoPlacement] = useState(false)
 
   const handleChangeItem = event => {
     const {target} = event
@@ -102,7 +103,9 @@ const Demo = () => {
         <label>Placements</label>
         <MoleculeSelect
           value={placement}
-          onChange={(ev, {value}) => setPlacement(value)}
+          onChange={(ev, {value}) => {
+            setPlacement(value)
+          }}
           placeholder="Select a size..."
           iconArrowDown={<IconArrowDown />}
         >
@@ -186,9 +189,20 @@ const Demo = () => {
             Disabled
           </label>
         </div>
+        <div>
+          <label>
+            <input
+              type="checkbox"
+              checked={autoPlacement}
+              onChange={ev => setAutoPlacement(ev.target.checked)}
+            />
+            Auto placement
+          </label>
+        </div>
 
         <h3>Component</h3>
         <MoleculeSelectPopover
+          autoPlacement={autoPlacement}
           acceptButtonText="Aceptar"
           cancelButtonText="Cancelar"
           customButtonText={addCustomButton && 'Borrar'}

--- a/components/molecule/selectPopover/demo/index.js
+++ b/components/molecule/selectPopover/demo/index.js
@@ -31,7 +31,6 @@ const Demo = () => {
   const [addCustomButton, setAddCustomButton] = useState(false)
   const [customContentWrapper, setCustomContentWrapper] = useState(false)
   const [renderSelect, setRenderSelect] = useState(false)
-  const [autoPlacement, setAutoPlacement] = useState(false)
 
   const handleChangeItem = event => {
     const {target} = event
@@ -189,20 +188,9 @@ const Demo = () => {
             Disabled
           </label>
         </div>
-        <div>
-          <label>
-            <input
-              type="checkbox"
-              checked={autoPlacement}
-              onChange={ev => setAutoPlacement(ev.target.checked)}
-            />
-            Auto placement
-          </label>
-        </div>
 
         <h3>Component</h3>
         <MoleculeSelectPopover
-          autoPlacement={autoPlacement}
           acceptButtonText="Aceptar"
           cancelButtonText="Cancelar"
           customButtonText={addCustomButton && 'Borrar'}

--- a/components/molecule/selectPopover/src/config.js
+++ b/components/molecule/selectPopover/src/config.js
@@ -7,6 +7,20 @@ export const SIZES = {
 }
 
 export const PLACEMENTS = {
+  AUTO_END: 'auto-end',
+  AUTO_START: 'auto-start',
   LEFT: 'left',
   RIGHT: 'right'
+}
+
+const placements = {
+  [PLACEMENTS.AUTO_START]: PLACEMENTS.LEFT,
+  [PLACEMENTS.AUTO_END]: PLACEMENTS.RIGHT,
+  [PLACEMENTS.LEFT]: PLACEMENTS.LEFT,
+  [PLACEMENTS.RIGHT]: PLACEMENTS.RIGHT,
+  [undefined]: PLACEMENTS.RIGHT
+}
+
+export const getPlacement = placement => {
+  return placements[placement]
 }

--- a/components/molecule/selectPopover/src/index.js
+++ b/components/molecule/selectPopover/src/index.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 
 import Button, {atomButtonDesigns} from '@s-ui/react-atom-button'
 
-import {SIZES, PLACEMENTS, BASE_CLASS} from './config.js'
+import {BASE_CLASS, getPlacement, PLACEMENTS, SIZES} from './config.js'
 
 function usePrevious(value) {
   const ref = useRef()
@@ -19,7 +19,6 @@ const popoverBaseClass = `${BASE_CLASS}-popover`
 function MoleculeSelectPopover({
   acceptButtonText,
   acceptButtonOptions,
-  autoPlacement = false,
   cancelButtonText,
   cancelButtonOptions,
   customButtonText,
@@ -36,7 +35,7 @@ function MoleculeSelectPopover({
   onClose = () => {},
   onCustomAction = () => {},
   onOpen = () => {},
-  placement = PLACEMENTS.RIGHT,
+  placement,
   renderContentWrapper: renderContentWrapperProp,
   renderSelect: renderSelectProp,
   selectText,
@@ -45,7 +44,7 @@ function MoleculeSelectPopover({
 }) {
   const [isOpen, setIsOpen] = useState(false)
   const [popoverClassName, setPopoverClassName] = useState(
-    cx(`${popoverBaseClass}`, `${popoverBaseClass}--${placement}`)
+    cx(`${popoverBaseClass}`, `${popoverBaseClass}--${getPlacement(placement)}`)
   )
 
   const previousIsOpen = usePrevious(isOpen)
@@ -62,7 +61,10 @@ function MoleculeSelectPopover({
       return
     }
 
-    if (isOpen && autoPlacement) {
+    if (
+      isOpen &&
+      [PLACEMENTS.AUTO_END, PLACEMENTS.AUTO_START].includes(placement)
+    ) {
       setPopoverClassName(getPopoverClassName())
     }
 
@@ -72,7 +74,10 @@ function MoleculeSelectPopover({
 
   useEffect(() => {
     setPopoverClassName(
-      cx(`${popoverBaseClass}`, `${popoverBaseClass}--${placement}`)
+      cx(
+        `${popoverBaseClass}`,
+        `${popoverBaseClass}--${getPlacement(placement)}`
+      )
     )
   }, [placement])
 
@@ -266,7 +271,6 @@ MoleculeSelectPopover.propTypes = {
     design: PropTypes.string,
     negative: PropTypes.bool
   }),
-  autoPlacement: PropTypes.bool,
   cancelButtonText: PropTypes.string,
   cancelButtonOptions: PropTypes.shape({
     design: PropTypes.string,
@@ -289,7 +293,12 @@ MoleculeSelectPopover.propTypes = {
   onClose: PropTypes.func,
   onCustomAction: PropTypes.func,
   onOpen: PropTypes.func,
-  placement: PropTypes.string,
+  placement: PropTypes.oneOf([
+    PLACEMENTS.AUTO_END,
+    PLACEMENTS.AUTO_START,
+    PLACEMENTS.LEFT,
+    PLACEMENTS.RIGHT
+  ]),
   renderContentWrapper: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   renderSelect: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   selectText: PropTypes.string.isRequired,

--- a/components/molecule/selectPopover/test/index.test.js
+++ b/components/molecule/selectPopover/test/index.test.js
@@ -154,13 +154,15 @@ describe(json.name, () => {
       // Given
       const library = pkg
       const expected = {
+        AUTO_START: 'auto-start',
+        AUTO_END: 'auto-end',
         LEFT: 'left',
         RIGHT: 'right'
       }
 
       // When
       const {selectPopoverPlacements: actual} = library
-      const {LEFT, RIGHT, ...others} = actual
+      const {LEFT, RIGHT, AUTO_START, AUTO_END, ...others} = actual
 
       // Then
       expect(Object.keys(others).length).to.equal(0)


### PR DESCRIPTION
## molecule/selectPopover
❓ Ask

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [X] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
<!--- Describe your changes in detail -->

When the popover is set up with placement to `selectPopoverPlacements.AUTO_START` or `selectPopoverPlacements.AUTO_END` it will be automatically placed into the viewport if is detected out of it when is opened.


