### PR TITLE
feat(components/atom/input): disable pointer events if there is no ha…

### DIFF
--- a/components/atom/input/src/Input/Wrappers/Icons/index.scss
+++ b/components/atom/input/src/Input/Wrappers/Icons/index.scss
@@ -21,9 +21,11 @@
     top: $t-atom-input-icon;
     transform: translateY($trf-ty-atom-input-icon);
     width: $w-atom-input-icon;
+    pointer-events: none;
 
     &--withHandler {
       cursor: pointer;
+      pointer-events: auto;
     }
 
     &--left {


### PR DESCRIPTION
## atom/input

### Types of changes

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
If `rightIcon` is added to `AtomInput` with `as` select clicking on the icon does not open the select. For example:

```
<Input
  as="select"
  rightIcon={<IconChevronDown />}
/>
```

The event is not bubbling since is not inside the `input`/`select`

![Screenshot 2022-06-17 at 09 02 34](https://user-images.githubusercontent.com/6877967/174243991-2e5a2e53-10a8-4cea-98ca-bf263345fae6.png)


