### PR TITLE
feat(components/atom/icon): props spreading atom icon

### DIFF
--- a/components/atom/icon/src/Icon.js
+++ b/components/atom/icon/src/Icon.js
@@ -4,7 +4,7 @@ import Poly from '@s-ui/react-primitive-polymorphic-element'
 
 import {getAttributes} from './settings.js'
 
-const AtomIcon = ({as, className, children, outerRef, title}) => {
+const AtomIcon = ({as, className, children, outerRef, title, ...props}) => {
   return (
     <Poly
       as={as}
@@ -12,6 +12,7 @@ const AtomIcon = ({as, className, children, outerRef, title}) => {
       title={title}
       ref={outerRef}
       {...getAttributes(title)}
+      {...props}
     >
       {children}
     </Poly>

--- a/components/atom/icon/src/index.js
+++ b/components/atom/icon/src/index.js
@@ -12,24 +12,22 @@ import {
 
 const AtomIcon = ({
   as = 'span',
-  className,
   children,
   color = ATOM_ICON_COLORS.currentColor,
   size = ATOM_ICON_SIZES.small,
   render = ATOM_ICON_RENDERS.eager,
   ...props
 }) => {
-  const styles = cx(
+  const className = cx(
     BASE_CLASS,
     `${BASE_CLASS}--${size}`,
-    color && `${BASE_CLASS}--${color}`,
-    className
+    color && `${BASE_CLASS}--${color}`
   )
 
   const IconRender = render === ATOM_ICON_RENDERS.eager ? Icon : LazyIcon
 
   return (
-    <IconRender as={as} className={styles} {...props}>
+    <IconRender as={as} {...props} className={className}>
       {children}
     </IconRender>
   )
@@ -39,10 +37,6 @@ AtomIcon.displayName = 'AtomIcon'
 AtomIcon.propTypes = {
   /* Render the passed value as the correspondent HTML tag or the component if a function is passed */
   as: PropTypes.elementType,
-  /**
-   * Optional custom class.
-   */
-  className: PropTypes.string,
   /**
    * Determine color of the icon
    * Besides the primary color types, you could use currentColor to inherit the color from the parent.

--- a/components/atom/icon/src/index.js
+++ b/components/atom/icon/src/index.js
@@ -16,6 +16,7 @@ const AtomIcon = ({
   color = ATOM_ICON_COLORS.currentColor,
   size = ATOM_ICON_SIZES.small,
   render = ATOM_ICON_RENDERS.eager,
+  style: _ignoredStyle, // eslint-disable-line react/prop-types
   ...props
 }) => {
   const className = cx(

--- a/components/atom/icon/src/index.js
+++ b/components/atom/icon/src/index.js
@@ -12,21 +12,24 @@ import {
 
 const AtomIcon = ({
   as = 'span',
+  className,
   children,
   color = ATOM_ICON_COLORS.currentColor,
   size = ATOM_ICON_SIZES.small,
   render = ATOM_ICON_RENDERS.eager,
-  title
+  ...props
 }) => {
-  const className = cx(
+  const styles = cx(
     BASE_CLASS,
     `${BASE_CLASS}--${size}`,
-    color && `${BASE_CLASS}--${color}`
+    color && `${BASE_CLASS}--${color}`,
+    className
   )
 
   const IconRender = render === ATOM_ICON_RENDERS.eager ? Icon : LazyIcon
+
   return (
-    <IconRender as={as} className={className} title={title}>
+    <IconRender as={as} className={styles} {...props}>
       {children}
     </IconRender>
   )
@@ -36,6 +39,10 @@ AtomIcon.displayName = 'AtomIcon'
 AtomIcon.propTypes = {
   /* Render the passed value as the correspondent HTML tag or the component if a function is passed */
   as: PropTypes.elementType,
+  /**
+   * Optional custom class.
+   */
+  className: PropTypes.string,
   /**
    * Determine color of the icon
    * Besides the primary color types, you could use currentColor to inherit the color from the parent.
@@ -55,11 +62,7 @@ AtomIcon.propTypes = {
    * 'eager': The icon will be server-side rendered (default)
    * 'lazy': The icon will be loaded on client when visible
    */
-  render: PropTypes.oneOf(Object.values(ATOM_ICON_RENDERS)),
-  /**
-   * Adds a title for accesibility purposes
-   */
-  title: PropTypes.string
+  render: PropTypes.oneOf(Object.values(ATOM_ICON_RENDERS))
 }
 
 export default AtomIcon


### PR DESCRIPTION
## atom/icon
🔍 Show

### Types of changes

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
 The Icon component has recently been converted to a polymorphic element, which allows to now use of icons as buttons or any other tag if necessary.
Missing the spread of props in case of polymorphism, we were not able to pass tag-specific properties, such as the onClick event for button tags or similar scenarios.
