### PR TITLE
feat(components/atom/spinner): new version of atom spinner

### DIFF
--- a/components/atom/spinner/README.md
+++ b/components/atom/spinner/README.md
@@ -13,11 +13,88 @@ $ npm install @s-ui/react-atom-spinner --save
 ## Usage
 
 ### Basic usage
+
 ```js
-import AtomSpinner, {AtomSpinnerTypes} from '@s-ui/react-atom-spinner'
+import AtomSpinner from '@s-ui/react-atom-spinner'
+
+return (
+  <AtomSpinner />
+)
+```
+
+### Full Screen Spinner
+By default ```type``` prop has ```atomSpinnerTypes.SECTION``` value.
+
+```js
+import AtomSpinner, {atomSpinnerTypes} from '@s-ui/react-atom-spinner'
 
 return (
   <AtomSpinner type={AtomSpinnerTypes.FULL} />
+)
+```
+
+### Delayed Spinner
+You can delay when the Spinner is shown.
+
+```js
+import AtomSpinner from '@s-ui/react-atom-spinner'
+
+return (
+  <AtomSpinner isDelayed  />
+)
+```
+
+### Overlay Types
+Different overlay types can be selected. Each one modify the overlay background color and the colors of the loader. All of these can be customized in your theme.
+Options are: ```LIGHT``` (default), ```ACCENT```, ```DARK```, ```PRIMARY``` and ```TRANSPARENT```.
+
+```js
+import AtomSpinner, {atomSpinnerOverlayTypes} from '@s-ui/react-atom-spinner'
+
+return (
+  <AtomSpinner overlayType={atomSpinnerOverlayTypes.DARK} />
+)
+```
+
+### Custom Children
+Children of ```AtomSpinner``` are injected with the same props ```AtomSpinner``` is receiving and with the component's default ones.
+In the following example, CustomChildren can be a reusable component.
+```js
+import {atomSpinnerOverlayTypes. atomSpinnerTypes} from '@s-ui/react-atom-spinner'
+import cx from 'classnames'
+
+const CustomChildren = ({children, loader, overlayType, type}) => {
+  const className = cx('readme-custom-children', {
+    'readme-custom-children--dark':
+      overlayType === atomSpinnerOverlayTypes.DARK,
+    'readme-custom-children--fullPage': type === atomSpinnerTypes.FULL
+  })
+
+  return (
+    <>
+      {loader}
+      // the use of `loader` is not mandatory, and can be replaced
+      <div className={className}>{children}</div>
+    </>
+  )
+}
+```
+
+```js
+import AtomSpinner, {atomSpinnerOverlayTypes. atomSpinnerTypes} from '@s-ui/react-atom-spinner'
+import CustomChildren from './CustomChildren.js'
+
+return (
+  <>
+  <AtomSpinner>
+    <CustomChildren>With custom children</CustomChildren>
+  </AtomSpinner>
+  <AtomSpinner overlayType={atomSpinnerOverlayTypes.DARK} type={atomSpinnerTypes.FULL}>
+    <CustomChildren>
+      With custom children but receiving different props through AtomSpinner
+    </CustomChildren>
+  </AtomSpinner>
+  </>
 )
 ```
 

--- a/components/atom/spinner/demo/CustomChildren.js
+++ b/components/atom/spinner/demo/CustomChildren.js
@@ -1,0 +1,21 @@
+/* eslint-disable react/prop-types */
+import cx from 'classnames'
+
+import {atomSpinnerOverlayTypes, atomSpinnerTypes} from '../src/index.js'
+
+const CustomChildren = ({children, loader, overlayType, type}) => {
+  const textClassName = cx('demo-AtomSpinner-children', {
+    'demo-AtomSpinner-children--dark':
+      overlayType === atomSpinnerOverlayTypes.DARK,
+    'demo-AtomSpinner-children--fullPage': type === atomSpinnerTypes.FULL
+  })
+
+  return (
+    <>
+      <div className="demo-AtomSpinner-loaderContainer">{loader}</div>
+      <div className={textClassName}>{children}</div>
+    </>
+  )
+}
+
+export default CustomChildren

--- a/components/atom/spinner/demo/CustomLoader.js
+++ b/components/atom/spinner/demo/CustomLoader.js
@@ -1,0 +1,7 @@
+/* eslint-disable react/prop-types */
+
+const CustomLoader = ({children}) => {
+  return <div className={'demo-AtomSpinner-customLoader'}>{children}</div>
+}
+
+export default CustomLoader

--- a/components/atom/spinner/demo/FullScreenSpinner.js
+++ b/components/atom/spinner/demo/FullScreenSpinner.js
@@ -1,34 +1,29 @@
-import {Component} from 'react'
+/* eslint-disable react/prop-types */
+import {useState} from 'react'
 import {Button} from '@s-ui/documentation-library'
 
-import AtomSpinner, {AtomSpinnerTypes} from '../src/index.js'
+import AtomSpinner, {atomSpinnerTypes} from '../src/index.js'
 
-class FullScreenSpinner extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {show: false}
+const FullScreenSpinner = ({children, overlayType}) => {
+  const [show, setShow] = useState(false)
 
-    this.handleClick = this.handleClick.bind(this)
+  const handleOnClick = () => {
+    setShow(true)
+    setTimeout(() => setShow(false), 5000)
   }
-
-  handleClick(ev) {
-    this.setState({show: true})
-    setTimeout(() => this.setState({show: false}), 5000)
-  }
-
-  render() {
-    return (
-      <>
-        <Button onClick={this.handleClick}>
-          Click to show fullscreen spinner for 5 seconds
-        </Button>
-        {this.state.show && <AtomSpinner type={AtomSpinnerTypes.FULL} />}
-      </>
-    )
-  }
+  return (
+    <>
+      <Button onClick={handleOnClick}>
+        Click to show fullscreen spinner for 5 seconds
+      </Button>
+      {show && (
+        <AtomSpinner overlayType={overlayType} type={atomSpinnerTypes.FULL}>
+          {children}
+        </AtomSpinner>
+      )}
+    </>
+  )
 }
-
-FullScreenSpinner.proptypes = {}
 
 FullScreenSpinner.displayName = 'FullScreenSpinner'
 

--- a/components/atom/spinner/demo/SpinnerWrapper.js
+++ b/components/atom/spinner/demo/SpinnerWrapper.js
@@ -1,37 +1,26 @@
-import {Component} from 'react'
+import {useEffect, useState} from 'react'
 import {Paragraph} from '@s-ui/documentation-library'
 
 import AtomSpinner from '../src/index.js'
 import {dashStyle} from './settings.js'
 
-class SpinnerWrapper extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {contentLoaded: false}
-  }
+const SpinnerWrapper = () => {
+  const [contentLoaded, setContentLoaded] = useState(false)
 
-  componentDidMount() {
+  useEffect(() => {
     setTimeout(() => {
-      this.setState({contentLoaded: true})
+      setContentLoaded(true)
     }, 5000)
-  }
-
-  render() {
-    const {contentLoaded} = this.state
-    return contentLoaded ? (
-      <Paragraph style={dashStyle}>
-        Content loaded, spinner disappears
-      </Paragraph>
-    ) : (
-      <Paragraph style={dashStyle}>
-        Slowly loading content, delayed spinner will be shown
-        <AtomSpinner delayed />
-      </Paragraph>
-    )
-  }
+  }, [])
+  return contentLoaded ? (
+    <Paragraph style={dashStyle}>Content loaded, spinner disappears</Paragraph>
+  ) : (
+    <Paragraph style={dashStyle}>
+      Slowly loading content, delayed spinner will be shown
+      <AtomSpinner delayed />
+    </Paragraph>
+  )
 }
-
-SpinnerWrapper.propTypes = {}
 
 SpinnerWrapper.displayName = 'SpinnerWrapper'
 

--- a/components/atom/spinner/demo/SpinnerWrapper.js
+++ b/components/atom/spinner/demo/SpinnerWrapper.js
@@ -17,7 +17,7 @@ const SpinnerWrapper = () => {
   ) : (
     <Paragraph style={dashStyle}>
       Slowly loading content, delayed spinner will be shown
-      <AtomSpinner delayed />
+      <AtomSpinner isDelayed />
     </Paragraph>
   )
 }

--- a/components/atom/spinner/demo/index.js
+++ b/components/atom/spinner/demo/index.js
@@ -28,7 +28,7 @@ const Demo = () => {
         <Paragraph>
           Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
         </Paragraph>
-        <AtomSpinner delayed />
+        <AtomSpinner isDelayed />
       </Article>
       <br />
       <Article className={CLASS_SECTION}>

--- a/components/atom/spinner/demo/index.js
+++ b/components/atom/spinner/demo/index.js
@@ -1,6 +1,8 @@
 import {H1, H2, Paragraph, Article} from '@s-ui/documentation-library'
 
-import AtomSpinner from '../src/index.js'
+import AtomSpinner, {atomSpinnerOverlayTypes} from '../src/index.js'
+import CustomChildren from './CustomChildren.js'
+import CustomLoader from './CustomLoader.js'
 import FullScreenSpinner from './FullScreenSpinner.js'
 import SpinnerWrapper from './SpinnerWrapper.js'
 import {CLASS_SECTION} from './settings.js'
@@ -39,13 +41,157 @@ const Demo = () => {
         <FullScreenSpinner />
       </Article>
       <br />
-      <Article className={CLASS_SECTION} mode="dark">
-        <H2>Dark mode Spinner</H2>
+
+      <H2>Overlay types</H2>
+      <Paragraph>Different background overlay types.</Paragraph>
+      <Article className={CLASS_SECTION}>
+        <H2>Light overlay type, the default one</H2>
         <Paragraph>
           Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
         </Paragraph>
-        <AtomSpinner noBackground />
+        <AtomSpinner overlayType={atomSpinnerOverlayTypes.LIGHT} />
       </Article>
+      <br />
+      <Article className={CLASS_SECTION}>
+        <H2>Accent overlay type</H2>
+        <Paragraph>
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+        </Paragraph>
+        <AtomSpinner overlayType={atomSpinnerOverlayTypes.ACCENT} />
+      </Article>
+      <br />
+      <Article className={CLASS_SECTION}>
+        <H2>Dark overlay type</H2>
+        <Paragraph>
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+        </Paragraph>
+        <AtomSpinner overlayType={atomSpinnerOverlayTypes.DARK} />
+      </Article>
+      <br />
+      <Article className={CLASS_SECTION}>
+        <H2>Primary overlay type</H2>
+        <Paragraph>
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+        </Paragraph>
+        <AtomSpinner overlayType={atomSpinnerOverlayTypes.PRIMARY} />
+      </Article>
+      <br />
+      <Article className={CLASS_SECTION}>
+        <H2>Transparent overlay type</H2>
+        <Paragraph>
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+        </Paragraph>
+        <AtomSpinner overlayType={atomSpinnerOverlayTypes.TRANSPARENT} />
+      </Article>
+
+      <br />
+      <H2>Overlay types over a dark content</H2>
+      <Paragraph>Different background overlay types.</Paragraph>
+      <Article className={CLASS_SECTION} mode="dark">
+        <H2>Light overlay type, the default one</H2>
+        <Paragraph>
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+        </Paragraph>
+        <AtomSpinner overlayType={atomSpinnerOverlayTypes.LIGHT} />
+      </Article>
+      <br />
+      <Article className={CLASS_SECTION} mode="dark">
+        <H2>Accent overlay type</H2>
+        <Paragraph>
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+        </Paragraph>
+        <AtomSpinner overlayType={atomSpinnerOverlayTypes.ACCENT} />
+      </Article>
+      <br />
+      <Article className={CLASS_SECTION} mode="dark">
+        <H2>Dark overlay type</H2>
+        <Paragraph>
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+        </Paragraph>
+        <AtomSpinner overlayType={atomSpinnerOverlayTypes.DARK} />
+      </Article>
+      <br />
+      <Article className={CLASS_SECTION} mode="dark">
+        <H2>Primary overlay type</H2>
+        <Paragraph>
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+        </Paragraph>
+        <AtomSpinner overlayType={atomSpinnerOverlayTypes.PRIMARY} />
+      </Article>
+      <br />
+      <Article className={CLASS_SECTION} mode="dark">
+        <H2>Transparent overlay type</H2>
+        <Paragraph>
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+        </Paragraph>
+        <AtomSpinner overlayType={atomSpinnerOverlayTypes.TRANSPARENT} />
+      </Article>
+
+      <H2>With children</H2>
+      <Paragraph>
+        Children receives the same props from AtomSpinner, to fully customize
+        the component.
+      </Paragraph>
+      <Paragraph>
+        Take a look on the children text color. It changes depending of the
+        AtomSpinner overlayType prop value, because our custom component is also
+        receiving the overlayType prop.
+      </Paragraph>
+      <Article className={CLASS_SECTION}>
+        <H2>With custom text children</H2>
+        <Paragraph>
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+        </Paragraph>
+        <AtomSpinner>
+          <CustomChildren>With custom text children</CustomChildren>
+        </AtomSpinner>
+      </Article>
+      <br />
+      <Article className={CLASS_SECTION}>
+        <H2>With custom text children and dark overlay type</H2>
+        <Paragraph>
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+        </Paragraph>
+        <AtomSpinner overlayType={atomSpinnerOverlayTypes.DARK}>
+          <CustomChildren>
+            With custom text children and dark overlay type
+          </CustomChildren>
+        </AtomSpinner>
+      </Article>
+      <br />
+      <Article className={CLASS_SECTION} style={{height: '400px'}}>
+        <H2>With children</H2>
+        <Paragraph>
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+        </Paragraph>
+        <AtomSpinner>
+          <CustomChildren>
+            <img src="https://upload.wikimedia.org/wikipedia/en/d/df/BJ_Blazkowicz.png" />
+          </CustomChildren>
+        </AtomSpinner>
+      </Article>
+      <br />
+      <Article className={CLASS_SECTION} style={{height: '400px'}}>
+        <H2>With custom loader as children </H2>
+        <Paragraph>
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+        </Paragraph>
+        <AtomSpinner>
+          <CustomLoader>
+            <img src="https://upload.wikimedia.org/wikipedia/en/d/df/BJ_Blazkowicz.png" />
+          </CustomLoader>
+        </AtomSpinner>
+      </Article>
+      <br />
+      <Article className={CLASS_SECTION} mode="dark">
+        <H2>Full Screen Spinner with children and primary overlay</H2>
+        <FullScreenSpinner overlayType={atomSpinnerOverlayTypes.PRIMARY}>
+          <CustomChildren>
+            With custom text children and primary colored overlay
+          </CustomChildren>
+        </FullScreenSpinner>
+      </Article>
+      <br />
     </div>
   )
 }

--- a/components/atom/spinner/demo/index.js
+++ b/components/atom/spinner/demo/index.js
@@ -43,7 +43,10 @@ const Demo = () => {
       <br />
 
       <H2>Overlay types</H2>
-      <Paragraph>Different background overlay types.</Paragraph>
+      <Paragraph>
+        Different background overlay types. Also the colors of the loader are
+        modified.
+      </Paragraph>
       <Article className={CLASS_SECTION}>
         <H2>Light overlay type, the default one</H2>
         <Paragraph>

--- a/components/atom/spinner/demo/index.scss
+++ b/components/atom/spinner/demo/index.scss
@@ -6,6 +6,7 @@
     font-size: $fz-l;
     font-weight: $fw-bold;
     margin-top: $m-l;
+    text-align: center;
     z-index: 999;
 
     &--dark {

--- a/components/atom/spinner/demo/index.scss
+++ b/components/atom/spinner/demo/index.scss
@@ -1,0 +1,43 @@
+@import '../src/index.scss';
+
+.demo-AtomSpinner {
+  &-children {
+    color: $c-black;
+    font-size: $fz-l;
+    font-weight: $fw-bold;
+    margin-top: $m-l;
+    z-index: 999;
+
+    &--dark {
+      color: $c-white;
+    }
+
+    &--fullPage {
+      margin-top: $m-xxxl * 2;
+      position: fixed;
+    }
+  }
+
+  &-loaderContainer {
+    height: 32px;
+    width: 32px;
+    position: relative;
+  }
+
+  &-customLoader {
+    perspective: 500px;
+    z-index: 999;
+
+    & > * {
+      animation: rotateAnimation 2s linear infinite;
+      height: 188px;
+      width: 333px;
+    }
+
+    @keyframes rotateAnimation {
+      100% {
+        transform: rotateY(360deg);
+      }
+    }
+  }
+}

--- a/components/atom/spinner/package.json
+++ b/components/atom/spinner/package.json
@@ -9,7 +9,8 @@
     "build:styles": "cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1"
+    "@s-ui/component-dependencies": "1",
+    "@s-ui/react-primitive-injector": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/atom/spinner/src/DefaultSpinner.js
+++ b/components/atom/spinner/src/DefaultSpinner.js
@@ -1,0 +1,15 @@
+import PropTypes from 'prop-types'
+import {forwardRef} from 'react'
+
+const DefaultSpinner = forwardRef(({delayed, loader}, forwardedRef) => {
+  return <span ref={forwardedRef}>{!delayed ? loader : <noscript />}</span>
+})
+
+DefaultSpinner.propTypes = {
+  delayed: PropTypes.bool,
+  loader: PropTypes.object
+}
+
+DefaultSpinner.displayName = 'DefaultSpinner'
+
+export default DefaultSpinner

--- a/components/atom/spinner/src/DefaultSpinner.js
+++ b/components/atom/spinner/src/DefaultSpinner.js
@@ -1,12 +1,12 @@
 import PropTypes from 'prop-types'
 import {forwardRef} from 'react'
 
-const DefaultSpinner = forwardRef(({delayed, loader}, forwardedRef) => {
-  return <span ref={forwardedRef}>{!delayed ? loader : <noscript />}</span>
+const DefaultSpinner = forwardRef(({isDelayed, loader}, forwardedRef) => {
+  return <span ref={forwardedRef}>{!isDelayed ? loader : <noscript />}</span>
 })
 
 DefaultSpinner.propTypes = {
-  delayed: PropTypes.bool,
+  isDelayed: PropTypes.bool,
   loader: PropTypes.object
 }
 

--- a/components/atom/spinner/src/SUILoader/index.scss
+++ b/components/atom/spinner/src/SUILoader/index.scss
@@ -2,7 +2,6 @@
 
 #{$base-class} {
   &-loader {
-    animation: $anim-atom-spinner;
     border-radius: $bdrs-rounded;
     height: $sz-atom-spinner-oval;
     left: 0;
@@ -12,5 +11,18 @@
     top: calc(50% - #{$sz-atom-spinner});
     width: $sz-atom-spinner-oval;
     z-index: $z-atom-spinner-loader;
+  }
+}
+
+@each $name, $type in $atom-spinner-overlay-types {
+  $loaderColorOne: map-get($type, loaderColorOne);
+  $loaderColorTwo: map-get($type, loaderColorTwo);
+
+  @include animation-atom-spinner($name, $loaderColorOne, $loaderColorTwo);
+
+  .sui-AtomSpinner--#{$name} {
+    & .sui-AtomSpinner-loader {
+      animation: atom-spinner-#{$name} 1.5s ease-in-out infinite;
+    }
   }
 }

--- a/components/atom/spinner/src/SUILoader/index.scss
+++ b/components/atom/spinner/src/SUILoader/index.scss
@@ -3,18 +3,12 @@
 #{$base-class} {
   &-loader {
     animation: $anim-atom-spinner;
-    background-color: transparent;
     border-radius: $bdrs-rounded;
-    box-shadow: -$sz-atom-spinner-oval $sz-atom-spinner-oval
-        $c-atom-spinner-loader-accent,
-      0 $sz-atom-spinner $c-atom-spinner-loader-primary;
-    display: none;
     height: $sz-atom-spinner-oval;
     left: 0;
     margin: 0 auto;
     position: absolute;
     right: 0;
-    text-indent: 100%;
     top: calc(50% - #{$sz-atom-spinner});
     width: $sz-atom-spinner-oval;
     z-index: $z-atom-spinner-loader;

--- a/components/atom/spinner/src/SUILoader/settings.scss
+++ b/components/atom/spinner/src/SUILoader/settings.scss
@@ -2,40 +2,40 @@ $c-atom-spinner-loader-accent: color-variation($c-accent, 1) !default;
 $c-atom-spinner-loader-primary: color-variation($c-primary, -1) !default;
 $sz-atom-spinner-oval: $sz-icon-s !default;
 $sz-atom-spinner: $sz-atom-spinner-oval * 2 !default;
-$z-atom-spinner-loader: 999;
-$c-atom-spinner-loader-accent: color-variation($c-accent, 1) !default;
-$c-atom-spinner-loader-primary: color-variation($c-primary, -1) !default;
-$sz-atom-spinner-oval: $sz-icon-s !default;
-$sz-atom-spinner: $sz-atom-spinner-oval * 2 !default;
-$z-atom-spinner-loader: 999;
+$z-atom-spinner-loader: 999 !default;
 
 @keyframes atom-spinner {
   0% {
-    box-shadow: -$sz-atom-spinner-oval $sz-atom-spinner-oval
+    box-shadow: -$sz-atom-spinner-oval * 0.5 $sz-atom-spinner-oval
         $c-atom-spinner-loader-accent,
-      0 $sz-atom-spinner $c-atom-spinner-loader-primary;
+      $sz-atom-spinner-oval * 0.5 $sz-atom-spinner
+        $c-atom-spinner-loader-primary;
   }
 
   25% {
-    box-shadow: 0 $sz-atom-spinner-oval $c-atom-spinner-loader-accent,
-      -$sz-atom-spinner-oval $sz-atom-spinner $c-atom-spinner-loader-primary;
+    box-shadow: $sz-atom-spinner-oval * 0.5 $sz-atom-spinner-oval
+        $c-atom-spinner-loader-accent,
+      -$sz-atom-spinner-oval * 0.5 $sz-atom-spinner $c-atom-spinner-loader-primary;
   }
 
   50% {
-    box-shadow: 0 $sz-atom-spinner $c-atom-spinner-loader-accent,
-      -$sz-atom-spinner-oval $sz-atom-spinner-oval $c-atom-spinner-loader-primary;
+    box-shadow: $sz-atom-spinner-oval * 0.5 $sz-atom-spinner
+        $c-atom-spinner-loader-accent,
+      -$sz-atom-spinner-oval * 0.5 $sz-atom-spinner-oval $c-atom-spinner-loader-primary;
   }
 
   75% {
-    box-shadow: -$sz-atom-spinner-oval $sz-atom-spinner
+    box-shadow: -$sz-atom-spinner-oval * 0.5 $sz-atom-spinner
         $c-atom-spinner-loader-accent,
-      0 $sz-atom-spinner-oval $c-atom-spinner-loader-primary;
+      $sz-atom-spinner-oval * 0.5 $sz-atom-spinner-oval
+        $c-atom-spinner-loader-primary;
   }
 
   100% {
-    box-shadow: -$sz-atom-spinner-oval $sz-atom-spinner-oval
+    box-shadow: -$sz-atom-spinner-oval * 0.5 $sz-atom-spinner-oval
         $c-atom-spinner-loader-accent,
-      0 $sz-atom-spinner $c-atom-spinner-loader-primary;
+      $sz-atom-spinner-oval * 0.5 $sz-atom-spinner
+        $c-atom-spinner-loader-primary;
   }
 }
 

--- a/components/atom/spinner/src/SUILoader/settings.scss
+++ b/components/atom/spinner/src/SUILoader/settings.scss
@@ -1,42 +1,32 @@
-$c-atom-spinner-loader-accent: color-variation($c-accent, 1) !default;
-$c-atom-spinner-loader-primary: color-variation($c-primary, -1) !default;
 $sz-atom-spinner-oval: $sz-icon-s !default;
 $sz-atom-spinner: $sz-atom-spinner-oval * 2 !default;
 $z-atom-spinner-loader: 999 !default;
 
-@keyframes atom-spinner {
-  0% {
-    box-shadow: -$sz-atom-spinner-oval * 0.5 $sz-atom-spinner-oval
-        $c-atom-spinner-loader-accent,
-      $sz-atom-spinner-oval * 0.5 $sz-atom-spinner
-        $c-atom-spinner-loader-primary;
-  }
+@mixin animation-atom-spinner($name, $color1, $color2) {
+  @keyframes atom-spinner-#{$name} {
+    0% {
+      box-shadow: -$sz-atom-spinner-oval * 0.5 $sz-atom-spinner-oval $color1,
+        $sz-atom-spinner-oval * 0.5 $sz-atom-spinner $color2;
+    }
 
-  25% {
-    box-shadow: $sz-atom-spinner-oval * 0.5 $sz-atom-spinner-oval
-        $c-atom-spinner-loader-accent,
-      -$sz-atom-spinner-oval * 0.5 $sz-atom-spinner $c-atom-spinner-loader-primary;
-  }
+    25% {
+      box-shadow: $sz-atom-spinner-oval * 0.5 $sz-atom-spinner-oval $color1,
+        -$sz-atom-spinner-oval * 0.5 $sz-atom-spinner $color2;
+    }
 
-  50% {
-    box-shadow: $sz-atom-spinner-oval * 0.5 $sz-atom-spinner
-        $c-atom-spinner-loader-accent,
-      -$sz-atom-spinner-oval * 0.5 $sz-atom-spinner-oval $c-atom-spinner-loader-primary;
-  }
+    50% {
+      box-shadow: $sz-atom-spinner-oval * 0.5 $sz-atom-spinner $color1,
+        -$sz-atom-spinner-oval * 0.5 $sz-atom-spinner-oval $color2;
+    }
 
-  75% {
-    box-shadow: -$sz-atom-spinner-oval * 0.5 $sz-atom-spinner
-        $c-atom-spinner-loader-accent,
-      $sz-atom-spinner-oval * 0.5 $sz-atom-spinner-oval
-        $c-atom-spinner-loader-primary;
-  }
+    75% {
+      box-shadow: -$sz-atom-spinner-oval * 0.5 $sz-atom-spinner $color1,
+        $sz-atom-spinner-oval * 0.5 $sz-atom-spinner-oval $color2;
+    }
 
-  100% {
-    box-shadow: -$sz-atom-spinner-oval * 0.5 $sz-atom-spinner-oval
-        $c-atom-spinner-loader-accent,
-      $sz-atom-spinner-oval * 0.5 $sz-atom-spinner
-        $c-atom-spinner-loader-primary;
+    100% {
+      box-shadow: -$sz-atom-spinner-oval * 0.5 $sz-atom-spinner-oval $color1,
+        $sz-atom-spinner-oval * 0.5 $sz-atom-spinner $color2;
+    }
   }
 }
-
-$anim-atom-spinner: atom-spinner 1.5s ease-in-out infinite;

--- a/components/atom/spinner/src/index.js
+++ b/components/atom/spinner/src/index.js
@@ -19,14 +19,14 @@ const AtomSpinner = forwardRef(
   (
     {
       children = <DefaultSpinner />,
-      delayed: delayedFromProps = false,
+      isDelayed: isDelayedFromProps = false,
       loader = <SUILoader />,
       overlayType = OVERLAY_TYPES.LIGHT,
       type = TYPES.SECTION
     },
     forwardedRef
   ) => {
-    const [delayed, setDelayed] = useState(delayedFromProps)
+    const [isDelayed, setIsDelayed] = useState(isDelayedFromProps)
     const refSpinner = useRef()
 
     useEffect(() => {
@@ -36,10 +36,10 @@ const AtomSpinner = forwardRef(
       })
       const parentNodeClassList = refSpinner.current.parentNode.classList
 
-      if (!delayed) addParentClass(parentNodeClassList)(parentClassName)
+      if (!isDelayed) addParentClass(parentNodeClassList)(parentClassName)
 
       const timer = setTimeout(() => {
-        setDelayed(false)
+        setIsDelayed(false)
         addParentClass(parentNodeClassList)(parentClassName)
       }, DELAY)
 
@@ -47,12 +47,12 @@ const AtomSpinner = forwardRef(
         clearTimeout(timer)
         removeParentClass(parentNodeClassList)(parentClassName)
       }
-    }, [delayed, overlayType, type])
+    }, [isDelayed, overlayType, type])
 
     return (
       <div ref={refSpinner} className="sui-AtomSpinner-content">
         <Injector
-          delayed={delayed}
+          isDelayed={isDelayed}
           loader={loader}
           overlayType={overlayType}
           ref={forwardedRef}
@@ -72,7 +72,7 @@ AtomSpinner.propTypes = {
   children: PropTypes.elementType,
 
   /** Makes the spinner appear after 500 ms */
-  delayed: PropTypes.bool,
+  isDelayed: PropTypes.bool,
 
   /** Loader to be shown in the middle of the container */
   loader: PropTypes.elementType,

--- a/components/atom/spinner/src/index.js
+++ b/components/atom/spinner/src/index.js
@@ -1,69 +1,100 @@
-import {useState, useEffect, useRef} from 'react'
+import {forwardRef, useState, useEffect, useRef} from 'react'
 import PropTypes from 'prop-types'
 
+import Injector from '@s-ui/react-primitive-injector'
+
+import DefaultSpinner from './DefaultSpinner.js'
 import SUILoader from './SUILoader/index.js'
+
 import {
-  TYPES,
+  addParentClass,
   DELAY,
   getParentClassName,
-  addParentClass,
-  removeParentClass
+  OVERLAY_TYPES,
+  removeParentClass,
+  TYPES
 } from './settings.js'
 
-const AtomSpinner = ({
-  delayed: delayedFromProps,
-  loader,
-  type,
-  noBackground
-}) => {
-  const [delayed, setDelayed] = useState(delayedFromProps)
-  const refSpinner = useRef()
+const AtomSpinner = forwardRef(
+  (
+    {
+      children = <DefaultSpinner />,
+      delayed: delayedFromProps = false,
+      loader = <SUILoader />,
+      overlayType = OVERLAY_TYPES.LIGHT,
+      type = TYPES.SECTION
+    },
+    forwardedRef
+  ) => {
+    const [delayed, setDelayed] = useState(delayedFromProps)
+    const refSpinner = useRef()
 
-  useEffect(() => {
-    const parentClassName = getParentClassName({type, noBackground})
-    const parentNodeClassList = refSpinner.current.parentNode.classList
+    useEffect(() => {
+      const parentClassName = getParentClassName({
+        overlayType,
+        type
+      })
+      const parentNodeClassList = refSpinner.current.parentNode.classList
 
-    if (!delayed) addParentClass(parentNodeClassList)(parentClassName)
+      if (!delayed) addParentClass(parentNodeClassList)(parentClassName)
 
-    const timer = setTimeout(() => {
-      setDelayed(false)
-      addParentClass(parentNodeClassList)(parentClassName)
-    }, DELAY)
+      const timer = setTimeout(() => {
+        setDelayed(false)
+        addParentClass(parentNodeClassList)(parentClassName)
+      }, DELAY)
 
-    return () => {
-      clearTimeout(timer)
-      removeParentClass(parentNodeClassList)(parentClassName)
-    }
-  }, [delayed, noBackground, type])
+      return () => {
+        clearTimeout(timer)
+        removeParentClass(parentNodeClassList)(parentClassName)
+      }
+    }, [delayed, overlayType, type])
 
-  return <span ref={refSpinner}>{!delayed ? loader : <noscript />}</span>
-}
+    return (
+      <div ref={refSpinner} className="sui-AtomSpinner-content">
+        <Injector
+          delayed={delayed}
+          loader={loader}
+          overlayType={overlayType}
+          ref={forwardedRef}
+          type={type}
+        >
+          {children}
+        </Injector>
+      </div>
+    )
+  }
+)
 
 AtomSpinner.displayName = 'AtomSpinner'
 
 AtomSpinner.propTypes = {
+  /** Children with injected props */
+  children: PropTypes.elementType,
+
+  /** Makes the spinner appear after 500 ms */
+  delayed: PropTypes.bool,
+
+  /** Loader to be shown in the middle of the container */
+  loader: PropTypes.elementType,
+
+  /**
+   * Possible options:
+   * 'ACCENT'
+   * 'DARK'
+   * 'LIGHT'
+   * 'PRIMARY'
+   * 'TRANSPARENT'
+   */
+  overlayType: PropTypes.oneOf(Object.values(OVERLAY_TYPES)),
+
   /**
    * Possible options:
    * 'FULL': The spinner fits the whole page container
    * 'SECTION': The spinner fits a specific site component
    */
-  type: PropTypes.oneOf(Object.values(TYPES)),
-
-  /** Makes the spinner appear after 500 ms */
-  delayed: PropTypes.bool,
-
-  /** No background */
-  noBackground: PropTypes.bool,
-
-  /** Loader to be shown in the middle of the container */
-  loader: PropTypes.object
+  type: PropTypes.oneOf(Object.values(TYPES))
 }
 
-AtomSpinner.defaultProps = {
-  delayed: false,
-  type: TYPES.SECTION,
-  loader: <SUILoader />
-}
+export {OVERLAY_TYPES as atomSpinnerOverlayTypes, TYPES as atomSpinnerTypes}
 
 export default AtomSpinner
-export {TYPES as AtomSpinnerTypes}

--- a/components/atom/spinner/src/settings.js
+++ b/components/atom/spinner/src/settings.js
@@ -5,16 +5,22 @@ export const TYPES = {
   SECTION: 'section'
 }
 
+export const OVERLAY_TYPES = {
+  ACCENT: 'accent',
+  DARK: 'dark',
+  LIGHT: 'light',
+  PRIMARY: 'primary',
+  TRANSPARENT: 'transparent'
+}
+
 export const DELAY = 500 // ms
 export const BASE_CLASS = 'sui-AtomSpinner'
 export const CLASS_FULL = `${BASE_CLASS}--fullPage`
-export const CLASS_NO_BACKGROUND = `${BASE_CLASS}--noBackground`
 
-export const getParentClassName = ({type, noBackground}) =>
-  cx({
+export const getParentClassName = ({overlayType, type}) =>
+  cx(`${BASE_CLASS}--${overlayType}`, {
     [BASE_CLASS]: type === TYPES.SECTION,
-    [CLASS_FULL]: type === TYPES.FULL,
-    [CLASS_NO_BACKGROUND]: noBackground
+    [CLASS_FULL]: type === TYPES.FULL
   })
 
 export const addParentClass = parentNodeClassList => parentClassName =>

--- a/components/atom/spinner/src/styles/index.scss
+++ b/components/atom/spinner/src/styles/index.scss
@@ -8,8 +8,16 @@ $base-class: '.sui-AtomSpinner';
     position: absolute;
   }
 
-  &--noBackground::before {
-    background-color: transparent;
+  &-content {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    justify-content: center;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
   }
 
   &--fullPage {
@@ -26,5 +34,13 @@ $base-class: '.sui-AtomSpinner';
 
   #{&}-loader {
     display: block;
+  }
+
+  @each $name, $type in $atom-spinner-overlay-types {
+    $bgc: map-get($type, bgc);
+
+    &--#{$name}::before {
+      background-color: $bgc;
+    }
   }
 }

--- a/components/atom/spinner/src/styles/settings.scss
+++ b/components/atom/spinner/src/styles/settings.scss
@@ -1,4 +1,7 @@
 $bgc-atom-spinner: rgba($c-white, 0.6) !default;
+$c-atom-spinner-loader-accent: color-variation($c-accent, 1) !default;
+$c-atom-spinner-loader-primary: color-variation($c-primary, -1) !default;
+$c-atom-spinner-loader-white: $c-white !default;
 
 $bgc-atom-spinner-accent: rgba($c-accent, 0.6) !default;
 $bgc-atom-spinner-dark: rgba($c-black, 0.6) !default;
@@ -6,23 +9,44 @@ $bgc-atom-spinner-light: $bgc-atom-spinner !default;
 $bgc-atom-spinner-primary: rgba($c-primary, 0.6) !default;
 $bgc-atom-spinner-transparent: transparent !default;
 
+$c-atom-spinner-loader-accent-one: $c-atom-spinner-loader-white !default;
+$c-atom-spinner-loader-accent-two: $c-atom-spinner-loader-primary !default;
+$c-atom-spinner-loader-dark-one: $c-atom-spinner-loader-accent !default;
+$c-atom-spinner-loader-dark-two: $c-atom-spinner-loader-white !default;
+$c-atom-spinner-loader-light-one: $c-atom-spinner-loader-accent !default;
+$c-atom-spinner-loader-light-two: $c-atom-spinner-loader-primary !default;
+$c-atom-spinner-loader-primary-one: $c-atom-spinner-loader-accent !default;
+$c-atom-spinner-loader-primary-two: $c-atom-spinner-loader-white !default;
+$c-atom-spinner-loader-transparent-one: $c-atom-spinner-loader-accent !default;
+$c-atom-spinner-loader-transparent-two: $c-atom-spinner-loader-primary !default;
+
 $z-atom-spinner: 999 !default;
 
 $atom-spinner-overlay-types: (
   accent: (
-    bgc: $bgc-atom-spinner-accent
+    bgc: $bgc-atom-spinner-accent,
+    loaderColorOne: $c-atom-spinner-loader-accent-one,
+    loaderColorTwo: $c-atom-spinner-loader-accent-two
   ),
   dark: (
-    bgc: $bgc-atom-spinner-dark
+    bgc: $bgc-atom-spinner-dark,
+    loaderColorOne: $c-atom-spinner-loader-dark-one,
+    loaderColorTwo: $c-atom-spinner-loader-dark-two
   ),
   light: (
-    bgc: $bgc-atom-spinner-light
+    bgc: $bgc-atom-spinner-light,
+    loaderColorOne: $c-atom-spinner-loader-light-one,
+    loaderColorTwo: $c-atom-spinner-loader-light-two
   ),
   primary: (
-    bgc: $bgc-atom-spinner-primary
+    bgc: $bgc-atom-spinner-primary,
+    loaderColorOne: $c-atom-spinner-loader-primary-one,
+    loaderColorTwo: $c-atom-spinner-loader-primary-two
   ),
   transparent: (
-    bgc: $bgc-atom-spinner-transparent
+    bgc: $bgc-atom-spinner-transparent,
+    loaderColorOne: $c-atom-spinner-loader-transparent-one,
+    loaderColorTwo: $c-atom-spinner-loader-transparent-two
   )
 ) !default;
 

--- a/components/atom/spinner/src/styles/settings.scss
+++ b/components/atom/spinner/src/styles/settings.scss
@@ -1,8 +1,32 @@
 $bgc-atom-spinner: rgba($c-white, 0.6) !default;
-$z-atom-spinner: 1 !default;
+
+$bgc-atom-spinner-accent: rgba($c-accent, 0.6) !default;
+$bgc-atom-spinner-dark: rgba($c-black, 0.6) !default;
+$bgc-atom-spinner-light: $bgc-atom-spinner !default;
+$bgc-atom-spinner-primary: rgba($c-primary, 0.6) !default;
+$bgc-atom-spinner-transparent: transparent !default;
+
+$z-atom-spinner: 999 !default;
+
+$atom-spinner-overlay-types: (
+  accent: (
+    bgc: $bgc-atom-spinner-accent
+  ),
+  dark: (
+    bgc: $bgc-atom-spinner-dark
+  ),
+  light: (
+    bgc: $bgc-atom-spinner-light
+  ),
+  primary: (
+    bgc: $bgc-atom-spinner-primary
+  ),
+  transparent: (
+    bgc: $bgc-atom-spinner-transparent
+  )
+) !default;
 
 %spinner-layer {
-  background-color: $bgc-atom-spinner;
   bottom: 0;
   content: '';
   left: 0;

--- a/components/atom/spinner/test/index.test.js
+++ b/components/atom/spinner/test/index.test.js
@@ -23,10 +23,19 @@ describe(json.name, () => {
   it('library should include defined exported elements', () => {
     // Given
     const library = pkg
-    const libraryExportedMembers = ['AtomSpinnerTypes', 'default']
+    const libraryExportedMembers = [
+      'atomSpinnerOverlayTypes',
+      'atomSpinnerTypes',
+      'default'
+    ]
 
     // When
-    const {AtomSpinnerTypes, default: AtomSpinner, ...others} = library
+    const {
+      atomSpinnerOverlayTypes,
+      atomSpinnerTypes,
+      default: AtomSpinner,
+      ...others
+    } = library
 
     // Then
     expect(Object.keys(library).length).to.equal(libraryExportedMembers.length)
@@ -75,13 +84,13 @@ describe(json.name, () => {
     })
   })
 
-  describe('AtomSpinnerTypes', () => {
+  describe('atomSpinnerTypes', () => {
     it('value must be an object enum', () => {
       // Given
       const library = pkg
 
       // When
-      const {AtomSpinnerTypes: actual} = library
+      const {atomSpinnerTypes: actual} = library
 
       // Then
       expect(actual).to.be.an('object')
@@ -96,8 +105,45 @@ describe(json.name, () => {
       }
 
       // When
-      const {AtomSpinnerTypes: actual} = library
+      const {atomSpinnerTypes: actual} = library
       const {FULL, SECTION, ...others} = actual
+
+      // Then
+      expect(Object.keys(others).length).to.equal(0)
+      expect(Object.keys(actual)).to.have.members(Object.keys(expected))
+      Object.entries(expected).forEach(([expectedKey, expectedValue]) => {
+        expect(Object.keys(actual).includes(expectedKey)).to.be.true
+        expect(actual[expectedKey]).to.equal(expectedValue)
+      })
+    })
+  })
+
+  describe('atomSpinnerOverlayTypes', () => {
+    it('value must be an object enum', () => {
+      // Given
+      const library = pkg
+
+      // When
+      const {atomSpinnerOverlayTypes: actual} = library
+
+      // Then
+      expect(actual).to.be.an('object')
+    })
+
+    it('value must be a defined string-key pair filled', () => {
+      // Given
+      const library = pkg
+      const expected = {
+        ACCENT: 'accent',
+        DARK: 'dark',
+        LIGHT: 'light',
+        PRIMARY: 'primary',
+        TRANSPARENT: 'transparent'
+      }
+
+      // When
+      const {atomSpinnerOverlayTypes: actual} = library
+      const {ACCENT, DARK, LIGHT, PRIMARY, TRANSPARENT, ...others} = actual
 
       // Then
       expect(Object.keys(others).length).to.equal(0)


### PR DESCRIPTION
## atom/spinner
#### `❓ Ask`

### Types of changes
New version of atom spinner!

### BREAKING CHANGES:

Add different overlay types, replacing old `noBackground` boolean prop.
Add children with injected props from `AtomSpinner`, allowing full customization of the component.
Removed `noBackground` prop. You can use now prop `overlayType: transparent`

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🧾 Documentation
- [x] 📷 Demo
- [x] 🧪 Test
- [x] 🧠 Refactor
- [x] 💄 Styles

### Description, Motivation and Context
By theme, only one overlay color could be set. We have the necessity to have two different overlays in motor at the same time. Now we can select the desired overlay by prop, also a transparent one, and we can define these colors on our theme, of course.

![image](https://user-images.githubusercontent.com/37936498/170490227-5737978b-f4cd-4922-9ebb-a119b334a3ae.png)

Also, `AtomSpinner` now can receive a `children` prop that will be injected with `AtomSpinner` props and the `AtomSpinner`'s loader, to fully customize our spinner.

![May-26-2022 14-50-35](https://user-images.githubusercontent.com/37936498/170491050-68592ba4-1e56-4fe1-9807-26c2a3e4f820.gif)

