### PR TITLE
fix(components/molecule/select): read-only clickable inputTag behavior

### DIFF
--- a/components/molecule/select/demo/index.js
+++ b/components/molecule/select/demo/index.js
@@ -130,7 +130,7 @@ const Demo = () => (
 
       <div className={CLASS_DEMO_SECTION}>
         <h3>Small size</h3>
-        <MoleculeSelect
+        <MoleculeSelectWithState
           placeholder="Select a Country..."
           onChange={(_, {value}) => console.log(value)}
           iconArrowDown={<IconArrowDown />}
@@ -141,7 +141,7 @@ const Demo = () => (
               {name}
             </MoleculeSelectOption>
           ))}
-        </MoleculeSelect>
+        </MoleculeSelectWithState>
       </div>
 
       <div className={CLASS_DEMO_SECTION}>
@@ -150,7 +150,7 @@ const Demo = () => (
           State to highlight that can be <code>success</code>,{' '}
           <code>error</code> or <code>alert</code>
         </p>
-        <MoleculeSelect
+        <MoleculeSelectWithState
           placeholder="Select a Country..."
           onChange={(_, {value}) => console.log(value)}
           iconArrowDown={<IconArrowDown />}
@@ -161,7 +161,7 @@ const Demo = () => (
               {name}
             </MoleculeSelectOption>
           ))}
-        </MoleculeSelect>
+        </MoleculeSelectWithState>
       </div>
 
       <h2>Multiple Selection</h2>

--- a/components/molecule/select/demo/package.json
+++ b/components/molecule/select/demo/package.json
@@ -12,7 +12,6 @@
   "license": "ISC",
   "dependencies": {
     "@s-ui/hoc": "1",
-    "@s-ui/react-molecule-dropdown-option": "1",
-    "axios": "^0.21.1"
+    "@s-ui/react-molecule-dropdown-option": "1"
   }
 }

--- a/components/molecule/select/package.json
+++ b/components/molecule/select/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@s-ui/js": "2",
     "@s-ui/react-atom-input": "5",
+    "@s-ui/react-hooks": "1",
     "@s-ui/react-molecule-dropdown-list": "1",
-    "@s-ui/react-molecule-input-tags": "2"
+    "@s-ui/react-molecule-input-tags": "2",
+    "@s-ui/react-primitive-injector": "1"
   },
   "peerDependencies": {
     "@s-ui/component-dependencies": "1"

--- a/components/molecule/select/src/components/MoleculeInputSelect.js
+++ b/components/molecule/select/src/components/MoleculeInputSelect.js
@@ -1,7 +1,7 @@
-import {Children, cloneElement} from 'react'
-
 import cx from 'classnames'
 import PropTypes from 'prop-types'
+
+import Injector from '@s-ui/react-primitive-injector'
 
 import {
   CLASS_ARROW,
@@ -18,14 +18,9 @@ const MoleculeInputSelect = props => {
     [CLASS_ARROW_UP]: isOpen
   })
 
-  const extendedChildren = () =>
-    Children.toArray(children)
-      .filter(Boolean)
-      .map((child, index) => cloneElement(child, props))
-
   return (
     <div className={CLASS_CONTAINER} onClick={!disabled ? onClick : null}>
-      {extendedChildren()}
+      <Injector {...props}>{children}</Injector>
       <span className={classNames}>{iconArrow}</span>
     </div>
   )

--- a/components/molecule/select/src/components/MultipleSelection.js
+++ b/components/molecule/select/src/components/MultipleSelection.js
@@ -70,12 +70,12 @@ const MoleculeSelectFieldMultiSelection = props => {
         placeholder={!values.length ? placeholder : ''}
         optionsData={optionsData}
         autoComplete="off"
-        readOnly
         noBorder
         required={required}
         size={selectSize}
         tabIndex={tabIndex}
         maxTags={maxTags}
+        value=""
       >
         <MoleculeInputTags />
       </MoleculeInputSelect>

--- a/components/molecule/select/src/components/SingleSelection.js
+++ b/components/molecule/select/src/components/SingleSelection.js
@@ -44,7 +44,6 @@ const MoleculeSelectSingleSelection = props => {
         iconArrowDown={iconArrowDown}
         placeholder={placeholder}
         autoComplete="off"
-        readOnly
         required={required}
         size={selectSize}
         tabIndex={tabIndex}

--- a/components/molecule/select/src/config.js
+++ b/components/molecule/select/src/config.js
@@ -1,5 +1,7 @@
 import {Children} from 'react'
 
+import cx from 'classnames'
+
 export const BASE_CLASS = `sui-MoleculeSelect`
 export const CLASS_FOCUS = `${BASE_CLASS}--focus`
 export const CLASS_DISABLED = `is-disabled`
@@ -22,3 +24,15 @@ export const getOptionData = children => {
   })
   return optionsData
 }
+
+export const getClassName = ({state, errorState, focus, disabled}) =>
+  cx(
+    BASE_CLASS,
+    errorState && `${BASE_CLASS}--${SELECT_STATES.ERROR}`,
+    errorState === false && `${BASE_CLASS}--${SELECT_STATES.SUCCESS}`,
+    state && `${BASE_CLASS}--${state}`,
+    {
+      [CLASS_FOCUS]: focus,
+      [CLASS_DISABLED]: disabled
+    }
+  )

--- a/components/molecule/select/src/index.js
+++ b/components/molecule/select/src/index.js
@@ -5,29 +5,28 @@ import {
   useCallback,
   useEffect,
   useRef,
-  useState
+  useState,
+  forwardRef
 } from 'react'
 
-import cx from 'classnames'
 import PropTypes from 'prop-types'
 
 import {getTarget} from '@s-ui/js/lib/react'
 import {inputSizes as SELECT_SIZES} from '@s-ui/react-atom-input'
+import useMergeRefs from '@s-ui/react-hooks/lib/useMergeRefs'
 import {moleculeDropdownListSizes as SIZES} from '@s-ui/react-molecule-dropdown-list'
 
 import MoleculeSelectMultipleSelection from './components/MultipleSelection.js'
 import MoleculeSelectSingleSelection from './components/SingleSelection.js'
 import {
-  BASE_CLASS,
-  CLASS_DISABLED,
-  CLASS_FOCUS,
   ENABLED_KEYS,
   getOptionData,
   SELECT_STATES,
-  SELECTION_KEYS
+  SELECTION_KEYS,
+  getClassName
 } from './config.js'
 
-const MoleculeSelect = props => {
+const MoleculeSelect = forwardRef((props, forwardedRef) => {
   const {
     isOpen,
     onToggle,
@@ -42,6 +41,7 @@ const MoleculeSelect = props => {
   } = props
   const refMoleculeSelect = useRef(refMoleculeSelectFromProps)
   const refsMoleculeSelectOptions = useRef([])
+  const ref = useMergeRefs(forwardedRef, refMoleculeSelect)
 
   const [isOpenState, setIsOpenState] = useState(isOpen)
   useEffect(() => setIsOpenState(isOpen), [isOpen, setIsOpenState])
@@ -61,16 +61,7 @@ const MoleculeSelect = props => {
       })
     })
 
-  const className = cx(
-    BASE_CLASS,
-    errorState && `${BASE_CLASS}--${SELECT_STATES.ERROR}`,
-    errorState === false && `${BASE_CLASS}--${SELECT_STATES.SUCCESS}`,
-    state && `${BASE_CLASS}--${state}`,
-    {
-      [CLASS_FOCUS]: focus,
-      [CLASS_DISABLED]: disabled
-    }
-  )
+  const className = getClassName({state, errorState, focus, disabled})
 
   const closeList = useCallback((ev, {isOutsideEvent = false}) => {
     setIsOpenState(false)
@@ -144,10 +135,13 @@ const MoleculeSelect = props => {
       setTimeout(() => focusFirstOption(ev))
     }
   }
+  const Select = multiselection
+    ? MoleculeSelectMultipleSelection
+    : MoleculeSelectSingleSelection
 
   return (
     <div
-      ref={refMoleculeSelect}
+      ref={ref}
       tabIndex="0"
       className={className}
       onKeyDown={handleKeyDown}
@@ -156,30 +150,18 @@ const MoleculeSelect = props => {
       onClick={handleClick}
       aria-label={ariaLabel}
     >
-      {multiselection ? (
-        <MoleculeSelectMultipleSelection
-          refMoleculeSelect={refMoleculeSelect}
-          optionsData={optionsData}
-          isOpen={isOpenState}
-          onToggle={handleToggle}
-          {...props}
-        >
-          {extendedChildren}
-        </MoleculeSelectMultipleSelection>
-      ) : (
-        <MoleculeSelectSingleSelection
-          refMoleculeSelect={refMoleculeSelect}
-          optionsData={optionsData}
-          isOpen={isOpenState}
-          onToggle={handleToggle}
-          {...props}
-        >
-          {extendedChildren}
-        </MoleculeSelectSingleSelection>
-      )}
+      <Select
+        refMoleculeSelect={refMoleculeSelect}
+        optionsData={optionsData}
+        isOpen={isOpenState}
+        onToggle={handleToggle}
+        {...props}
+      >
+        {extendedChildren}
+      </Select>
     </div>
   )
-}
+})
 
 MoleculeSelect.propTypes = {
   /** children */

--- a/components/molecule/select/src/styles/index.scss
+++ b/components/molecule/select/src/styles/index.scss
@@ -21,13 +21,15 @@ $class-select-atom-input-tags: '#{$class-select-atom-input}--withTags';
       cursor: pointer;
       display: flex;
 
-      #{$class-select-atom-input-input}--readOnly {
+      #{$class-select-atom-input-input} {
+        caret-color: transparent;
         background: $bgc-atom-input;
         color: $c-atom-input;
       }
 
       .is-disabled & {
         cursor: default;
+
         #{$class-select-atom-input-input} {
           -webkit-text-fill-color: $c-molecule-select-disabled;
 
@@ -99,6 +101,7 @@ $class-select-atom-input-tags: '#{$class-select-atom-input}--withTags';
           border-color: $bdc-molecule-select-input-with-state;
         }
       }
+
       &#{$base-class}--focus #{$base-class}-inputSelect-container {
         .sui-AtomInput-input,
         .sui-AtomInput--withTags {


### PR DESCRIPTION
## Molecule/Select
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
`🔍 Show`
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
Select does not set the inputTag element as a readOnly

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [x] 🧠 Refactor
- [ ] 💄 Styles

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
