### PR TITLE
fix(components/molecule/drawer): fix broken class for drawer overlay

### DIFF
--- a/components/molecule/drawer/src/Overlay.js
+++ b/components/molecule/drawer/src/Overlay.js
@@ -1,6 +1,10 @@
 import PropTypes from 'prop-types'
 import {useEffect, forwardRef} from 'react'
 
+import {BASE_CLASS} from './settings'
+
+const DRAWER_OVERLAY_CLASS = `${BASE_CLASS}-overlay`
+
 const DrawerOverlay = forwardRef(
   ({isVisible, target, children, ...props}, forwardedRef) => {
     useEffect(() => {
@@ -9,12 +13,9 @@ const DrawerOverlay = forwardRef(
         target.current.style.overflow = 'hidden'
       }
     }, [target])
+
     return isVisible ? (
-      <div
-        ref={forwardedRef}
-        className="react-MoleculeDrawer-overlay"
-        {...props}
-      >
+      <div ref={forwardedRef} className={DRAWER_OVERLAY_CLASS} {...props}>
         {children}
       </div>
     ) : null

--- a/components/molecule/drawer/src/index.js
+++ b/components/molecule/drawer/src/index.js
@@ -5,12 +5,15 @@ import PropTypes from 'prop-types'
 import useEventListener from '@s-ui/react-hooks/lib/useEventListener'
 
 import {
+  BASE_CLASS,
   PLACEMENTS as moleculeDrawerPlacements,
   SIZES as moleculeDrawerSizes,
   ANIMATION_DURATION as moleculeDrawerAnimationDuration
 } from './settings.js'
 
 import MoleculeDrawerOverlay from './Overlay.js'
+
+const DRAWER_CONTENT_CLASS = `${BASE_CLASS}-content`
 
 const MoleculeDrawer = forwardRef(
   (
@@ -52,13 +55,13 @@ const MoleculeDrawer = forwardRef(
     return (
       <div
         className={cx(
-          'sui-MoleculeDrawer-content',
-          `sui-MoleculeDrawer-content--placement-${placement}`,
-          `sui-MoleculeDrawer-content--size-${size}`,
-          `sui-MoleculeDrawer-content--animationDuration-${animationDuration}`,
-          `sui-MoleculeDrawer-content--state-${isOpen ? 'opened' : 'closed'}`,
+          DRAWER_CONTENT_CLASS,
+          `${DRAWER_CONTENT_CLASS}--placement-${placement}`,
+          `${DRAWER_CONTENT_CLASS}--size-${size}`,
+          `${DRAWER_CONTENT_CLASS}--animationDuration-${animationDuration}`,
+          `${DRAWER_CONTENT_CLASS}--state-${isOpen ? 'opened' : 'closed'}`,
           {
-            'sui-MoleculeDrawer-content--placement':
+            [`${DRAWER_CONTENT_CLASS}--placement`]:
               typeof target === 'undefined'
           }
         )}

--- a/components/molecule/drawer/src/settings.js
+++ b/components/molecule/drawer/src/settings.js
@@ -1,3 +1,5 @@
+export const BASE_CLASS = 'sui-MoleculeDrawer'
+
 export const PLACEMENTS = {
   TOP: 'top',
   RIGHT: 'right',


### PR DESCRIPTION
## molecule/drawer
🔍 Show

### Types of changes

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
The Drawer overlay component was not rendering correctly due to a mismatching CSS class name.
The solution was to abstract the base class name into a shared setting and apply it where required.
