### PR TITLE
feat(components/atom/input): use polymorphic input

### DIFF
--- a/components/atom/input/package.json
+++ b/components/atom/input/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@s-ui/react-hooks": "1",
+    "@s-ui/react-primitive-polymorphic-element": "1",
     "imask": "3.4.0"
   },
   "peerDependencies": {

--- a/components/atom/input/src/Input/Component/index.js
+++ b/components/atom/input/src/Input/Component/index.js
@@ -111,7 +111,7 @@ const Input = forwardRef(
         required={required}
         pattern={pattern}
         inputMode={inputMode}
-        children={children}
+        children={as === 'input' ? undefined : children}
       />
     )
   }

--- a/components/atom/input/src/Input/Component/index.js
+++ b/components/atom/input/src/Input/Component/index.js
@@ -1,6 +1,7 @@
 import {forwardRef} from 'react'
 import PropTypes from 'prop-types'
 
+import PolymorphicElement from '@s-ui/react-primitive-polymorphic-element'
 import useMergeRefs from '@s-ui/react-hooks/lib/useMergeRefs'
 
 import {
@@ -14,6 +15,7 @@ import {
 const Input = forwardRef(
   (
     {
+      as = 'input',
       disabled,
       readOnly,
       hideInput,
@@ -47,7 +49,8 @@ const Input = forwardRef(
       required,
       pattern,
       inputMode,
-      shape
+      shape,
+      children
     },
     forwardedRef
   ) => {
@@ -79,7 +82,8 @@ const Input = forwardRef(
     })
 
     return (
-      <input
+      <PolymorphicElement
+        as={as}
         className={className}
         tabIndex={tabIndex}
         aria-label={ariaLabel}
@@ -107,12 +111,15 @@ const Input = forwardRef(
         required={required}
         pattern={pattern}
         inputMode={inputMode}
+        children={children}
       />
     )
   }
 )
 
 Input.propTypes = {
+  /* Render the passed value as the correspondent HTML tag or the component if a function is passed */
+  as: PropTypes.elementType,
   /* This Boolean attribute prevents the user from interacting with the input */
   disabled: PropTypes.bool,
   /* This Boolean attribute prevents the user from interacting with the input but without disabled styles */
@@ -180,7 +187,9 @@ Input.propTypes = {
   /** To select input keyboard mode on mobile. It can be 'numeric', 'decimal', 'email', etc */
   inputMode: PropTypes.string,
   /** Sets the shape of the input field. It can be 'rounded', 'square' or 'circle' */
-  shape: PropTypes.oneOf(Object.values(INPUT_SHAPES))
+  shape: PropTypes.oneOf(Object.values(INPUT_SHAPES)),
+  /** Nodes to be rendered inside the component */
+  children: PropTypes.node
 }
 
 export default Input

--- a/components/atom/input/src/Input/index.js
+++ b/components/atom/input/src/Input/index.js
@@ -37,7 +37,12 @@ const BaseInput = forwardRef(
             onClickLeftIcon={onClickLeftIcon}
             onClickRightIcon={onClickRightIcon}
           >
-            <Input ref={forwardedRef} {...inputProps} size={size} />
+            <Input
+              ref={forwardedRef}
+              children={children}
+              {...inputProps}
+              size={size}
+            />
           </InputIcons>
         </InputAddons>
       </InputButton>

--- a/components/atom/input/src/Input/index.js
+++ b/components/atom/input/src/Input/index.js
@@ -37,12 +37,9 @@ const BaseInput = forwardRef(
             onClickLeftIcon={onClickLeftIcon}
             onClickRightIcon={onClickRightIcon}
           >
-            <Input
-              ref={forwardedRef}
-              children={children}
-              {...inputProps}
-              size={size}
-            />
+            <Input ref={forwardedRef} {...inputProps} size={size}>
+              {children}
+            </Input>
           </InputIcons>
         </InputAddons>
       </InputButton>

--- a/components/atom/input/src/index.js
+++ b/components/atom/input/src/index.js
@@ -1,3 +1,4 @@
+import {forwardRef} from 'react'
 import PropTypes from 'prop-types'
 
 import Input, {inputSizes, inputStates} from './Input/index.js'
@@ -5,16 +6,16 @@ import Password from './Password/index.js'
 import Mask from './Mask/index.js'
 import {TYPES, INPUT_SHAPES} from './config.js'
 
-const AtomInput = ({type, ...props}) => {
+const AtomInput = forwardRef(({type, ...props}, ref) => {
   switch (type) {
     case 'sui-password':
-      return <Password {...props} />
+      return <Password ref={ref} {...props} />
     case 'mask':
-      return <Mask {...props} />
+      return <Mask ref={ref} {...props} />
     default:
-      return <Input {...props} type={type} />
+      return <Input ref={ref} {...props} type={type} />
   }
-}
+})
 
 AtomInput.propTypes = {
   /** native types (text, date, ...), 'sui-password' */


### PR DESCRIPTION
## atom/input

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
This PR makes input work wit `as` prop. The main reason is to use it as a `select`. The look and feel should be the same but it works as a native select. We are planning to release a `NativeSelect` component that uses the input (we will discuss this tomorrow cc @andresin87 @turolopezsanabria).

**How can it be used ?**

```
<Input as="select">
  <option value="1">1</option>
  <option value="2">2</option>
  <option value="3">3</option>
</Input>
```