### PR TITLE
feat(components/molecule/tabs): Allow to disable scroll into view

### DIFF
--- a/components/molecule/tabs/src/components/MoleculeTab.js
+++ b/components/molecule/tabs/src/components/MoleculeTab.js
@@ -1,19 +1,31 @@
-import {useEffect, useRef, forwardRef} from 'react'
+import {forwardRef, useEffect, useRef} from 'react'
+
 import cx from 'classnames'
 import PropTypes from 'prop-types'
+
 import useMergeRefs from '@s-ui/react-hooks/lib/useMergeRefs'
 
 import {
   CLASS_TAB,
-  CLASS_TAB_ICON,
-  CLASS_TAB_COUNT,
   CLASS_TAB_ACTIVE,
-  CLASS_TAB_DISABLED
+  CLASS_TAB_COUNT,
+  CLASS_TAB_DISABLED,
+  CLASS_TAB_ICON
 } from './config.js'
 
 const MoleculeTab = forwardRef(
   (
-    {active, onChange, disabled, icon, count, label, numTab, isIntersecting},
+    {
+      autoScrollIntoView = true,
+      active,
+      onChange,
+      disabled,
+      icon,
+      count,
+      label,
+      numTab,
+      isIntersecting
+    },
     forwardedRef
   ) => {
     const innerRef = useRef()
@@ -23,14 +35,14 @@ const MoleculeTab = forwardRef(
     }
 
     useEffect(() => {
-      if (active && isIntersecting) {
+      if (autoScrollIntoView && active && isIntersecting) {
         innerRef.current.scrollIntoView({
           behavior: 'smooth',
           block: 'nearest',
           inline: 'start'
         })
       }
-    }, [active, isIntersecting, innerRef])
+    }, [autoScrollIntoView, active, isIntersecting, innerRef])
 
     const className = cx(CLASS_TAB, {
       [CLASS_TAB_ACTIVE]: active,
@@ -52,6 +64,9 @@ const MoleculeTab = forwardRef(
 )
 
 MoleculeTab.propTypes = {
+  /** Enable scroll into view funcionality */
+  autoScrollIntoView: PropTypes.bool,
+
   /** Handler on Change Tabs */
   onChange: PropTypes.func,
 

--- a/components/molecule/tabs/src/components/MoleculeTab.js
+++ b/components/molecule/tabs/src/components/MoleculeTab.js
@@ -16,15 +16,15 @@ import {
 const MoleculeTab = forwardRef(
   (
     {
-      autoScrollIntoView = true,
       active,
-      onChange,
+      autoScrollIntoView = true,
+      count,
       disabled,
       icon,
-      count,
+      isIntersecting,
       label,
       numTab,
-      isIntersecting
+      onChange
     },
     forwardedRef
   ) => {

--- a/components/molecule/tabs/src/components/MoleculeTabs.js
+++ b/components/molecule/tabs/src/components/MoleculeTabs.js
@@ -1,6 +1,8 @@
 import {Children, cloneElement, isValidElement} from 'react'
+
 import cx from 'classnames'
 import PropTypes from 'prop-types'
+
 import useOnScreen from '@s-ui/react-hooks/lib/useOnScreen'
 
 import {
@@ -11,7 +13,13 @@ import {
   VARIANTS
 } from '../config.js'
 
-const MoleculeTabs = ({variant, type, children, onChange}) => {
+const MoleculeTabs = ({
+  autoScrollIntoView = true,
+  children,
+  onChange,
+  type,
+  variant
+}) => {
   const className = cx(BASE_CLASS, {
     [`${BASE_CLASS}--${variant}`]: variant,
     [`${BASE_CLASS}--${type}`]: type
@@ -25,9 +33,10 @@ const MoleculeTabs = ({variant, type, children, onChange}) => {
     .map((child, index) => {
       const numTab = index + 1
       return cloneElement(child, {
-        onChange,
+        autoScrollIntoView,
+        isIntersecting,
         numTab,
-        isIntersecting
+        onChange
       })
     })
 
@@ -54,6 +63,9 @@ const MoleculeTabs = ({variant, type, children, onChange}) => {
 MoleculeTabs.displayName = 'MoleculeTabs'
 
 MoleculeTabs.propTypes = {
+  /** Enable scroll into view funcionality */
+  autoScrollIntoView: PropTypes.bool,
+
   /** children */
   children: PropTypes.any,
 

--- a/components/molecule/tabs/src/index.js
+++ b/components/molecule/tabs/src/index.js
@@ -1,10 +1,10 @@
 import {Children, cloneElement, useEffect, useState} from 'react'
-import PropTypes from 'prop-types'
 
-import {TYPES, VARIANTS} from './config.js'
+import PropTypes from 'prop-types'
 
 import MoleculeTab from './components/MoleculeTab.js'
 import MoleculeTabs from './components/MoleculeTabs.js'
+import {TYPES, VARIANTS} from './config.js'
 
 const MoleculeTabsWithStateActive = ({children, onChange, ...props}) => {
   const [activeTab, setActiveTab] = useState(null)


### PR DESCRIPTION
## MOLECULE/TABS
#### `🔍 Show` 

### Types of changes

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
The current MoleculeTabs scrollToView is not working fine. When tabs scroll into view, all container is moving rarely and is not working as expected. 

As discussed with @andresin87, we will add a prop `autoScrollIntoView` (true by default to maintain the compatibility) to disable this funcionality in case you want, and in the near future we will improve this funcionality to fix the bug correctly. Probably the fix will cause a new major version.