### PR TITLE
Feat/help and validation text margin

### DIFF
--- a/components/atom/helpText/src/styles/index.scss
+++ b/components/atom/helpText/src/styles/index.scss
@@ -4,5 +4,5 @@ $base-class: '.sui-AtomHelpText';
   color: $c-help-text;
   display: block;
   font-size: $fz-atom-help-text;
-  margin: $m-s 0 0;
+  margin: $mt-atom-help-text 0 0;
 }

--- a/components/atom/helpText/src/styles/index.scss
+++ b/components/atom/helpText/src/styles/index.scss
@@ -4,5 +4,5 @@ $base-class: '.sui-AtomHelpText';
   color: $c-help-text;
   display: block;
   font-size: $fz-atom-help-text;
-  margin: $mt-atom-help-text 0 0;
+  margin: $m-atom-help-text;
 }

--- a/components/atom/helpText/src/styles/settings.scss
+++ b/components/atom/helpText/src/styles/settings.scss
@@ -1,3 +1,3 @@
 $c-help-text: $c-gray-light-3 !default;
 $fz-atom-help-text: $fz-xs !default;
-$mt-atom-help-text: $m-s !default;
+$m-atom-help-text: $m-s 0 0 !default;

--- a/components/atom/helpText/src/styles/settings.scss
+++ b/components/atom/helpText/src/styles/settings.scss
@@ -1,2 +1,3 @@
 $c-help-text: $c-gray-light-3 !default;
 $fz-atom-help-text: $fz-xs !default;
+$mt-atom-help-text: $m-s !default;

--- a/components/atom/validationText/src/styles/index.scss
+++ b/components/atom/validationText/src/styles/index.scss
@@ -3,7 +3,8 @@ $base-class: '.sui-AtomValidationText';
 #{$base-class} {
   display: block;
   font-size: $fz-atom-validation-text;
-  margin: $m-s 0 0;
+  margin: $mt-atom-validation-text 0 0;
+
   @each $type, $color in $validation {
     &--#{$type} {
       color: $color;

--- a/components/atom/validationText/src/styles/index.scss
+++ b/components/atom/validationText/src/styles/index.scss
@@ -3,7 +3,7 @@ $base-class: '.sui-AtomValidationText';
 #{$base-class} {
   display: block;
   font-size: $fz-atom-validation-text;
-  margin: $m-atom-validation-text 0 0;
+  margin: $m-atom-validation-text;
 
   @each $type, $color in $validation {
     &--#{$type} {

--- a/components/atom/validationText/src/styles/index.scss
+++ b/components/atom/validationText/src/styles/index.scss
@@ -3,7 +3,7 @@ $base-class: '.sui-AtomValidationText';
 #{$base-class} {
   display: block;
   font-size: $fz-atom-validation-text;
-  margin: $mt-atom-validation-text 0 0;
+  margin: $m-atom-validation-text 0 0;
 
   @each $type, $color in $validation {
     &--#{$type} {

--- a/components/atom/validationText/src/styles/settings.scss
+++ b/components/atom/validationText/src/styles/settings.scss
@@ -1,2 +1,3 @@
 $fz-atom-validation-text: $fz-xs !default;
+$mt-atom-validation-text: $m-s !default;
 $validation: success $c-success, error $c-error, alert $c-alert;

--- a/components/atom/validationText/src/styles/settings.scss
+++ b/components/atom/validationText/src/styles/settings.scss
@@ -1,3 +1,3 @@
 $fz-atom-validation-text: $fz-xs !default;
-$mt-atom-validation-text: $m-s !default;
+$m-atom-validation-text: $m-s 0 0 !default;
 $validation: success $c-success, error $c-error, alert $c-alert;


### PR DESCRIPTION
## 🔍 atom/validationText and atom/helpText

### Types of changes

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context

This PR add two new variables:
- `$mt-atom-help-text`
- `$mt-atom-validation-text`

That will allow us to configure the margin between the field and the help or validation text