### PR TITLE
Feature/atom spinner add negative prop

### DIFF
--- a/components/atom/spinner/demo/index.js
+++ b/components/atom/spinner/demo/index.js
@@ -46,6 +46,14 @@ const Demo = () => {
         </Paragraph>
         <AtomSpinner noBackground />
       </Article>
+      <br />
+      <Article className={CLASS_SECTION}>
+        <H2>Negative overlay spinner</H2>
+        <Paragraph>
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+        </Paragraph>
+        <AtomSpinner negative />
+      </Article>
     </div>
   )
 }

--- a/components/atom/spinner/src/index.js
+++ b/components/atom/spinner/src/index.js
@@ -11,16 +11,21 @@ import {
 } from './settings.js'
 
 const AtomSpinner = ({
-  delayed: delayedFromProps,
-  loader,
-  type,
-  noBackground
+  delayed: delayedFromProps = false,
+  loader = <SUILoader />,
+  negative = false,
+  noBackground = false,
+  type = TYPES.SECTION
 }) => {
   const [delayed, setDelayed] = useState(delayedFromProps)
   const refSpinner = useRef()
 
   useEffect(() => {
-    const parentClassName = getParentClassName({type, noBackground})
+    const parentClassName = getParentClassName({
+      negative,
+      noBackground,
+      type
+    })
     const parentNodeClassList = refSpinner.current.parentNode.classList
 
     if (!delayed) addParentClass(parentNodeClassList)(parentClassName)
@@ -52,17 +57,14 @@ AtomSpinner.propTypes = {
   /** Makes the spinner appear after 500 ms */
   delayed: PropTypes.bool,
 
+  /** Alternate overlay color */
+  negative: PropTypes.bool,
+
   /** No background */
   noBackground: PropTypes.bool,
 
   /** Loader to be shown in the middle of the container */
   loader: PropTypes.object
-}
-
-AtomSpinner.defaultProps = {
-  delayed: false,
-  type: TYPES.SECTION,
-  loader: <SUILoader />
 }
 
 export default AtomSpinner

--- a/components/atom/spinner/src/settings.js
+++ b/components/atom/spinner/src/settings.js
@@ -8,13 +8,15 @@ export const TYPES = {
 export const DELAY = 500 // ms
 export const BASE_CLASS = 'sui-AtomSpinner'
 export const CLASS_FULL = `${BASE_CLASS}--fullPage`
+export const CLASS_NEGATIVE = `${BASE_CLASS}--negative`
 export const CLASS_NO_BACKGROUND = `${BASE_CLASS}--noBackground`
 
-export const getParentClassName = ({type, noBackground}) =>
+export const getParentClassName = ({negative, noBackground, type}) =>
   cx({
     [BASE_CLASS]: type === TYPES.SECTION,
     [CLASS_FULL]: type === TYPES.FULL,
-    [CLASS_NO_BACKGROUND]: noBackground
+    [CLASS_NO_BACKGROUND]: noBackground,
+    [CLASS_NEGATIVE]: negative
   })
 
 export const addParentClass = parentNodeClassList => parentClassName =>

--- a/components/atom/spinner/src/styles/index.scss
+++ b/components/atom/spinner/src/styles/index.scss
@@ -8,6 +8,10 @@ $base-class: '.sui-AtomSpinner';
     position: absolute;
   }
 
+  &--negative::before {
+    background-color: $bgc-atom-spinner-negative;
+  }
+
   &--noBackground::before {
     background-color: transparent;
   }

--- a/components/atom/spinner/src/styles/settings.scss
+++ b/components/atom/spinner/src/styles/settings.scss
@@ -1,4 +1,5 @@
 $bgc-atom-spinner: rgba($c-white, 0.6) !default;
+$bgc-atom-spinner-negative: rgba($c-black, 0.6) !default;
 $z-atom-spinner: 1 !default;
 
 %spinner-layer {


### PR DESCRIPTION
## atom/spinner
#### `🔍 Show`

### Types of changes
Add a negative prop, to have an alternate overlay color.

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 💄 Styles

### Description, Motivation and Context
In motor we have the need to have an alternate overlay background color. We currently have a light one, but in some places a dark one fits better. By theme, currently we only can have one background color defined.
With this PR we can have two background colors defined.

### Screenshots 
Current: ![image](https://user-images.githubusercontent.com/37936498/170049502-8678e019-e757-49af-a84e-61d882a42025.png)
Negative: ![image](https://user-images.githubusercontent.com/37936498/170049449-7604d78b-0032-4681-95a2-222a8a2c8c4f.png)
