### PR TITLE
feat(components/atom/tag): add title as a new prop and also allow the…

### DIFF
--- a/components/atom/tag/src/Actionable/index.js
+++ b/components/atom/tag/src/Actionable/index.js
@@ -54,10 +54,7 @@ const ActionableTag = function ({
 ActionableTag.propTypes = {
   className: PropTypes.string,
   disabled: PropTypes.bool,
-  label: PropTypes.oneOfType([
-    PropTypes.string.isRequired,
-    PropTypes.node.isRequired
-  ]),
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   icon: PropTypes.node,
   href: PropTypes.string,
   iconPlacement: PropTypes.oneOf([LEFT_ICON_PLACEMENT, RIGHT_ICON_PLACEMENT]),

--- a/components/atom/tag/src/Actionable/index.js
+++ b/components/atom/tag/src/Actionable/index.js
@@ -20,6 +20,7 @@ const ActionableTag = function ({
   linkFactory,
   className,
   disabled,
+  title,
   value = null
 }) {
   return (
@@ -40,7 +41,7 @@ const ActionableTag = function ({
       {icon && iconPlacement === LEFT_ICON_PLACEMENT && (
         <span className="sui-AtomTag-icon">{icon}</span>
       )}
-      <span className="sui-AtomTag-label" title={label}>
+      <span className="sui-AtomTag-label" title={title || label}>
         {label}
       </span>
       {icon && iconPlacement === RIGHT_ICON_PLACEMENT && (
@@ -53,7 +54,10 @@ const ActionableTag = function ({
 ActionableTag.propTypes = {
   className: PropTypes.string,
   disabled: PropTypes.bool,
-  label: PropTypes.string.isRequired,
+  label: PropTypes.oneOfType([
+    PropTypes.string.isRequired,
+    PropTypes.node.isRequired
+  ]),
   icon: PropTypes.node,
   href: PropTypes.string,
   iconPlacement: PropTypes.oneOf([LEFT_ICON_PLACEMENT, RIGHT_ICON_PLACEMENT]),
@@ -61,6 +65,7 @@ ActionableTag.propTypes = {
   target: PropTypes.oneOf(['_self', '_blank', '_parent', '_top']),
   rel: PropTypes.arrayOf(PropTypes.oneOf(Object.values(LINK_TYPES))),
   linkFactory: PropTypes.func,
+  title: PropTypes.string,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 }
 

--- a/components/atom/tag/src/Standard.js
+++ b/components/atom/tag/src/Standard.js
@@ -41,10 +41,7 @@ StandardTag.propTypes = {
   onClose: PropTypes.func,
   closeIcon: PropTypes.node,
   icon: PropTypes.node,
-  label: PropTypes.oneOfType([
-    PropTypes.string.isRequired,
-    PropTypes.node.isRequired
-  ]),
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   className: PropTypes.string,
   title: PropTypes.string,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])

--- a/components/atom/tag/src/Standard.js
+++ b/components/atom/tag/src/Standard.js
@@ -8,7 +8,8 @@ const StandardTag = ({
   label,
   onClose,
   value,
-  disabled
+  disabled,
+  title
 }) => {
   const classNames = cx(className, closeIcon && 'sui-AtomTag-hasClose')
   const handleClick = ev => {
@@ -21,7 +22,7 @@ const StandardTag = ({
   return (
     <span className={classNames}>
       {icon && <span className="sui-AtomTag-icon">{icon}</span>}
-      <span className="sui-AtomTag-label" title={label}>
+      <span className="sui-AtomTag-label" title={title || label}>
         {label}
       </span>
       {closeIcon && !disabled && (
@@ -40,8 +41,12 @@ StandardTag.propTypes = {
   onClose: PropTypes.func,
   closeIcon: PropTypes.node,
   icon: PropTypes.node,
-  label: PropTypes.string.isRequired,
+  label: PropTypes.oneOfType([
+    PropTypes.string.isRequired,
+    PropTypes.node.isRequired
+  ]),
   className: PropTypes.string,
+  title: PropTypes.string,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 }
 

--- a/components/atom/tag/src/index.js
+++ b/components/atom/tag/src/index.js
@@ -67,10 +67,7 @@ AtomTag.displayName = 'AtomTag'
 
 AtomTag.propTypes = {
   disabled: PropTypes.bool,
-  label: PropTypes.oneOfType([
-    PropTypes.string.isRequired,
-    PropTypes.node.isRequired
-  ]),
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   icon: PropTypes.node,
   onClose: PropTypes.func,
   /**

--- a/components/atom/tag/src/index.js
+++ b/components/atom/tag/src/index.js
@@ -67,7 +67,10 @@ AtomTag.displayName = 'AtomTag'
 
 AtomTag.propTypes = {
   disabled: PropTypes.bool,
-  label: PropTypes.string.isRequired,
+  label: PropTypes.oneOfType([
+    PropTypes.string.isRequired,
+    PropTypes.node.isRequired
+  ]),
   icon: PropTypes.node,
   onClose: PropTypes.func,
   /**
@@ -102,6 +105,10 @@ AtomTag.propTypes = {
    * Tag size
    */
   size: PropTypes.oneOf(Object.values(SIZES)),
+  /**
+   * Tag title
+   */
+  title: PropTypes.string,
   /**
    * Tag type in order to color it as desired
    * from a high order component.


### PR DESCRIPTION
## Atom/tag
#### `🔍 Show` 


### Types of changes

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
Add title as a new prop and also allow the label as node proptype

### Screenshots - Animations
**Before**
<img width="249" alt="Screenshot 2022-07-13 at 08 32 10" src="https://user-images.githubusercontent.com/55990391/178666191-31495062-b3d9-4983-b0a8-7e1e6cd1fd39.png">

**After**
<img width="177" alt="Screenshot 2022-07-13 at 08 32 33" src="https://user-images.githubusercontent.com/55990391/178666284-7b2be667-c207-41d7-80d5-ad4615f13539.png">



