### PR TITLE
feat(components/molecule/imageEditor): Add two scss tokens to parametrize the imageEditor tokens

### DIFF
--- a/components/molecule/imageEditor/src/styles/index.scss
+++ b/components/molecule/imageEditor/src/styles/index.scss
@@ -10,7 +10,7 @@ $base-class: '.sui-MoleculeImageEditor';
   &-slider {
     align-items: center;
     display: flex;
-    margin-top: $m-xl;
+    margin-top: $mt-molecule-image-editor-slider;
 
     .sui-AtomSlider {
       flex: 1;

--- a/components/molecule/imageEditor/src/styles/index.scss
+++ b/components/molecule/imageEditor/src/styles/index.scss
@@ -4,7 +4,7 @@ $base-class: '.sui-MoleculeImageEditor';
   &-crop {
     position: relative;
     height: $h-molecule-image-editor;
-    margin-bottom: $m-xxl;
+    margin-bottom: $mb-molecule-image-editor-crop;
   }
 
   &-slider {

--- a/components/molecule/imageEditor/src/styles/settings.scss
+++ b/components/molecule/imageEditor/src/styles/settings.scss
@@ -1,3 +1,4 @@
 $h-molecule-image-editor: 300px !default;
+$mb-molecule-image-editor-crop: $m-xxl !default;
 $mt-molecule-image-editor-slider: $m-xl !default;
 $w-molecule-image-editor-label-text: 50px !default;

--- a/components/molecule/imageEditor/src/styles/settings.scss
+++ b/components/molecule/imageEditor/src/styles/settings.scss
@@ -1,2 +1,3 @@
 $h-molecule-image-editor: 300px !default;
+$mt-molecule-image-editor-slider: $m-xl !default;
 $w-molecule-image-editor-label-text: 50px !default;


### PR DESCRIPTION
#### `❓ Ask`

### Types of changes

- [X] ✨ New feature (non-breaking change which adds functionality)
- [X] 💄 Styles

### Description, Motivation and Context

In cnetpro we're implementing a page from where the user is able to edit its details.
We're using the `molecule/imageEditor` component to let the user select an image and crop/rotate it.

To customize the `imageEditor` layout we need a way to edit the `margin-top` css attribute from all `sui-MoleculeImageEditor-slider` elements and the `margin-bottom` css attribute from the crop element.

### Screenshots - Animations

Just two new scss tokens. Doesn't modify how the component is displayed by default.
