### PR TITLE
fix(components/atom/label): change default line height value to inherit

### DIFF
--- a/components/atom/label/src/styles/settings.scss
+++ b/components/atom/label/src/styles/settings.scss
@@ -6,4 +6,4 @@ $fw-atom-label: inherit !default;
 $c-atom-label-type: success $c-success, error $c-error, alert $c-alert,
   contrast $c-atom-label-contrast, disabled $c-atom-label-disabled !default;
 $fz-atom-label: $fz-base !default;
-$lh-atom-label: 1 !default;
+$lh-atom-label: inherit !default;


### PR DESCRIPTION
## atom/label
#### `🔍 Show`

### Types of changes

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)

### Description, Motivation and Context
Change the recently added default value for line-height to avoid breaking styles on verticals.

BEFORE (bug) :
![image](https://user-images.githubusercontent.com/37936498/176657502-a9c6a139-d15f-4b33-9925-ee529b6ce4e0.png)

NOW (fixed) :
![image](https://user-images.githubusercontent.com/37936498/176657557-88d4c3e2-7b6a-4952-8229-1c0ffc845128.png)
 