### PR TITLE
feat(components/molecule/drawer): add customizable border radius

### DIFF
--- a/components/molecule/drawer/src/_settings.scss
+++ b/components/molecule/drawer/src/_settings.scss
@@ -4,6 +4,8 @@ $z-molecule-drawer: $z-modal !default;
 $z-molecule-drawer-overlay: $z-modal - 1 !default;
 $bxsh-molecule-drawer: 0 0 6px rgba(0, 0, 0, 0.4) !default;
 $bgc-molecule-drawer: $c-white !default;
+$bdtlrs-molecule-drawer-content: 0 !default;
+$bdtrrs-molecule-drawer-content: 0 !default;
 
 $z-molecule-drawer-map: (
   auto: auto,

--- a/components/molecule/drawer/src/styles/index.scss
+++ b/components/molecule/drawer/src/styles/index.scss
@@ -13,6 +13,8 @@ $base-class: '.sui-MoleculeDrawer';
 
   &-content {
     $this: &;
+    border-top-left-radius: $bdtlrs-molecule-drawer-content;
+    border-top-right-radius: $bdtrrs-molecule-drawer-content;
     z-index: $z-molecule-drawer;
     position: absolute;
     background-color: $bgc-molecule-drawer;


### PR DESCRIPTION
## Molecule/Drawer

 #### `🔍 Show` 

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- https://jira.scmspain.com/browse/MTR-53849 -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
<!--- Describe your changes in detail -->
The change allow the chance to use border radius on both top corners of the contextual menu.

This change is required by Coches PRO UX/UI team

![image](https://user-images.githubusercontent.com/17437586/171138197-1ef40a39-7984-4aae-a9cf-67556d6842e6.png)


