### PR TITLE
feat(components/atom/tag): add border style and width in types token

### DIFF
--- a/components/atom/tag/demo/index.scss
+++ b/components/atom/tag/demo/index.scss
@@ -1,9 +1,9 @@
 @import '~@s-ui/react-atom-icon/lib/index';
 
-@import '../src/index';
-
 $atom-tag-types: (
   'alert': (
+    bds: double,
+    bdw: 4px,
     bgc: red,
     c: white,
     bgc-hover: color-variation(red, 2),
@@ -28,3 +28,5 @@ $atom-tag-types: (
     c-hover: white
   )
 );
+
+@import '../src/index';

--- a/components/atom/tag/src/styles/index.scss
+++ b/components/atom/tag/src/styles/index.scss
@@ -181,10 +181,14 @@ $base-class: '.sui-AtomTag';
     $bgc-hover: map-get($type, bgc-hover);
     $c-hover: map-get($type, c-hover);
     $bdc: map-get($type, bdc);
+    $bds: map-get($type, bds);
+    $bdw: map-get($type, bdw);
     $bdc-hover: map-get($type, bdc-hover);
 
     &--#{$name} {
       background-color: $bgc;
+      border-style: $bds;
+      border-width: $bdw;
       color: $c;
       fill: $c;
       &#{$self}-actionable {


### PR DESCRIPTION
## Atom/Tag
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
<!-- #### `❓ Ask` -->
🔍 Show

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID --> None

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [x] 💄 Styles

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
We need style types with custom border

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
<img width="797" alt="image" src="https://user-images.githubusercontent.com/11008947/169507864-76edb9b7-13ee-4090-96d4-f4ef036e944f.png">

