### PR TITLE
feat(components/molecule/imageEditor): Add a preview mode to molecule/imageEditor to optimize image

### DIFF
--- a/components/molecule/imageEditor/package.json
+++ b/components/molecule/imageEditor/package.json
@@ -19,6 +19,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@s-ui/js": "2",
     "@s-ui/react-atom-slider": "1",
     "react-easy-crop": "3.4.0"
   }

--- a/components/molecule/imageEditor/src/config.js
+++ b/components/molecule/imageEditor/src/config.js
@@ -1,3 +1,4 @@
 export const baseClass = 'sui-MoleculeImageEditor'
 export const DEFAULT_ASPECT = 4 / 3
 export const noop = () => {}
+export const DEBOUNCING_TIME = 100

--- a/components/molecule/imageEditor/src/index.js
+++ b/components/molecule/imageEditor/src/index.js
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useRef, useState} from 'react'
+import {useCallback, useState} from 'react'
 import Cropper from 'react-easy-crop'
 
 import PropTypes from 'prop-types'
@@ -10,7 +10,6 @@ import {baseClass, DEFAULT_ASPECT, noop} from './config.js'
 
 const MoleculeImageEditor = ({
   aspect = DEFAULT_ASPECT,
-  previewOnlyMode = false,
   cropLabelIcon,
   cropLabelText,
   image,
@@ -22,17 +21,11 @@ const MoleculeImageEditor = ({
   const [crop, setCrop] = useState({x: 0, y: 0})
   const [rotation, setRotation] = useState(0)
   const [zoom, setZoom] = useState(0)
-  const getRotationDegrees = rotation => (rotation * 360) / 100
 
-  const lastCrop = useRef(null)
+  const getRotationDegrees = rotation => (rotation * 360) / 100
 
   const onCropComplete = useCallback(
     async (croppedArea, croppedAreaPixels) => {
-      if (previewOnlyMode) {
-        lastCrop.current = {croppedArea, croppedAreaPixels}
-        return
-      }
-
       const rotationDegrees = getRotationDegrees(rotation)
       onCropping(true)
       const [croppedImageUrl, croppedImageBlobObject] = await getCroppedImg(
@@ -43,15 +36,8 @@ const MoleculeImageEditor = ({
       onChange(croppedImageUrl, croppedImageBlobObject)
       onCropping(false)
     },
-    [previewOnlyMode, rotation, onCropping, image, onChange]
+    [rotation, onCropping, image, onChange]
   )
-
-  useEffect(() => {
-    if (!previewOnlyMode && lastCrop.current !== null) {
-      const {croppedArea, croppedAreaPixels} = lastCrop.current
-      onCropComplete(croppedArea, croppedAreaPixels)
-    }
-  }, [previewOnlyMode, onCropComplete])
 
   return (
     <div className={baseClass}>
@@ -113,7 +99,6 @@ const MoleculeImageEditor = ({
 MoleculeImageEditor.displayName = 'MoleculeImageEditor'
 MoleculeImageEditor.propTypes = {
   aspect: PropTypes.number,
-  previewOnlyMode: PropTypes.bool,
   cropLabelIcon: PropTypes.node,
   cropLabelText: PropTypes.string,
   image: PropTypes.string.isRequired,


### PR DESCRIPTION
## Molecule/ImageEditor

#### `❓ Ask`

### Types of changes

- [X] ✨ New feature (non-breaking change which adds functionality)

### Description, Motivation and Context

ImageEditor is currently calculating a new image every time the user makes zoom or rotates an image. Which, with a normal use, could happen between 50 and 100 times just by sliding the zoom or rotation slide.

This is causing a bad performance. Additionally, as we don't know which is the final calculated image, we're not sure when the  `save` button of our web-app can be enabled to finish the process.

To solve this problematic, this proposal debounces the execution of some critical functions, to ensure that image is calculate just when needed.

Co-authored with @andresin87 

### Screenshots - Animations

There aren't visual changes.