### PR TITLE
feat(components/molecule/imageEditor): Add a SCSS token to customize imageEditor labels color

### DIFF
--- a/components/molecule/imageEditor/src/styles/index.scss
+++ b/components/molecule/imageEditor/src/styles/index.scss
@@ -19,7 +19,7 @@ $base-class: '.sui-MoleculeImageEditor';
 
   &-label {
     align-items: center;
-    color: $c-gray;
+    color: $c-molecule-image-editor-label;
     display: flex;
     margin-right: $m-l;
 

--- a/components/molecule/imageEditor/src/styles/settings.scss
+++ b/components/molecule/imageEditor/src/styles/settings.scss
@@ -1,3 +1,4 @@
+$c-molecule-image-editor-label: $c-gray !default;
 $h-molecule-image-editor: 300px !default;
 $mb-molecule-image-editor-crop: $m-xxl !default;
 $mt-molecule-image-editor-slider: $m-xl !default;


### PR DESCRIPTION
## molecule/imageEditor

#### `❓ Ask` 

### Types of changes

- [X] 💄 Styles

### Description, Motivation and Context
Context: We're performing the QA phase of the CNET PRO `myAccount` page.
This PR modifies the styles of `molecule/imageEditor` to allow customizing its color property from a web-app's theme.

### Screenshots - Animations

<img width="697" alt="Captura de Pantalla 2022-09-19 a las 17 53 40" src="https://user-images.githubusercontent.com/16169223/191060102-bbb2da53-9d61-4b4a-a0b6-4cc84d12867c.png">
