### PR TITLE
Fix/export colors dictionary correctly

### DIFF
--- a/components/atom/button/demo/index.js
+++ b/components/atom/button/demo/index.js
@@ -1,36 +1,37 @@
 /* eslint-disable react/prop-types, no-unused-vars, no-console */
 
-import {useState, Fragment} from 'react'
+import {Fragment, useState} from 'react'
 
 import AtomButton, {atomButtonGroupPositions} from 'components/atom/button/src'
+
 import {
-  Label,
-  H1,
-  H2,
-  Box,
-  Paragraph,
   Article,
+  Box,
+  Cell,
   Code,
   Grid,
-  Cell,
-  RadioButtonGroup,
-  RadioButton,
+  H1,
+  H2,
   Input,
-  UnorderedList,
-  ListItem
+  Label,
+  ListItem,
+  Paragraph,
+  RadioButton,
+  RadioButtonGroup,
+  UnorderedList
 } from '@s-ui/documentation-library'
 
 import {
-  CLASS_SECTION,
-  starIcon,
-  atomButtonColorsIterator,
-  atomButtonSocialColorsIterator,
-  atomButtonDesignsIterator,
-  atomButtonSizesIterator,
   atomButtonAlignmentIterator,
+  atomButtonColorsIterator,
+  atomButtonDesignsIterator,
   atomButtonShapesIterator,
+  atomButtonSizesIterator,
+  atomButtonSocialColorsIterator,
+  CLASS_SECTION,
+  flexCenteredStyle,
   socialIconsMapper,
-  flexCenteredStyle
+  starIcon
 } from './settings.js'
 import TypeDeprecatedArticle from './TypeDeprecatedArticle.js'
 

--- a/components/atom/button/demo/settings.js
+++ b/components/atom/button/demo/settings.js
@@ -40,7 +40,7 @@ export const starIcon = (
   <AntDesignIcon icon="AiFillStar" style={{color: 'currentColor'}} />
 )
 
-export const atomButtonColorsIterator = atomButtonColors
+export const atomButtonColorsIterator = Object.values(atomButtonColors)
   .filter(color =>
     ['primary', 'accent', 'neutral', 'success', 'alert', 'error'].includes(
       color
@@ -48,7 +48,7 @@ export const atomButtonColorsIterator = atomButtonColors
   )
   .map((color, index) => [{color}, index])
 
-export const atomButtonSocialColorsIterator = atomButtonColors
+export const atomButtonSocialColorsIterator = Object.values(atomButtonColors)
   .filter(color =>
     [
       'social-facebook',

--- a/components/atom/button/src/Button.js
+++ b/components/atom/button/src/Button.js
@@ -1,5 +1,6 @@
-import PropTypes from 'prop-types'
 import {forwardRef} from 'react'
+
+import PropTypes from 'prop-types'
 
 const Button = ({
   children,

--- a/components/atom/button/src/ButtonIcon.js
+++ b/components/atom/button/src/ButtonIcon.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types'
 import {
   CLASS,
   ICON_POSITIONS,
-  SIZES,
   isAtomIcon,
-  prepareAtomIcon
+  prepareAtomIcon,
+  SIZES
 } from './config.js'
 
 const ButtonIcon = ({children, position, size}) => {

--- a/components/atom/button/src/config.js
+++ b/components/atom/button/src/config.js
@@ -29,20 +29,20 @@ export const ALIGNMENT = {
 /**
  * Available colors for the button
  */
-export const COLORS = [
-  'primary',
-  'accent',
-  'neutral',
-  'success',
-  'alert',
-  'error',
-  'social-facebook',
-  'social-twitter',
-  'social-google',
-  'social-youtube',
-  'social-whatsapp',
-  'social-instagram'
-]
+export const COLORS = {
+  PRIMARY: 'primary',
+  ACCENT: 'accent',
+  NEUTRAL: 'neutral',
+  SUCCESS: 'success',
+  ALERT: 'alert',
+  ERROR: 'error',
+  SOCIAL_FACEBOOK: 'social-facebook',
+  SOCIAL_TWITTER: 'social-twitter',
+  SOCIAL_GOOGLE: 'social-google',
+  SOCIAL_YOUTUBE: 'social-youtube',
+  SOCIAL_WHATSAPP: 'social-whatsapp',
+  SOCIAL_INSTAGRAM: 'social-instagram'
+}
 
 /**
  * Positions to be used when the button is used on group
@@ -137,7 +137,7 @@ export const createClasses = (array, sufix = '') =>
   array.reduce((res, key) => ({...res, [key]: `${CLASS}--${key}${sufix}`}), {})
 
 export const CLASSES = createClasses([
-  ...COLORS,
+  ...Object.values(COLORS),
   ...Object.values(DESIGNS),
   ...Object.values(ALIGNMENT),
   ...MODIFIERS,

--- a/components/atom/button/src/index.js
+++ b/components/atom/button/src/index.js
@@ -1,27 +1,28 @@
 import {forwardRef} from 'react'
-import PropTypes from 'prop-types'
-import cx from 'classnames'
 
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+
+import ButtonSpinnerIcon from './buttonSpinnerIcon/index.js'
 import Button from './Button.js'
 import ButtonIcon from './ButtonIcon.js'
-import ButtonSpinnerIcon from './buttonSpinnerIcon/index.js'
 import {
-  CLASS,
-  COLORS,
-  DESIGNS,
   ALIGNMENT,
-  ICON_POSITIONS,
-  GROUP_POSITIONS,
-  SIZES,
-  TYPES,
-  SHAPES,
-  TYPES_CONVERSION,
+  CLASS,
   CLASSES,
   cleanProps,
-  getModifiers,
+  COLORS,
   deprecated,
+  DESIGNS,
+  getModifiers,
+  getPropsWithDefaultValues,
+  GROUP_POSITIONS,
+  ICON_POSITIONS,
+  SHAPES,
+  SIZES,
   typeConversion,
-  getPropsWithDefaultValues
+  TYPES,
+  TYPES_CONVERSION
 } from './config.js'
 
 const AtomButton = forwardRef((props, ref) => {
@@ -138,7 +139,7 @@ AtomButton.propTypes = {
    * 'social-whatsapp',
    * 'social-instagram'
    */
-  color: PropTypes.oneOf(COLORS),
+  color: PropTypes.oneOf(Object.values(COLORS)),
   /**
    * Shape of button
    */

--- a/components/atom/button/test/index.test.js
+++ b/components/atom/button/test/index.test.js
@@ -7,12 +7,12 @@ import ReactDOM from 'react-dom'
 import chai, {expect} from 'chai'
 import chaiDOM from 'chai-dom'
 import sinon from 'sinon'
+
 import {fireEvent} from '@testing-library/react'
 
-import * as pkg from '../src/index.js'
-import {createClasses} from '../src/config.js'
-
 import json from '../package.json'
+import {createClasses} from '../src/config.js'
+import * as pkg from '../src/index.js'
 
 chai.use(chaiDOM)
 
@@ -139,7 +139,7 @@ describe(json.name, () => {
             type: 'primary'
           }
           const classes = createClasses([
-            ...atomButtonColors,
+            ...Object.values(atomButtonColors),
             ...Object.values(atomButtonDesigns)
           ])
           const findSentence = str => string =>
@@ -164,7 +164,7 @@ describe(json.name, () => {
             link: true
           }
           const classes = createClasses([
-            ...atomButtonColors,
+            ...Object.values(atomButtonColors),
             ...Object.values(atomButtonDesigns)
           ])
           const findSentence = str => string =>
@@ -190,7 +190,7 @@ describe(json.name, () => {
             type: 'accent'
           }
           const classes = createClasses([
-            ...atomButtonColors,
+            ...Object.values(atomButtonColors),
             ...Object.values(atomButtonDesigns)
           ])
           const findSentence = str => string =>
@@ -215,7 +215,7 @@ describe(json.name, () => {
             link: true
           }
           const classes = createClasses([
-            ...atomButtonColors,
+            ...Object.values(atomButtonColors),
             ...Object.values(atomButtonDesigns)
           ])
           const findSentence = str => string =>
@@ -241,7 +241,7 @@ describe(json.name, () => {
             type: 'secondary'
           }
           const classes = createClasses([
-            ...atomButtonColors,
+            ...Object.values(atomButtonColors),
             ...Object.values(atomButtonDesigns)
           ])
           const findSentence = str => string =>
@@ -266,7 +266,7 @@ describe(json.name, () => {
             link: true
           }
           const classes = createClasses([
-            ...atomButtonColors,
+            ...Object.values(atomButtonColors),
             ...Object.values(atomButtonDesigns)
           ])
           const findSentence = str => string =>
@@ -292,7 +292,7 @@ describe(json.name, () => {
             type: 'tertiary'
           }
           const classes = createClasses([
-            ...atomButtonColors,
+            ...Object.values(atomButtonColors),
             ...Object.values(atomButtonDesigns)
           ])
           const findSentence = str => string =>
@@ -317,7 +317,7 @@ describe(json.name, () => {
             link: true
           }
           const classes = createClasses([
-            ...atomButtonColors,
+            ...Object.values(atomButtonColors),
             ...Object.values(atomButtonDesigns)
           ])
           const findSentence = str => string =>
@@ -542,7 +542,7 @@ describe(json.name, () => {
   })
 
   describe('atomButtonColors', () => {
-    it('value must be an array', () => {
+    it('value must be a dictionary', () => {
       // Given
       const library = pkg
 
@@ -550,7 +550,8 @@ describe(json.name, () => {
       const {atomButtonColors: actual} = library
 
       // Then
-      expect(actual).to.be.an('array')
+      expect(actual).to.be.an('object')
+      expect(Object.values(actual)).to.be.an('array')
     })
 
     it('value must contain the defined array values', () => {
@@ -572,7 +573,8 @@ describe(json.name, () => {
       ]
 
       // When
-      const {atomButtonColors: actual} = library
+      const {atomButtonColors} = library
+      const actual = Object.values(atomButtonColors)
 
       // Then
       expect(actual.length).to.equal(expected.length)

--- a/components/atom/button/test/index.test.js
+++ b/components/atom/button/test/index.test.js
@@ -579,7 +579,7 @@ describe(json.name, () => {
 
       // Then
       expect(actual.length).to.equal(expected.length)
-      expect(actual).to.have.members(expected)
+      expect(actual).to.be.an('object')
     })
   })
 

--- a/components/atom/button/test/index.test.js
+++ b/components/atom/button/test/index.test.js
@@ -542,7 +542,7 @@ describe(json.name, () => {
   })
 
   describe('atomButtonColors', () => {
-    it('value must be an object enum, () => {
+    it('value must be an object enum', () => {
       // Given
       const library = pkg
 

--- a/components/atom/button/test/index.test.js
+++ b/components/atom/button/test/index.test.js
@@ -551,7 +551,6 @@ describe(json.name, () => {
 
       // Then
       expect(actual).to.be.an('object')
-      expect(Object.values(actual)).to.be.an('array')
     })
 
     it('value must contain the defined object values', () => {
@@ -575,11 +574,9 @@ describe(json.name, () => {
 
       // When
       const {atomButtonColors} = library
-      const actual = Object.values(atomButtonColors)
 
       // Then
-      expect(actual.length).to.equal(expected.length)
-      expect(actual).to.be.an('object')
+      expect(atomButtonColors.length).to.equal(expected.length)
     })
   })
 

--- a/components/atom/button/test/index.test.js
+++ b/components/atom/button/test/index.test.js
@@ -554,23 +554,24 @@ describe(json.name, () => {
       expect(Object.values(actual)).to.be.an('array')
     })
 
-    it('value must contain the defined array values', () => {
+    it('value must contain the defined object values', () => {
       // Given
       const library = pkg
-      const expected = [
-        'primary',
-        'accent',
-        'neutral',
-        'success',
-        'alert',
-        'error',
-        'social-facebook',
-        'social-twitter',
-        'social-google',
-        'social-youtube',
-        'social-whatsapp',
-        'social-instagram'
-      ]
+
+      const expected = {
+        PRIMARY: 'primary',
+        ACCENT: 'accent',
+        NEUTRAL: 'neutral',
+        SUCCESS: 'success',
+        ALERT: 'alert',
+        ERROR: 'error',
+        SOCIAL_FACEBOOK: 'social-facebook',
+        SOCIAL_TWITTER: 'social-twitter',
+        SOCIAL_GOOGLE: 'social-google',
+        SOCIAL_YOUTUBE: 'social-youtube',
+        SOCIAL_WHATSAPP: 'social-whatsapp',
+        SOCIAL_INSTAGRAM: 'social-instagram'
+      }
 
       // When
       const {atomButtonColors} = library

--- a/components/atom/button/test/index.test.js
+++ b/components/atom/button/test/index.test.js
@@ -542,7 +542,7 @@ describe(json.name, () => {
   })
 
   describe('atomButtonColors', () => {
-    it('value must be a dictionary', () => {
+    it('value must be an object enum, () => {
       // Given
       const library = pkg
 

--- a/components/atom/button/test/index.test.js
+++ b/components/atom/button/test/index.test.js
@@ -577,6 +577,10 @@ describe(json.name, () => {
 
       // Then
       expect(atomButtonColors.length).to.equal(expected.length)
+      Object.entries(expected).forEach(([expectedKey, expectedValue]) => {
+        expect(Object.keys(atomButtonColors).includes(expectedKey)).to.be.true
+        expect(atomButtonColors[expectedKey]).to.equal(expectedValue)
+      })
     })
   })
 


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [x] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
<!--- Describe your changes in detail -->

On the Button component, the array "atomButtonColors" it is not working correctly and in no vertical is it being used. 

It's only implemented in some cases and it's working because it's taking the default color "primary":
https://github.mpi-internal.com/search?q=atomButtonColors&type=code

To fix this issue I changed the array "atomButtonColors" for an Object.

<!--- Why is this change required? What problem does it solve? -->
We are going to be able to use the atomButtonColors variable on all verticals and remove magic strings. 

<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
