### PR TITLE
feat(components/atom/button): Add elevation prop and focus var

### DIFF
--- a/components/atom/button/README.md
+++ b/components/atom/button/README.md
@@ -178,7 +178,7 @@ import Button from '@s-ui/react-atom-button'
 return (
   <Button
     link
-    href="http://www.schibsted.com/"
+    href="https://www.adevinta.com"
     target="_blank"
     rel="nofollow noopener"
   >
@@ -192,7 +192,7 @@ output:
 ```html
 <a
   class="sui-AtomButton sui-AtomButton--link"
-  href="http://www.schibsted.com/"
+  href="https://www.adevinta.com"
   target="_blank"
   >Link</a
 >

--- a/components/atom/button/README.md
+++ b/components/atom/button/README.md
@@ -17,12 +17,15 @@ $ npm install @s-ui/react-atom-button --save
 ```js
 import Button from '@s-ui/react-atom-button'
 
-return (<div>
-  <Button>Normal</Button>
-  <Button focused>Focused</Button>
-  <Button size='large' disabled>Disabled</Button>
-</div>)
-
+return (
+  <div>
+    <Button>Normal</Button>
+    <Button focused>Focused</Button>
+    <Button size="large" disabled>
+      Disabled
+    </Button>
+  </div>
+)
 ```
 
 ### Flexible props
@@ -32,17 +35,19 @@ All props available from regular buttons can be used.
 ```js
 import Button from '@s-ui/react-atom-button'
 
-return (<div>
-  <Button onClick={() => alert('Primary with onClick')}>
-    Primary with onClick
-  </Button>
-  <Button type='accent' title="Title: Lorem Ipsum">
-    Accent with title
-  </Button>
-  <Button type='secondary' className='customClass'>
-    Secondary with className
-  </Button>
-</div>)
+return (
+  <div>
+    <Button onClick={() => alert('Primary with onClick')}>
+      Primary with onClick
+    </Button>
+    <Button type="accent" title="Title: Lorem Ipsum">
+      Accent with title
+    </Button>
+    <Button type="secondary" className="customClass">
+      Secondary with className
+    </Button>
+  </div>
+)
 ```
 
 ### Button with AtomIcon
@@ -53,21 +58,25 @@ You could use the `AtomButton` along the `AtomIcon` in order to show the button 
 import Button from '@s-ui/react-atom-button'
 import AtomIcon from '@s-ui/react-atom-icon'
 
-const Icon = <AtomIcon>
-  <svg viewBox="0 0 24 24">
-    <path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" />
-  </svg>
-</AtomIcon>
+const Icon = (
+  <AtomIcon>
+    <svg viewBox="0 0 24 24">
+      <path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" />
+    </svg>
+  </AtomIcon>
+)
 
-return (<div>
-  <Button leftIcon={Icon} />
-  <Button size="large" rightIcon={Icon} >
-    Large icon
-  </Button>
-  <Button size="small" rightIcon={Icon} >
-    Small icon
-  </Button>
-</div>)
+return (
+  <div>
+    <Button leftIcon={Icon} />
+    <Button size="large" rightIcon={Icon}>
+      Large icon
+    </Button>
+    <Button size="small" rightIcon={Icon}>
+      Small icon
+    </Button>
+  </div>
+)
 ```
 
 ### Button shape
@@ -97,6 +106,20 @@ return (
   <>
     <AtomButton isLoading />
     <AtomButton loadingText="Submitting" isLoading />
+  </>
+)
+```
+
+### Button with elevation
+
+Set `elevation` prop to display a shadow around the button. If it's not set no shadow will be shown.
+
+```js
+import Button from '@s-ui/react-atom-button'
+return (
+  <>
+    <Button elevation="medium">Example</Button>
+    <Button elevation="large">Example</Button>
   </>
 )
 ```
@@ -131,8 +154,12 @@ return (
       <input type="text" placeholder="Put your name" />
     </div>
     <div>
-      <Button isButton onClick={() => window.alert('Click!')}>Click Me!</Button>
-      <Button isButton onClick={() => window.alert('Click!')}>Click Me!</Button>
+      <Button isButton onClick={() => window.alert('Click!')}>
+        Click Me!
+      </Button>
+      <Button isButton onClick={() => window.alert('Click!')}>
+        Click Me!
+      </Button>
     </div>
     <div>
       <Button isSubmit>Submit</Button>
@@ -142,21 +169,33 @@ return (
 ```
 
 ### Rendering a link
+
 When `link` property is passed, the component will render an html link.
 
 ```js
 import Button from '@s-ui/react-atom-button'
 
 return (
-  <Button link href='http://www.schibsted.com/' target='_blank' rel="nofollow noopener">Link</Button>
+  <Button
+    link
+    href="http://www.schibsted.com/"
+    target="_blank"
+    rel="nofollow noopener"
+  >
+    Link
+  </Button>
 )
-
 ```
 
 output:
 
 ```html
-<a class="sui-AtomButton sui-AtomButton--link" href="http://www.schibsted.com/" target='_blank'>Link</a>
+<a
+  class="sui-AtomButton sui-AtomButton--link"
+  href="http://www.schibsted.com/"
+  target="_blank"
+  >Link</a
+>
 ```
 
 > **Find full description and more examples in the [demo page](https://sui-components.now.sh/workbench/atom/button).**

--- a/components/atom/button/demo/index.js
+++ b/components/atom/button/demo/index.js
@@ -224,7 +224,7 @@ const Demo = () => {
             button. If it's not set no shadow will be shown.
           </Paragraph>
         </div>
-        <Grid cols={2} gutter={10}>
+        <Grid cols={atomButtonElevationsIterator.length} gutter={10}>
           {atomButtonElevationsIterator.map(([{elevation}], index) => (
             <Fragment key={index}>
               <Cell style={flexCenteredStyle}>

--- a/components/atom/button/demo/index.js
+++ b/components/atom/button/demo/index.js
@@ -25,6 +25,7 @@ import {
   atomButtonAlignmentIterator,
   atomButtonColorsIterator,
   atomButtonDesignsIterator,
+  atomButtonElevationsIterator,
   atomButtonShapesIterator,
   atomButtonSizesIterator,
   atomButtonSocialColorsIterator,
@@ -209,6 +210,31 @@ const Demo = () => {
           {atomButtonSizesIterator.map(([{size}], index) => (
             <Cell key={index} style={flexCenteredStyle}>
               <AtomButton size={size} color="primary">
+                Button
+              </AtomButton>
+            </Cell>
+          ))}
+        </Grid>
+      </Article>
+      <Article className={CLASS_SECTION}>
+        <H2>Elevation</H2>
+        <div>
+          <Paragraph>
+            Use <Code>elevation</Code> prop to display a shadow around the
+            button. If it's not set no shadow will be shown.
+          </Paragraph>
+        </div>
+        <Grid cols={2} gutter={10}>
+          {atomButtonElevationsIterator.map(([{elevation}], index) => (
+            <Fragment key={index}>
+              <Cell style={flexCenteredStyle}>
+                <Label>{elevation}</Label>
+              </Cell>
+            </Fragment>
+          ))}
+          {atomButtonElevationsIterator.map(([{elevation}], index) => (
+            <Cell key={index} style={flexCenteredStyle}>
+              <AtomButton elevation={elevation} color="primary">
                 Button
               </AtomButton>
             </Cell>

--- a/components/atom/button/demo/settings.js
+++ b/components/atom/button/demo/settings.js
@@ -4,6 +4,7 @@ import {
   atomButtonAlignment,
   atomButtonColors,
   atomButtonDesigns,
+  atomButtonElevations,
   atomButtonShapes,
   atomButtonSizes
 } from '../src/index.js'
@@ -64,6 +65,10 @@ export const atomButtonSocialColorsIterator = Object.values(atomButtonColors)
 export const atomButtonDesignsIterator = Object.values(atomButtonDesigns).map(
   (design, index) => [{design}, index]
 )
+
+export const atomButtonElevationsIterator = Object.values(
+  atomButtonElevations
+).map((elevation, index) => [{elevation}, index])
 
 export const atomButtonSizesIterator = [
   atomButtonSizes.SMALL,

--- a/components/atom/button/src/config.js
+++ b/components/atom/button/src/config.js
@@ -20,6 +20,14 @@ export const DESIGNS = {
   LINK: 'link'
 }
 
+/**
+ * A set of elevations that define the box shadow
+ */
+export const ELEVATIONS = {
+  MEDIUM: 'medium',
+  LARGE: 'large'
+}
+
 export const ALIGNMENT = {
   CENTER: 'center',
   LEFT: 'left',

--- a/components/atom/button/src/index.js
+++ b/components/atom/button/src/index.js
@@ -14,6 +14,7 @@ import {
   COLORS,
   deprecated,
   DESIGNS,
+  ELEVATIONS,
   getModifiers,
   getPropsWithDefaultValues,
   GROUP_POSITIONS,
@@ -45,6 +46,7 @@ const AtomButton = forwardRef((props, ref) => {
     title,
     type,
     shape,
+    elevation,
     isFitted,
     selected,
     value
@@ -66,7 +68,8 @@ const AtomButton = forwardRef((props, ref) => {
     {[`${CLASS}--${shape}`]: Object.values(SHAPES).includes(shape)},
     {
       [`${CLASS}--loading`]: isLoading,
-      [`${CLASS}--fitted`]: isFitted
+      [`${CLASS}--fitted`]: isFitted,
+      [`${CLASS}--elevation-${elevation}`]: !!elevation
     },
     className
   )
@@ -218,6 +221,10 @@ AtomButton.propTypes = {
    */
   fullWidth: PropTypes.bool,
   /**
+   * Size of button shadow
+   */
+  elevation: PropTypes.oneOf(Object.values(ELEVATIONS)),
+  /**
    * Icon to be added on the left of the content
    */
   leftIcon: PropTypes.node,
@@ -268,3 +275,4 @@ export {SIZES as atomButtonSizes}
 export {TYPES as atomButtonTypes}
 export {ALIGNMENT as atomButtonAlignment}
 export {SHAPES as atomButtonShapes}
+export {ELEVATIONS as atomButtonElevations}

--- a/components/atom/button/src/styles/index.scss
+++ b/components/atom/button/src/styles/index.scss
@@ -244,6 +244,24 @@ $base-class: '.sui-AtomButton';
     }
   }
 
+  @each $key-bxsh, $bxsh in $bxsh-atom-button {
+    &--elevation-#{$key-bxsh} {
+      box-shadow: $bxsh;
+
+      &#{$base-class}--primary {
+        box-shadow: $bxsh;
+
+        &#{$base-class}--negative {
+          box-shadow: $bxsh;
+        }
+      }
+    }
+  }
+
+  &:focus {
+    box-shadow: $bxsh-atom-butto-focus;
+  }
+
   &--squared {
     border-radius: 0;
   }

--- a/components/atom/button/src/styles/index.scss
+++ b/components/atom/button/src/styles/index.scss
@@ -259,7 +259,7 @@ $base-class: '.sui-AtomButton';
   }
 
   &:focus {
-    box-shadow: $bxsh-atom-butto-focus;
+    box-shadow: $bxsh-atom-button-focus;
   }
 
   &--squared {

--- a/components/atom/button/src/styles/settings.scss
+++ b/components/atom/button/src/styles/settings.scss
@@ -103,7 +103,7 @@ $bxsh-atom-button: (
   large: $bxsh-l,
   medium: $bxsh-m
 ) !default;
-$bxsh-atom-buttom-focus: none !default;
+$bxsh-atom-button-focus: none !default;
 
 $tt-atom-button: none !default;
 

--- a/components/atom/button/src/styles/settings.scss
+++ b/components/atom/button/src/styles/settings.scss
@@ -103,7 +103,7 @@ $bxsh-atom-button: (
   large: $bxsh-l,
   medium: $bxsh-m
 ) !default;
-$bxsh-atom-butto-focus: none !default;
+$bxsh-atom-buttom-focus: none !default;
 
 $tt-atom-button: none !default;
 

--- a/components/atom/button/src/styles/settings.scss
+++ b/components/atom/button/src/styles/settings.scss
@@ -99,6 +99,12 @@ $p-atom-button-group-sides: $p-l !default;
 $bxsh-atom-button-solid-primary: none !default;
 $bxsh-atom-button-solid-primary-negative: none !default;
 
+$bxsh-atom-button: (
+  large: $bxsh-l,
+  medium: $bxsh-m
+) !default;
+$bxsh-atom-butto-focus: none !default;
+
 $tt-atom-button: none !default;
 
 $icon-fill-color: currentColor !default;

--- a/components/atom/button/test/index.test.js
+++ b/components/atom/button/test/index.test.js
@@ -33,6 +33,7 @@ describe(json.name, () => {
       'atomButtonTypes',
       'atomButtonAlignment',
       'atomButtonShapes',
+      'atomButtonElevations',
       'default'
     ]
 
@@ -45,6 +46,7 @@ describe(json.name, () => {
       atomButtonTypes,
       atomButtonAlignment,
       atomButtonShapes,
+      atomButtonElevations,
       default: AtomButton,
       ...others
     } = library


### PR DESCRIPTION
## atom/button

### Types of changes
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
This PR:
- Add `elevation` prop that can be used to display a shadow around the button. If it's not set no shadow will be shown
- Add `focus` custom shadow. By default is set to `none` so no breaking change is performed. Nevertheless each vertical should override `$bxsh-atom-butto-focus` variable since focus is really important in terms of accessibility (e.g. to use keyword navigation the user should visually know which element is focused)

### Screenshots - Animations

Documentation
![Screenshot 2022-08-17 at 16 33 15](https://user-images.githubusercontent.com/6877967/185162232-f23a9dd8-a668-4b99-8d7a-3e50e16c4cb0.png)

Focus
![Screenshot 2022-08-17 at 16 03 37](https://user-images.githubusercontent.com/6877967/185161772-bc4d7961-b856-4a07-aa99-00a294386336.png)

