### PR TITLE
feat(components/molecule/photoUploader): add photo uploader max callback

### DIFF
--- a/components/molecule/photoUploader/src/index.js
+++ b/components/molecule/photoUploader/src/index.js
@@ -66,6 +66,7 @@ const MoleculePhotoUploader = forwardRef(
       initialPhotos = [],
       limitPhotosUploadedNotification,
       limitPhotosUploadedText,
+      onLimitPhotosUploaded,
       mainPhotoLabel,
       maxImageHeight = DEFAULT_MAX_IMAGE_HEIGHT,
       maxImageWidth = DEFAULT_MAX_IMAGE_WIDTH,
@@ -151,15 +152,24 @@ const MoleculePhotoUploader = forwardRef(
       callbackPhotosRejected(rejectedFilesWithReason)
     }
 
+    const _onLimitPhotosUpload = () => {
+      if (onLimitPhotosUploaded) {
+        onLimitPhotosUploaded()
+        return
+      }
+
+      setNotificationError({
+        isError: true,
+        text: limitPhotosUploadedNotification
+      })
+    }
+
     const _onDropAccepted = acceptedFiles => {
       setNotificationError(DEFAULT_NOTIFICATION_ERROR)
       if (isLoading) return false
 
       if (isPhotoUploaderFully()) {
-        setNotificationError({
-          isError: true,
-          text: limitPhotosUploadedNotification
-        })
+        _onLimitPhotosUpload()
         _scrollToBottom()
         return false
       }
@@ -179,10 +189,7 @@ const MoleculePhotoUploader = forwardRef(
           _scrollToBottom()
         },
         setMaxPhotosError: () => {
-          setNotificationError({
-            isError: true,
-            text: limitPhotosUploadedNotification
-          })
+          _onLimitPhotosUpload()
         },
         allowUploadDuplicatedPhotos,
         maxPhotos
@@ -226,7 +233,7 @@ const MoleculePhotoUploader = forwardRef(
       noKeyboard: isPhotoUploaderFully(),
       accept: acceptedFileTypes,
       onDrop: onDropFiles,
-      onFileDialogOpen: onFileDialogOpen,
+      onFileDialogOpen,
       onDropAccepted: acceptedFiles => _onDropAccepted(acceptedFiles),
       onDropRejected: rejectedFiles => _onDropRejected(rejectedFiles)
     })
@@ -451,6 +458,9 @@ MoleculePhotoUploader.propTypes = {
 
   /** Text showed at error notification when the user drops more images than the max allowed at maxPhotos */
   limitPhotosUploadedNotification: PropTypes.string.isRequired,
+
+  /** Function called when the user drops more images than the max allowed at maxPhotos. If defined no notification will be displayed */
+  onLimitPhotosUploaded: PropTypes.func,
 
   /**
    *  Text placed at badge of the preview first item.


### PR DESCRIPTION
## Molecule/PhotoUploader

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
This PR add `onLimitPhotosUploaded` which is a function that will be called when the user drops more images than the max allowed. If defined no notification will be displayed