### PR TITLE
feat(components/molecule/select): Add readOnly styles to select component

### DIFF
--- a/components/molecule/select/src/styles/index.scss
+++ b/components/molecule/select/src/styles/index.scss
@@ -21,6 +21,11 @@ $class-select-atom-input-tags: '#{$class-select-atom-input}--withTags';
       cursor: pointer;
       display: flex;
 
+      #{$class-select-atom-input-input}--readOnly {
+        background: $bgc-atom-input;
+        color: $c-atom-input;
+      }
+
       .is-disabled & {
         cursor: default;
         #{$class-select-atom-input-input} {


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
`🔍 Show`
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: [#issueID ](https://jira.scmspain.com/browse/MTR-55842)

### Types of changes

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
Add readOnly styles into molecule select component

