### PR TITLE
feat(components/molecule/photoUploader): optional divider

### DIFF
--- a/components/molecule/photoUploader/src/InitialState/index.js
+++ b/components/molecule/photoUploader/src/InitialState/index.js
@@ -1,5 +1,5 @@
+import cx from 'classname'
 import PropTypes from 'prop-types'
-
 import Button, {atomButtonShapes} from '@s-ui/react-atom-button'
 import AtomIcon, {ATOM_ICON_SIZES} from '@s-ui/react-atom-icon'
 
@@ -32,8 +32,15 @@ const InitialState = ({
         <AtomIcon size={ATOM_ICON_SIZES.extraLarge}>{icon}</AtomIcon>
       </div>
       <div className={TEXT_STATE_CLASS_NAME}>
-        <span className={TEXT_STATE_TEXT_CLASS_NAME}>{text}</span>
-        <span className={TEXT_STATE_DIVIDER_CLASS_NAME}>{dividerText}</span>
+        <span
+          className={cx(TEXT_STATE_TEXT_CLASS_NAME, {isSpaced: !dividerText})}
+        >
+          {text}
+        </span>
+
+        {dividerText ? (
+          <span className={TEXT_STATE_DIVIDER_CLASS_NAME}>{dividerText}</span>
+        ) : null}
       </div>
       <div className={BUTTON_STATE_CLASS_NAME}>
         <Button

--- a/components/molecule/photoUploader/src/InitialState/index.js
+++ b/components/molecule/photoUploader/src/InitialState/index.js
@@ -1,4 +1,4 @@
-import cx from 'classname'
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import Button, {atomButtonShapes} from '@s-ui/react-atom-button'
 import AtomIcon, {ATOM_ICON_SIZES} from '@s-ui/react-atom-icon'

--- a/components/molecule/photoUploader/src/styles/index.scss
+++ b/components/molecule/photoUploader/src/styles/index.scss
@@ -55,6 +55,10 @@ $skeleton-class: '#{$base-class}-skeleton';
 
     &Text {
       margin-top: $m-m;
+
+      &.isSpaced {
+        margin-bottom: $m-m;
+      }
     }
     &Divider {
       margin: $m-m 0;


### PR DESCRIPTION
## molecule/photoUploader

This PR makes `divider` optional

### Types of changes

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
A layout given by the design team without divider

![Screenshot 2022-05-23 at 09 31 55](https://user-images.githubusercontent.com/6877967/169767013-9e31d6a1-7ad1-4e98-9c86-36856cca12d8.png)
