### PR TITLE
feat(components/molecule/photoUploader): add padding to photo uploader

### DIFF
--- a/components/molecule/photoUploader/src/styles/index.scss
+++ b/components/molecule/photoUploader/src/styles/index.scss
@@ -32,6 +32,7 @@ $skeleton-class: '#{$base-class}-skeleton';
   }
   &-initialState {
     align-items: center;
+    padding: $p-photo-uploader-initial-state;
     background: $bg-photo-uploader-initial-state;
     border: $bd-photo-uploader;
     border-radius: $bdrs-photo-uploader-initial-state;

--- a/components/molecule/photoUploader/src/styles/settings.scss
+++ b/components/molecule/photoUploader/src/styles/settings.scss
@@ -46,6 +46,7 @@ $p-photo-uploader: $p-m !default;
 $s-photo-uploader-thumb-icons: 16px !default;
 $w-photo-uploader-thumb-image-desktop: 160px !default;
 $w-photo-uploader-thumb-image: 100% !default;
+$p-photo-uploader-initial-state: 0 !default;
 
 $mih-photo-uploader: 249px !default;
 $s-photo-uploader-counter: 16px !default;


### PR DESCRIPTION
## Molecule/PhotoUploader

### Types of changes

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
This PR add `$p-photo-uploader-initial-state` variable to add padding to the initial state of the component
