### PR TITLE
feat(components/atom/label): allow customization for AtomLabel line-h…

### DIFF
--- a/components/atom/label/src/styles/index.scss
+++ b/components/atom/label/src/styles/index.scss
@@ -5,6 +5,7 @@ $base-class: '.sui-AtomLabel';
   color: $c-atom-label;
   font-size: $fz-atom-label;
   font-weight: $fw-atom-label;
+  line-height: $lh-atom-label;
 
   &-optionalText {
     color: $c-atom-label-optional;

--- a/components/atom/label/src/styles/settings.scss
+++ b/components/atom/label/src/styles/settings.scss
@@ -6,3 +6,4 @@ $fw-atom-label: inherit !default;
 $c-atom-label-type: success $c-success, error $c-error, alert $c-alert,
   contrast $c-atom-label-contrast, disabled $c-atom-label-disabled !default;
 $fz-atom-label: $fz-base !default;
+$lh-atom-label: 1 !default;


### PR DESCRIPTION
…eight

## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
`🔍 Show`
<!-- #### `❓ Ask` -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

<img width="230" alt="image" src="https://user-images.githubusercontent.com/21960669/175242993-0ac5d92e-158e-46b5-b13b-af26bebe1803.png">
We need to be able to set a different line-height for the AtomLabel inside the CheckboxField

