### PR TITLE
feat/add-children-prop-to-breadcrumb

### DIFF
--- a/components/molecule/breadcrumb/package.json
+++ b/components/molecule/breadcrumb/package.json
@@ -19,6 +19,7 @@
   "license": "ISC",
   "dependencies": {
     "@s-ui/component-dependencies": "1",
+    "@s-ui/react-hooks": "1",
     "@s-ui/react-icons": "1"
   }
 }

--- a/components/molecule/breadcrumb/src/index.js
+++ b/components/molecule/breadcrumb/src/index.js
@@ -3,13 +3,14 @@ import {useState} from 'react'
 import PropTypes from 'prop-types'
 import Chevronright from '@s-ui/react-icons/lib/Chevronright'
 
-import {breadcrumbClassName} from './settings.js'
+import {breadcrumbClassName, BASE_CLASS} from './settings.js'
 
 const BreadcrumbBasic = ({
   items,
   icon,
   linkFactory: Link,
-  isScrollable = false
+  isScrollable = false,
+  children
 }) => {
   const [isExpanded, setIsExpanded] = useState(false)
   const expandBreadcrumb = () => setIsExpanded(true)
@@ -20,17 +21,18 @@ const BreadcrumbBasic = ({
   return (
     <nav aria-label="breadcrumb" role="navigation">
       <div className={breadcrumbClassName({isExpanded, isScrollable})}>
-        <button onClick={expandBreadcrumb} className="sui-BreadcrumbBasic-btn">
+        {children && <div className={`${BASE_CLASS}-children`}>{children}</div>}
+        <button onClick={expandBreadcrumb} className={`${BASE_CLASS}-btn`}>
           ...
         </button>
-        <ul className="sui-BreadcrumbBasic-list">
+        <ul className={`${BASE_CLASS}-list`}>
           {items.map(({url, label}, index) => (
-            <li className="sui-BreadcrumbBasic-listItem" key={index}>
+            <li className={`${BASE_CLASS}-listItem`} key={index}>
               {index !== 0 && index <= numItems && (
-                <IconAngle svgClass="sui-BreadcrumbBasic-icon" />
+                <IconAngle svgClass={`${BASE_CLASS}-icon`} />
               )}
               {url ? (
-                <Link to={url} href={url} className="sui-BreadcrumbBasic-link">
+                <Link to={url} href={url} className={`${BASE_CLASS}-link`}>
                   {label}
                 </Link>
               ) : (
@@ -73,7 +75,11 @@ BreadcrumbBasic.propTypes = {
   /**
    * Boolean that allows us to show the items with a horizontal scroll
    */
-  isScrollable: PropTypes.bool
+  isScrollable: PropTypes.bool,
+  /**
+   * Children to render before breadcrumb
+   */
+  children: PropTypes.node
 }
 
 BreadcrumbBasic.defaultProps = {

--- a/components/molecule/breadcrumb/src/index.js
+++ b/components/molecule/breadcrumb/src/index.js
@@ -10,7 +10,7 @@ const BreadcrumbBasic = ({
   icon,
   linkFactory: Link,
   isScrollable = false,
-  children
+  leftAddon
 }) => {
   const [isExpanded, setIsExpanded] = useState(false)
   const expandBreadcrumb = () => setIsExpanded(true)
@@ -21,7 +21,9 @@ const BreadcrumbBasic = ({
   return (
     <nav aria-label="breadcrumb" role="navigation">
       <div className={breadcrumbClassName({isExpanded, isScrollable})}>
-        {children && <div className={`${BASE_CLASS}-children`}>{children}</div>}
+        {leftAddon && (
+          <div className={`${BASE_CLASS}-leftAddon`}>{leftAddon}</div>
+        )}
         <button onClick={expandBreadcrumb} className={`${BASE_CLASS}-btn`}>
           ...
         </button>
@@ -77,9 +79,9 @@ BreadcrumbBasic.propTypes = {
    */
   isScrollable: PropTypes.bool,
   /**
-   * Children to render before breadcrumb
+   * Element to render at the left
    */
-  children: PropTypes.node
+  leftAddon: PropTypes.node
 }
 
 BreadcrumbBasic.defaultProps = {

--- a/components/molecule/breadcrumb/src/index.js
+++ b/components/molecule/breadcrumb/src/index.js
@@ -39,7 +39,12 @@ const BreadcrumbBasic = ({
 
   return (
     <nav aria-label="breadcrumb" role="navigation">
-      <div className={breadcrumbClassName({isExpanded, isScrollable})}>
+      <div
+        className={breadcrumbClassName({
+          isExpanded: isExpandedState,
+          isScrollable
+        })}
+      >
         <button onClick={handleClick} className={`${BASE_CLASS}-btn`}>
           ...
         </button>
@@ -94,10 +99,6 @@ BreadcrumbBasic.propTypes = {
    * Boolean that allows us to show the items with a horizontal scroll
    */
   isScrollable: PropTypes.bool,
-  /**
-   * Element to render at the left
-   */
-  leftAddon: PropTypes.node,
   /**
    * The controlled value of the expanded l&f of the component
    */

--- a/components/molecule/breadcrumb/src/index.js
+++ b/components/molecule/breadcrumb/src/index.js
@@ -1,30 +1,46 @@
-/* eslint-disable react/prop-types */
-import {useState} from 'react'
 import PropTypes from 'prop-types'
-import Chevronright from '@s-ui/react-icons/lib/Chevronright'
 
-import {breadcrumbClassName, BASE_CLASS} from './settings.js'
+import useControlledState from '@s-ui/react-hooks/lib/useControlledState/index.js'
+import ChevronRight from '@s-ui/react-icons/lib/Chevronright'
+
+import {breadcrumbClassName, BASE_CLASS, isFunction} from './settings.js'
 
 const BreadcrumbBasic = ({
   items,
   icon,
-  linkFactory: Link,
+  linkFactory: Link = ({to, href, className, children}) => (
+    <a href={to || href} className={className}>
+      {children}
+    </a>
+  ),
   isScrollable = false,
-  leftAddon
+  isExpanded,
+  defaultIsExpanded = false,
+  onExpand,
+  onCollapse,
+  onClick
 }) => {
-  const [isExpanded, setIsExpanded] = useState(false)
-  const expandBreadcrumb = () => setIsExpanded(true)
+  const [isExpandedState, setIsExpandedState] = useControlledState(
+    isExpanded,
+    defaultIsExpanded
+  )
+  const handleClick = event => {
+    setIsExpandedState(!isExpandedState)
+    isFunction(onClick) && onClick(event, {value: !isExpandedState})
+    if (isExpandedState) {
+      isFunction(onCollapse) && onCollapse(event, {value: false})
+    } else {
+      isFunction(onExpand) && onExpand(event, {value: true})
+    }
+  }
 
-  const IconAngle = icon || Chevronright
+  const IconAngle = icon || ChevronRight
   const numItems = items.length - 1
 
   return (
     <nav aria-label="breadcrumb" role="navigation">
       <div className={breadcrumbClassName({isExpanded, isScrollable})}>
-        {leftAddon && (
-          <div className={`${BASE_CLASS}-leftAddon`}>{leftAddon}</div>
-        )}
-        <button onClick={expandBreadcrumb} className={`${BASE_CLASS}-btn`}>
+        <button onClick={handleClick} className={`${BASE_CLASS}-btn`}>
           ...
         </button>
         <ul className={`${BASE_CLASS}-list`}>
@@ -81,15 +97,21 @@ BreadcrumbBasic.propTypes = {
   /**
    * Element to render at the left
    */
-  leftAddon: PropTypes.node
-}
-
-BreadcrumbBasic.defaultProps = {
-  linkFactory: ({to, href, className, children}) => (
-    <a href={to || href} className={className}>
-      {children}
-    </a>
-  )
+  leftAddon: PropTypes.node,
+  /**
+   * The controlled value of the expanded l&f of the component
+   */
+  isExpanded: PropTypes.bool,
+  /**
+   * The initial value of the expanded l&f of the component
+   */
+  defaultIsExpanded: PropTypes.bool,
+  /** expand handler **/
+  onExpand: PropTypes.func,
+  /** collapse handler **/
+  onCollapse: PropTypes.func,
+  /** click handler (expand or collapse) **/
+  onClick: PropTypes.func
 }
 
 export default BreadcrumbBasic

--- a/components/molecule/breadcrumb/src/settings.js
+++ b/components/molecule/breadcrumb/src/settings.js
@@ -7,3 +7,5 @@ export const breadcrumbClassName = ({isExpanded, isScrollable}) =>
     'is-expanded': isExpanded,
     'is-scrollable': isScrollable
   })
+
+export const isFunction = fn => typeof fn === 'function'

--- a/components/molecule/breadcrumb/src/settings.js
+++ b/components/molecule/breadcrumb/src/settings.js
@@ -1,6 +1,6 @@
 import cx from 'classnames'
 
-const BASE_CLASS = 'sui-BreadcrumbBasic'
+export const BASE_CLASS = 'sui-BreadcrumbBasic'
 
 export const breadcrumbClassName = ({isExpanded, isScrollable}) =>
   cx(BASE_CLASS, {

--- a/components/molecule/breadcrumb/src/styles/index.scss
+++ b/components/molecule/breadcrumb/src/styles/index.scss
@@ -10,6 +10,16 @@ $base-class: '.sui-BreadcrumbBasic';
   display: flex;
   padding: $p-breadcrumb-mobile;
 
+  &-children {
+    display: none;
+    @include media-breakpoint-up(m) {
+      display: block;
+    }
+    .is-expanded & {
+      display: block;
+    }
+  }
+
   &-btn {
     @include reset-button;
     @include media-breakpoint-up(m) {

--- a/components/molecule/breadcrumb/src/styles/index.scss
+++ b/components/molecule/breadcrumb/src/styles/index.scss
@@ -10,7 +10,7 @@ $base-class: '.sui-BreadcrumbBasic';
   display: flex;
   padding: $p-breadcrumb-mobile;
 
-  &-children {
+  &-leftAddon {
     display: none;
     @include media-breakpoint-up(m) {
       display: block;

--- a/components/molecule/breadcrumb/src/styles/index.scss
+++ b/components/molecule/breadcrumb/src/styles/index.scss
@@ -10,16 +10,6 @@ $base-class: '.sui-BreadcrumbBasic';
   display: flex;
   padding: $p-breadcrumb-mobile;
 
-  &-leftAddon {
-    display: none;
-    @include media-breakpoint-up(m) {
-      display: block;
-    }
-    .is-expanded & {
-      display: block;
-    }
-  }
-
   &-btn {
     @include reset-button;
     @include media-breakpoint-up(m) {


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
 #### `🔍 Show` 
<!-- #### `❓ Ask` -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
Add children prop because we need it to pass a component

### Screenshots - Animations
![image](https://user-images.githubusercontent.com/80967888/169492763-a4f463a2-3a8d-4b75-8973-e9e08ae49211.png)
