### PR TITLE
feat(components/atom/tag): add customizable padding

### DIFF
--- a/components/atom/tag/src/_settings.scss
+++ b/components/atom/tag/src/_settings.scss
@@ -11,6 +11,8 @@ $p-atom-tag-l: 0 $p-l !default;
 $p-atom-tag-m: 0 $p-l !default;
 $p-atom-tag-s: 0 $p-m !default;
 
+$p-atom-tag-medium-hasIcon-hasClose: $p-atom-tag-m !default;
+
 // outline
 $bc-atom-tag-outline: color-variation($c-gray, 3) !default;
 $bdw-atom-tag-outline: $bdw-s !default;

--- a/components/atom/tag/src/_settings.scss
+++ b/components/atom/tag/src/_settings.scss
@@ -11,7 +11,11 @@ $p-atom-tag-l: 0 $p-l !default;
 $p-atom-tag-m: 0 $p-l !default;
 $p-atom-tag-s: 0 $p-m !default;
 
-$p-atom-tag-medium-hasIcon-hasClose: $p-atom-tag-m !default;
+$p-atom-tag-hasIcon-hasClose: (
+  small: $p-atom-tag-s,
+  medium: $p-atom-tag-m,
+  large: $p-atom-tag-l
+) !default;
 
 // outline
 $bc-atom-tag-outline: color-variation($c-gray, 3) !default;

--- a/components/atom/tag/src/styles/index.scss
+++ b/components/atom/tag/src/styles/index.scss
@@ -140,6 +140,12 @@ $base-class: '.sui-AtomTag';
     }
   }
 
+  &-medium {
+    &.sui-AtomTag-hasIcon.sui-AtomTag-hasClose {
+      padding: $p-atom-tag-medium-hasIcon-hasClose;
+    }
+  }
+
   &-large {
     border-radius: ceil($h-atom-tag-l * 0.5);
     height: $h-atom-tag-l;

--- a/components/atom/tag/src/styles/index.scss
+++ b/components/atom/tag/src/styles/index.scss
@@ -122,6 +122,9 @@ $base-class: '.sui-AtomTag';
   &-small {
     height: $h-atom-tag-s;
     padding: $p-atom-tag-s;
+    &.sui-AtomTag-hasIcon.sui-AtomTag-hasClose {
+      padding: map-get($p-atom-tag-hasIcon-hasClose, 'small');
+    }
 
     & .sui-AtomTag-label {
       line-height: $h-atom-tag-s;
@@ -142,7 +145,7 @@ $base-class: '.sui-AtomTag';
 
   &-medium {
     &.sui-AtomTag-hasIcon.sui-AtomTag-hasClose {
-      padding: $p-atom-tag-medium-hasIcon-hasClose;
+      padding: map-get($p-atom-tag-hasIcon-hasClose, 'medium');
     }
   }
 
@@ -150,6 +153,9 @@ $base-class: '.sui-AtomTag';
     border-radius: ceil($h-atom-tag-l * 0.5);
     height: $h-atom-tag-l;
     padding: $p-atom-tag-l;
+    &.sui-AtomTag-hasIcon.sui-AtomTag-hasClose {
+      padding: map-get($p-atom-tag-hasIcon-hasClose, 'large');
+    }
 
     & .sui-AtomTag-label {
       line-height: $h-atom-tag-l;


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
`🔍 Show`
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
Add customizable variable for padding only for medium tag and it has icon and close button.
It's a requirement form UI to adjust tags in that case

### Screenshots - Animations
medium tag with icon and close:
![Screenshot 2022-06-02 at 14 04 40](https://user-images.githubusercontent.com/74129/171625569-c351f58d-8966-4cbe-a116-20a386dbeb44.png)
large tag with icon and close: 
![Screenshot 2022-06-02 at 14 04 32](https://user-images.githubusercontent.com/74129/171625566-f73d86ef-913d-4407-b8e0-213036419b66.png)
medium tag with only icon:
![Screenshot 2022-06-02 at 14 04 52](https://user-images.githubusercontent.com/74129/171625574-1db6d52e-3f17-4a26-a823-055bd972bf72.png)

