### PR TITLE
feat(components/molecule/accordion): render children with React Child…

### DIFF
--- a/components/molecule/accordion/src/index.js
+++ b/components/molecule/accordion/src/index.js
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react'
+import {useEffect, useState, Children} from 'react'
 import PropTypes from 'prop-types'
 
 import Tab from './Tab/index.js'
@@ -45,7 +45,7 @@ const MoleculeAccordion = ({
 
   return (
     <div className={BASE_CLASS} role="tablist">
-      {children.map((child, index) => (
+      {Children.map(children, (child, index) => (
         <Tab
           isOpen={openedTabsState.includes(index)}
           key={index}


### PR DESCRIPTION
## molecule/accordion
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
<!-- #### `❓ Ask` -->
`🔍 Show`

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: MMAA-28091

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
The old way is assuming the children are always an array, but we need to render a single child in our case. The changes implement the React `Children.map` fn that handles this behaviour.

