### PR TITLE
feat(components/molecule/imageEditor): Add debouncingTime as a customizable property

### DIFF
--- a/components/molecule/imageEditor/demo/articles/ArticleCustomChildren.js
+++ b/components/molecule/imageEditor/demo/articles/ArticleCustomChildren.js
@@ -2,7 +2,7 @@ import {useState} from 'react'
 
 import PropTypes from 'prop-types'
 
-import {Article, H2, Paragraph, Code} from '@s-ui/documentation-library'
+import {Article, Code, H2, Paragraph} from '@s-ui/documentation-library'
 
 import MoleculeImageEditor from '../../src/index.js'
 import {DEMO_IMAGE} from '../settings.js'

--- a/components/molecule/imageEditor/demo/articles/CustomChildren.js
+++ b/components/molecule/imageEditor/demo/articles/CustomChildren.js
@@ -1,9 +1,10 @@
 import PropTypes from 'prop-types'
 
-import {Grid, Cell} from '@s-ui/documentation-library'
+import {Cell, Grid} from '@s-ui/documentation-library'
+
 import {
-  MoleculeImageEditorSliders,
-  MoleculeImageEditorCropper
+  MoleculeImageEditorCropper,
+  MoleculeImageEditorSliders
 } from '../../src/index.js'
 
 const CustomChildren = ({

--- a/components/molecule/imageEditor/demo/index.js
+++ b/components/molecule/imageEditor/demo/index.js
@@ -1,8 +1,8 @@
 import {H1, Paragraph} from '@s-ui/documentation-library'
 
-import {CLASS_SECTION} from './settings.js'
-import ArticleDefault from './articles/ArticleDefault.js'
 import ArticleCustomChildren from './articles/ArticleCustomChildren.js'
+import ArticleDefault from './articles/ArticleDefault.js'
+import {CLASS_SECTION} from './settings.js'
 
 const Demo = () => (
   <div className="sui-StudioPreview">

--- a/components/molecule/imageEditor/src/ImageEditorCropper.js
+++ b/components/molecule/imageEditor/src/ImageEditorCropper.js
@@ -1,6 +1,6 @@
-import PropTypes from 'prop-types'
-
 import Cropper from 'react-easy-crop'
+
+import PropTypes from 'prop-types'
 
 import {baseClass, getRotationDegrees} from './config.js'
 

--- a/components/molecule/imageEditor/src/ImageEditorDefault.js
+++ b/components/molecule/imageEditor/src/ImageEditorDefault.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types'
+
 import ImageEditorCropper from './ImageEditorCropper.js'
 import ImageEditorSliders from './ImageEditorSliders.js'
 

--- a/components/molecule/imageEditor/src/config.js
+++ b/components/molecule/imageEditor/src/config.js
@@ -1,6 +1,5 @@
 export const baseClass = 'sui-MoleculeImageEditor'
 export const DEFAULT_ASPECT = 4 / 3
 export const noop = () => {}
-export const DEBOUNCING_TIME = 100
 
 export const getRotationDegrees = rotation => (rotation * 360) / 100

--- a/components/molecule/imageEditor/src/index.js
+++ b/components/molecule/imageEditor/src/index.js
@@ -10,7 +10,7 @@ import {baseClass, DEFAULT_ASPECT, getRotationDegrees, noop} from './config.js'
 import ImageEditorCropper from './ImageEditorCropper.js'
 import ImageEditorDefault from './ImageEditorDefault.js'
 import ImageEditorSliders from './ImageEditorSliders.js'
-import {debouncingTime} from './prop-types.js'
+import {debouncingTimePropType} from './prop-types.js'
 
 const MoleculeImageEditor = ({
   aspect = DEFAULT_ASPECT,

--- a/components/molecule/imageEditor/src/index.js
+++ b/components/molecule/imageEditor/src/index.js
@@ -6,22 +6,17 @@ import {debounce} from '@s-ui/js/lib/function/debounce.js'
 import Injector from '@s-ui/react-primitive-injector'
 
 import getCroppedImg from './utils/cropImage.js'
-import {
-  baseClass,
-  DEBOUNCING_TIME,
-  DEFAULT_ASPECT,
-  getRotationDegrees,
-  noop
-} from './config.js'
+import {baseClass, DEFAULT_ASPECT, getRotationDegrees, noop} from './config.js'
 import ImageEditorCropper from './ImageEditorCropper.js'
 import ImageEditorDefault from './ImageEditorDefault.js'
 import ImageEditorSliders from './ImageEditorSliders.js'
+import {debouncingTime} from './prop-types.js'
 
 const MoleculeImageEditor = ({
   aspect = DEFAULT_ASPECT,
   cropLabelIcon,
   cropLabelText,
-  debouncingTime = DEBOUNCING_TIME,
+  debouncingTime,
   image,
   onChange,
   onCropping = noop,
@@ -34,15 +29,19 @@ const MoleculeImageEditor = ({
   const [zoom, zoomSetter] = useState(0)
 
   const setCrop =
-    debouncingTime > 0 ? debounce(cropSetter, debouncingTime) : cropSetter
+    debouncingTime === undefined
+      ? cropSetter
+      : debounce(cropSetter, debouncingTime)
 
   const setRotation =
-    debouncingTime > 0
-      ? debounce(rotationSetter, debouncingTime)
-      : rotationSetter
+    debouncingTime === undefined
+      ? rotationSetter
+      : debounce(rotationSetter, debouncingTime)
 
   const setZoom =
-    debouncingTime > 0 ? debounce(zoomSetter, debouncingTime) : zoomSetter
+    debouncingTime === undefined
+      ? zoomSetter
+      : debounce(zoomSetter, debouncingTime)
 
   const cropCompleteHandler = async (croppedArea, croppedAreaPixels) => {
     const rotationDegrees = getRotationDegrees(rotation)
@@ -57,9 +56,9 @@ const MoleculeImageEditor = ({
   }
 
   const onCropComplete = useCallback(
-    debouncingTime > 0
-      ? debounce(cropCompleteHandler, debouncingTime)
-      : cropCompleteHandler,
+    debouncingTime === undefined
+      ? cropCompleteHandler
+      : debounce(cropCompleteHandler, debouncingTime),
     [rotation, onCropping, image, onChange]
   )
 
@@ -93,7 +92,7 @@ MoleculeImageEditor.propTypes = {
   aspect: PropTypes.number,
   cropLabelIcon: PropTypes.node,
   cropLabelText: PropTypes.string,
-  debouncingTime: PropTypes.number,
+  debouncingTime,
   image: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   onCropping: PropTypes.func,

--- a/components/molecule/imageEditor/src/index.js
+++ b/components/molecule/imageEditor/src/index.js
@@ -6,21 +6,22 @@ import {debounce} from '@s-ui/js/lib/function/debounce.js'
 import Injector from '@s-ui/react-primitive-injector'
 
 import getCroppedImg from './utils/cropImage.js'
-import ImageEditorDefault from './ImageEditorDefault.js'
-import ImageEditorCropper from './ImageEditorCropper.js'
-import ImageEditorSliders from './ImageEditorSliders.js'
 import {
   baseClass,
   DEBOUNCING_TIME,
   DEFAULT_ASPECT,
-  noop,
-  getRotationDegrees
+  getRotationDegrees,
+  noop
 } from './config.js'
+import ImageEditorCropper from './ImageEditorCropper.js'
+import ImageEditorDefault from './ImageEditorDefault.js'
+import ImageEditorSliders from './ImageEditorSliders.js'
 
 const MoleculeImageEditor = ({
   aspect = DEFAULT_ASPECT,
   cropLabelIcon,
   cropLabelText,
+  debouncingTime = DEBOUNCING_TIME,
   image,
   onChange,
   onCropping = noop,
@@ -32,9 +33,16 @@ const MoleculeImageEditor = ({
   const [rotation, rotationSetter] = useState(0)
   const [zoom, zoomSetter] = useState(0)
 
-  const setCrop = debounce(cropSetter, DEBOUNCING_TIME)
-  const setRotation = debounce(rotationSetter, DEBOUNCING_TIME)
-  const setZoom = debounce(zoomSetter, DEBOUNCING_TIME)
+  const setCrop =
+    debouncingTime > 0 ? debounce(cropSetter, debouncingTime) : cropSetter
+
+  const setRotation =
+    debouncingTime > 0
+      ? debounce(rotationSetter, debouncingTime)
+      : rotationSetter
+
+  const setZoom =
+    debouncingTime > 0 ? debounce(zoomSetter, debouncingTime) : zoomSetter
 
   const cropCompleteHandler = async (croppedArea, croppedAreaPixels) => {
     const rotationDegrees = getRotationDegrees(rotation)
@@ -49,7 +57,9 @@ const MoleculeImageEditor = ({
   }
 
   const onCropComplete = useCallback(
-    debounce(cropCompleteHandler, DEBOUNCING_TIME),
+    debouncingTime > 0
+      ? debounce(cropCompleteHandler, debouncingTime)
+      : cropCompleteHandler,
     [rotation, onCropping, image, onChange]
   )
 
@@ -83,6 +93,7 @@ MoleculeImageEditor.propTypes = {
   aspect: PropTypes.number,
   cropLabelIcon: PropTypes.node,
   cropLabelText: PropTypes.string,
+  debouncingTime: PropTypes.number,
   image: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   onCropping: PropTypes.func,

--- a/components/molecule/imageEditor/src/index.js
+++ b/components/molecule/imageEditor/src/index.js
@@ -92,7 +92,7 @@ MoleculeImageEditor.propTypes = {
   aspect: PropTypes.number,
   cropLabelIcon: PropTypes.node,
   cropLabelText: PropTypes.string,
-  debouncingTime,
+  debouncingTime: debouncingTimePropType,
   image: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   onCropping: PropTypes.func,

--- a/components/molecule/imageEditor/src/prop-types.js
+++ b/components/molecule/imageEditor/src/prop-types.js
@@ -1,4 +1,4 @@
-export const debouncingTime = function (props, propName, componentName) {
+export const debouncingTimePropType = function (props, propName, componentName) {
   const prop = props[propName]
   if (typeof prop !== 'number' || prop < 1) {
     return new Error(

--- a/components/molecule/imageEditor/src/prop-types.js
+++ b/components/molecule/imageEditor/src/prop-types.js
@@ -1,4 +1,8 @@
-export const debouncingTimePropType = function (props, propName, componentName) {
+export const debouncingTimePropType = function (
+  props,
+  propName,
+  componentName
+) {
   const prop = props[propName]
   if (typeof prop !== 'number' || prop < 1) {
     return new Error(

--- a/components/molecule/imageEditor/src/prop-types.js
+++ b/components/molecule/imageEditor/src/prop-types.js
@@ -1,0 +1,13 @@
+export const debouncingTime = function (props, propName, componentName) {
+  const prop = props[propName]
+  if (typeof prop !== 'number' || prop < 1) {
+    return new Error(
+      'Invalid prop `' +
+        propName +
+        '` supplied to' +
+        ' `' +
+        componentName +
+        '`. Validation failed.'
+    )
+  }
+}


### PR DESCRIPTION
## molecule/imageEditor

#### `❓ Ask`

### Types of changes

- [X] ✨ New feature (non-breaking change which adds functionality)

### Description, Motivation and Context

It would be great for us in CNET PRO, to have the possibility of customizing the debouncingTime of  `imageEditor`.

Thanks to the new extensibility capabilities, we have been able to implement an approach to improve the component performance without requiring modifications on the `sui` side.  Basically, this new approach avoids calculating the image every time the user performs a modification on the crop or rotation parameters, and exposes a function to calculate it once, only when the edition is finished, using the `useImperativeHandle` hook.

However, as the interface runs smoothly now, debouncing is not longer necessary from our side, and it's slowing the image editor. (It increases performance when image is calculated on every edition, but slows the interface if there are not performance issues and image calculation is performed only at the end of the edition process).

With this PR we suggest an approach to make the debounce time customizable via props so we can disable it only when needed.

Type checking and code flow improvements suggested by @andresin87 