### PR TITLE
feat(components/atom/tag): Allow setting bdc from tag types

### DIFF
--- a/components/atom/tag/src/styles/index.scss
+++ b/components/atom/tag/src/styles/index.scss
@@ -199,6 +199,7 @@ $base-class: '.sui-AtomTag';
 
     &--#{$name} {
       background-color: $bgc;
+      border-color: $bdc;
       border-style: $bds;
       border-width: $bdw;
       color: $c;


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
🔍 Show
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: https://jira.scmspain.com/browse/MTR-53668

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
We have a little difference with tags on CarFactory and in CNET. 
Basically, we want to be able to edit the border color from CF but is not allowing to do so cause sui-AtomTag is not setting the **bdc** for their $atom-tag-types

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
**BEFORE**
![image](https://user-images.githubusercontent.com/9258540/174061196-ccc9f257-a1e6-45c5-9e8f-95c03a7577ef.png)
**AFTER - notice border on Last Call tag**
![image](https://user-images.githubusercontent.com/9258540/174063324-5ebf8855-221a-43b4-8684-d68ee6e02ec6.png)


