### PR TITLE
test(components/molecule/inputTags): increase coverage

### DIFF
--- a/components/molecule/inputTags/src/index.js
+++ b/components/molecule/inputTags/src/index.js
@@ -84,8 +84,14 @@ const MoleculeInputTags = forwardRef(
       ev.preventDefault()
       if (value) {
         const nextTags = [...tags]
+        let options
         if (allowDuplicates || !isDuplicate(tags, value)) {
-          nextTags.push(value)
+          if (optionsData) {
+            options = optionsData.filter(
+              optionData => optionData.label === value
+            )[0]
+          }
+          nextTags.push(options || value)
         }
         setTags(nextTags)
         setValue('')
@@ -100,7 +106,7 @@ const MoleculeInputTags = forwardRef(
       }
     }
 
-    const handleInputChange = (ev, {value, args}) => {
+    const handleInputChange = (ev, {value, ...args}) => {
       setValue(value)
       isFunction(onInputChange) && onInputChange(ev, {...args, value, tags})
     }


### PR DESCRIPTION
## Molecule/InputTags
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
`🔍 Show`
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [x] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->

InputTags:
- from : 
	- 53.84% Statements 28/52
	- 53.65% Branches 22/41
	- 23.07% Functions 3/13
	- 59.57% Lines 28/47
![image](https://user-images.githubusercontent.com/1674036/182805541-757584f7-fba0-44d6-b654-5200df67aa3e.png)
- to
	-  92.72% Statements 51/55
	- 93.33% Branches 42/45
	- 85.71% Functions 12/14
	- 96% Lines 48/50
![image](https://user-images.githubusercontent.com/1674036/182805651-349dc34d-9189-4f9d-b465-113e4f7511f5.png)

### RAW data
<details>
  <summary>from</summary>
  
  ```javascript
    {
   	"/inputTags/src/config.js":{
     	 "lines":{
        	 "total":11,
	         "covered":8,
    	     "skipped":0,
	         "pct":72.72
    	  },
	      "functions":{
	         "total":0,
	         "covered":0,
	         "skipped":0,
	         "pct":0
	      },
	      "statements":{
  	       	"total":12,
	         "covered":8,
    	     "skipped":0,
        	 "pct":66.66
	      },
    	  "branches":{
	         "total":2,
	         "covered":0,
	         "skipped":0,
	         "pct":0
	      }
	   },
	   "/inputTags/src/index.js":{
	      "lines":{
	         "total":20,
	         "covered":36,
	         "skipped":0,
	         "pct":55.55
	      },
	      "functions":{
	         "total":10,
	         "covered":3,
	         "skipped":0,
	         "pct":30
	      },
	      "statements":{
	         "total":40,
	         "covered":20,
	         "skipped":0,
	         "pct":56.41
	      },
	      "branches":{
	         "total":39,
	         "covered":22,
	         "skipped":0,
	         "pct":56.41
	      }
	   }
	}
  ```
</details>

<details>
  <summary>to</summary>
  
  ```javascript
    {
	   "/inputTags/src/config.js":{
	      "lines":{
	         "total":11,
	         "covered":11,
	         "skipped":0,
	         "pct":100
	      },
	      "functions":{
	         "total":3,
	         "covered":3,
	         "skipped":0,
	         "pct":100
	      },
	      "statements":{
	         "total":12,
	         "covered":12,
	         "skipped":0,
	         "pct":100
	      },
	      "branches":{
	         "total":2,
	         "covered":2,
	         "skipped":0,
	         "pct":100
	      }
	   },
	   "/inputTags/src/index.js":{
	      "lines":{
	         "total":39,
	         "covered":37,
	         "skipped":0,
	         "pct":94.87
	      },
	      "functions":{
	         "total":11,
	         "covered":9,
	         "skipped":0,
	         "pct":81.81
	      },
	      "statements":{
	         "total":43,
	         "covered":39,
	         "skipped":0,
	         "pct":90.69
	      },
	      "branches":{
	         "total":43,
	         "covered":40,
	         "skipped":0,
	         "pct":93.02
	      }
	   }
	}
  ```
</details>