### PR TITLE
Feat/image editor improvement

### DIFF
--- a/components/molecule/imageEditor/README.md
+++ b/components/molecule/imageEditor/README.md
@@ -25,7 +25,6 @@ return (
     onChange={handleChange}
     rotateLabelIcon={<RotateIcon>}
     rotateLabelText="Rotate"
-    returnBlobObject={true}
   />
 )
 ```

--- a/components/molecule/imageEditor/README.md
+++ b/components/molecule/imageEditor/README.md
@@ -25,6 +25,7 @@ return (
     onChange={handleChange}
     rotateLabelIcon={<RotateIcon>}
     rotateLabelText="Rotate"
+    returnBlobObject={true}
   />
 )
 ```

--- a/components/molecule/imageEditor/src/index.js
+++ b/components/molecule/imageEditor/src/index.js
@@ -15,6 +15,7 @@ const MoleculeImageEditor = ({
   image,
   onChange,
   onCropping = noop,
+  returnBlobObject = false,
   rotateLabelIcon,
   rotateLabelText
 }) => {
@@ -31,7 +32,8 @@ const MoleculeImageEditor = ({
       const croppedImage = await getCroppedImg(
         image,
         croppedAreaPixels,
-        rotationDegrees
+        rotationDegrees,
+        returnBlobObject
       )
       onChange(croppedImage)
       onCropping(false)
@@ -104,6 +106,7 @@ MoleculeImageEditor.propTypes = {
   image: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   onCropping: PropTypes.func,
+  returnBlobObject: PropTypes.bool,
   rotateLabelIcon: PropTypes.node,
   rotateLabelText: PropTypes.string
 }

--- a/components/molecule/imageEditor/src/index.js
+++ b/components/molecule/imageEditor/src/index.js
@@ -15,7 +15,6 @@ const MoleculeImageEditor = ({
   image,
   onChange,
   onCropping = noop,
-  returnBlobObject = false,
   rotateLabelIcon,
   rotateLabelText
 }) => {
@@ -29,13 +28,12 @@ const MoleculeImageEditor = ({
     async (croppedArea, croppedAreaPixels) => {
       const rotationDegrees = getRotationDegrees(rotation)
       onCropping(true)
-      const croppedImage = await getCroppedImg(
+      const [croppedImageUrl, croppedImageBlobObject] = await getCroppedImg(
         image,
         croppedAreaPixels,
-        rotationDegrees,
-        returnBlobObject
+        rotationDegrees
       )
-      onChange(croppedImage)
+      onChange(croppedImageUrl, croppedImageBlobObject)
       onCropping(false)
     },
     [rotation, onCropping, image, onChange]
@@ -106,7 +104,6 @@ MoleculeImageEditor.propTypes = {
   image: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   onCropping: PropTypes.func,
-  returnBlobObject: PropTypes.bool,
   rotateLabelIcon: PropTypes.node,
   rotateLabelText: PropTypes.string
 }

--- a/components/molecule/imageEditor/src/utils/cropImage.js
+++ b/components/molecule/imageEditor/src/utils/cropImage.js
@@ -16,14 +16,8 @@ function getRadianAngle(degreeValue) {
  * @param {File} image - Image File url
  * @param {Object} pixelCrop - pixelCrop Object provided by react-easy-crop
  * @param {number} rotation - optional rotation parameter
- * @param {Boolean} returnBlobObject - If true, returns a blob object, if not returns the blob's accessible url
  */
-export default async function getCroppedImg(
-  imageSrc,
-  pixelCrop,
-  rotation = 0,
-  returnBlobObject
-) {
+export default async function getCroppedImg(imageSrc, pixelCrop, rotation = 0) {
   const image = await createImage(imageSrc)
   const canvas = document.createElement('canvas')
   const ctx = canvas.getContext('2d')
@@ -63,8 +57,8 @@ export default async function getCroppedImg(
   // As a blob
   return new Promise(resolve => {
     canvas.toBlob(file => {
-      const result = returnBlobObject ? file : URL.createObjectURL(file)
-      resolve(result)
+      const fileUrl = URL.createObjectURL(file)
+      resolve(fileUrl, file)
     }, 'image/jpeg')
   })
 }

--- a/components/molecule/imageEditor/src/utils/cropImage.js
+++ b/components/molecule/imageEditor/src/utils/cropImage.js
@@ -16,8 +16,14 @@ function getRadianAngle(degreeValue) {
  * @param {File} image - Image File url
  * @param {Object} pixelCrop - pixelCrop Object provided by react-easy-crop
  * @param {number} rotation - optional rotation parameter
+ * @param {Boolean} returnBlobObject - If true, returns a blob object, if not returns the blob's accessible url
  */
-export default async function getCroppedImg(imageSrc, pixelCrop, rotation = 0) {
+export default async function getCroppedImg(
+  imageSrc,
+  pixelCrop,
+  rotation = 0,
+  returnBlobObject
+) {
   const image = await createImage(imageSrc)
   const canvas = document.createElement('canvas')
   const ctx = canvas.getContext('2d')
@@ -57,7 +63,8 @@ export default async function getCroppedImg(imageSrc, pixelCrop, rotation = 0) {
   // As a blob
   return new Promise(resolve => {
     canvas.toBlob(file => {
-      resolve(URL.createObjectURL(file))
+      const result = returnBlobObject ? file : URL.createObjectURL(file)
+      resolve(result)
     }, 'image/jpeg')
   })
 }

--- a/components/molecule/imageEditor/src/utils/cropImage.js
+++ b/components/molecule/imageEditor/src/utils/cropImage.js
@@ -58,7 +58,7 @@ export default async function getCroppedImg(imageSrc, pixelCrop, rotation = 0) {
   return new Promise(resolve => {
     canvas.toBlob(file => {
       const fileUrl = URL.createObjectURL(file)
-      resolve(fileUrl, file)
+      resolve([fileUrl, file])
     }, 'image/jpeg')
   })
 }


### PR DESCRIPTION
## Molecule/ImageEditor

#### `❓ Ask`

**TASK**: [MTR-56617](https://jira.scmspain.com/browse/MTR-56617)

### Types of changes

- [X] ✨ New feature (non-breaking change which adds functionality)

### Description, Motivation and Context

**Motivation**
In coches.net pro we are working to implement a page from which users can edit their account details. One of these details is the user profile image.

Following the UX specifications, we need a way to not only select a new user image, but also crop and edit that image before submitting it. We've selected `molecule/imageEditor` to achieve this goal.

However, every time an image is edited on `molecule/imageEditor` a blob url is returned by default, and it would be easier for us to directly receive the blob object instead of a url, in order to be able to submit the result as part of a `FormData` object. 

**Technical observations**
Technically, it should be possible to reverse the url-generation process by performing an http request to retrieve the blob url content, and initialize a blob object with that content, however we think that this approach adds too much complexity to our domain, and doesn't seem to be a performance-oriented approach (internally, the blob object is duplicated, first in the `imageEditor` component, and later from our side).

**Changes**
This PR adds the possibility of directly retrieving a blob object when using the `molecule/imageEditor` component.
