### PR TITLE
feat(components/atom/spinner): remove warnings

### DIFF
--- a/components/atom/spinner/src/SUILoader/index.scss
+++ b/components/atom/spinner/src/SUILoader/index.scss
@@ -20,7 +20,7 @@
 
   @include animation-atom-spinner($name, $loaderColorOne, $loaderColorTwo);
 
-  .sui-AtomSpinner--#{$name} {
+  .sui-AtomSpinner--#{'' + $name} {
     & .sui-AtomSpinner-loader {
       animation: atom-spinner-#{$name} 1.5s ease-in-out infinite;
     }

--- a/components/atom/spinner/src/SUILoader/settings.scss
+++ b/components/atom/spinner/src/SUILoader/settings.scss
@@ -3,7 +3,7 @@ $sz-atom-spinner: $sz-atom-spinner-oval * 2 !default;
 $z-atom-spinner-loader: 999 !default;
 
 @mixin animation-atom-spinner($name, $color1, $color2) {
-  @keyframes atom-spinner-#{$name} {
+  @keyframes atom-spinner-#{'' + $name} {
     0% {
       box-shadow: -$sz-atom-spinner-oval * 0.5 $sz-atom-spinner-oval $color1,
         $sz-atom-spinner-oval * 0.5 $sz-atom-spinner $color2;

--- a/components/atom/spinner/src/styles/index.scss
+++ b/components/atom/spinner/src/styles/index.scss
@@ -39,7 +39,7 @@ $base-class: '.sui-AtomSpinner';
   @each $name, $type in $atom-spinner-overlay-types {
     $bgc: map-get($type, bgc);
 
-    &--#{$name}::before {
+    &--#{'' + $name}::before {
       background-color: $bgc;
     }
   }


### PR DESCRIPTION
## atom/spinner
#### `🔍 Show`

### Types of changes
Remove warnings due to the `transparent overlayType` name.

### Description, Motivation and Context
### Screenshots - Animations
<img width="600" alt="image" src="https://user-images.githubusercontent.com/37936498/170951464-2890bc2b-222e-48fa-91c9-0785e316bfc4.png">

