### PR TITLE
feat(components/molecule/tabs): Change tabs to be able to modify current active tabs by updating props

### DIFF
--- a/components/molecule/tabs/demo/Articles/ArticleActiveTabs.js
+++ b/components/molecule/tabs/demo/Articles/ArticleActiveTabs.js
@@ -1,0 +1,111 @@
+import {useState} from 'react'
+
+import MoleculeTabs, {MoleculeTab} from 'components/molecule/tabs/src/index.js'
+import PropTypes from 'prop-types'
+
+import {
+  Article,
+  Code,
+  H2,
+  H3,
+  Paragraph,
+  RadioButton,
+  RadioButtonGroup
+} from '@s-ui/documentation-library'
+
+import Content from '../components/Content.js'
+import {CLASS_DEMO_CONTENT_TAB} from '../config.js'
+
+const tabsNumber = 5
+
+const ArticleActiveTabs = ({className}) => {
+  const [activeTabIndex, setActiveTabIndex] = useState(3)
+  return (
+    <Article className={className}>
+      <H2>Controlled and uncontrolled active tabs</H2>
+      <Paragraph>
+        Under <Code>activeTabIndex</Code> (number, default 1) developer can
+        control the active tab. Use the <Code>defaultActiveTabIndex</Code> for
+        defining the initial tab uncontrolled.
+      </Paragraph>
+      <H3>Uncontrolled</H3>
+      <MoleculeTabs defaultActiveTabIndex={3}>
+        {Array(tabsNumber)
+          .fill(true)
+          .map((v, index) => (
+            <MoleculeTab
+              key={index + 1}
+              label={<span style={{padding: '0 8px'}}>Label {index + 1}</span>}
+              numTab={index + 1}
+              disabled={index + 1 === 4}
+            >
+              <Content
+                title="Title"
+                number={index + 1}
+                className={CLASS_DEMO_CONTENT_TAB}
+                style={{
+                  borderTop: 0,
+                  borderLeft: '1px solid #e6e6e6',
+                  borderRight: '1px solid #e6e6e6',
+                  borderBottom: '1px solid #e6e6e6'
+                }}
+              />
+            </MoleculeTab>
+          ))}
+      </MoleculeTabs>
+      <H3>Controlled</H3>
+      <RadioButtonGroup
+        value={activeTabIndex}
+        onChange={(event, value) => {
+          setActiveTabIndex(value)
+        }}
+      >
+        {Array(tabsNumber)
+          .fill(true)
+          .map((v, index) => (
+            <RadioButton
+              value={index + 1}
+              checked={index + 1 === activeTabIndex}
+            >{`tab ${index + 1}`}</RadioButton>
+          ))}
+      </RadioButtonGroup>
+      <MoleculeTabs
+        activeTabIndex={activeTabIndex}
+        onChange={(event, {numTab}) => {
+          setActiveTabIndex(numTab)
+        }}
+      >
+        {Array(tabsNumber)
+          .fill(true)
+          .map((v, index) => (
+            <MoleculeTab
+              key={index + 1}
+              label={<span style={{padding: '0 8px'}}>Label {index + 1}</span>}
+              numTab={index + 1}
+              disabled={index + 1 === 4}
+            >
+              <Content
+                title="Title"
+                number={index + 1}
+                className={CLASS_DEMO_CONTENT_TAB}
+                style={{
+                  borderTop: 0,
+                  borderLeft: '1px solid #e6e6e6',
+                  borderRight: '1px solid #e6e6e6',
+                  borderBottom: '1px solid #e6e6e6'
+                }}
+              />
+            </MoleculeTab>
+          ))}
+      </MoleculeTabs>
+    </Article>
+  )
+}
+
+ArticleActiveTabs.displayName = 'ArticleActiveTabs'
+
+ArticleActiveTabs.propTypes = {
+  className: PropTypes.string
+}
+
+export default ArticleActiveTabs

--- a/components/molecule/tabs/demo/index.js
+++ b/components/molecule/tabs/demo/index.js
@@ -1,5 +1,6 @@
 import {H1, Paragraph} from '@s-ui/documentation-library'
 
+import ArticleActiveTabs from './Articles/ArticleActiveTabs.js'
 import ArticleDefault from './Articles/ArticleDefault.js'
 import ArticleIconsCounters from './Articles/ArticleIconsCounters.js'
 import ArticleType from './Articles/ArticleType.js'
@@ -17,6 +18,8 @@ const Demo = () => {
         classic or highlighted variants
       </Paragraph>
       <ArticleDefault className={CLASS_DEMO_SECTION} />
+      <br />
+      <ArticleActiveTabs className={CLASS_DEMO_SECTION} />
       <br />
       <ArticleType className={CLASS_DEMO_SECTION} />
       <br />

--- a/components/molecule/tabs/src/index.js
+++ b/components/molecule/tabs/src/index.js
@@ -1,50 +1,49 @@
-import {Children, cloneElement, useEffect, useState} from 'react'
+import {Children, cloneElement} from 'react'
 
 import PropTypes from 'prop-types'
+
+import useControlledState from '@s-ui/react-hooks/lib/useControlledState'
 
 import MoleculeTab from './components/MoleculeTab.js'
 import MoleculeTabs from './components/MoleculeTabs.js'
 import {TYPES, VARIANTS} from './config.js'
 
-const MoleculeTabsWithStateActive = ({children, onChange, ...props}) => {
-  const [activeTab, setActiveTab] = useState(null)
+const MoleculeTabsWithStateActive = ({
+  children,
+  activeTabIndex: activeTabIndexProp,
+  defaultActiveTabIndex: defaultActiveTabIndexProp = 1,
+  onChange,
+  ...props
+}) => {
+  const [activeTab, setActiveTab] = useControlledState(
+    activeTabIndexProp,
+    defaultActiveTabIndexProp
+  )
 
-  useEffect(() => {
-    Children.forEach(children, (child, index) => {
-      if (child) {
-        const {active} = child.props
-        const childrenActiveTab = index + 1
-        if (active && childrenActiveTab !== activeTab) {
-          setActiveTab(childrenActiveTab)
-        }
-      }
-    })
-  }, [children]) // eslint-disable-line
-
-  const extendedChildren = () => {
-    return Children.toArray(children)
-      .filter(Boolean)
-      .map((child, index) => {
-        const numTab = index + 1
-        const active = activeTab === numTab
-        return cloneElement(child, {active})
-      })
-  }
-
-  const handleChange = (e, {numTab}) => {
-    setActiveTab(numTab)
-    typeof onChange === 'function' && onChange(e, {numTab})
+  const handleChange = (e, {numTab: tabIndex}) => {
+    setActiveTab(tabIndex)
+    typeof onChange === 'function' && onChange(e, {numTab: tabIndex})
   }
 
   return (
-    <MoleculeTabs {...props} onChange={handleChange}>
-      {extendedChildren()}
+    <MoleculeTabs {...props} activeTab={activeTab} onChange={handleChange}>
+      {Children.toArray(children)
+        .filter(Boolean)
+        .map((child, index) =>
+          cloneElement(child, {active: activeTab === index + 1})
+        )}
     </MoleculeTabs>
   )
 }
 
 MoleculeTabsWithStateActive.displayName = 'MoleculeTabsWithStateActive'
 MoleculeTabsWithStateActive.propTypes = {
+  /** defines the active tab */
+  activeTabIndex: PropTypes.number,
+
+  /** defines the initial active tab */
+  defaultActiveTabIndex: PropTypes.number,
+
   /** children of the component */
   children: PropTypes.element,
 

--- a/components/molecule/tabs/src/index.js
+++ b/components/molecule/tabs/src/index.js
@@ -26,7 +26,7 @@ const MoleculeTabsWithStateActive = ({
   }
 
   return (
-    <MoleculeTabs {...props} activeTab={activeTab} onChange={handleChange}>
+    <MoleculeTabs {...props} onChange={handleChange}>
       {Children.toArray(children)
         .filter(Boolean)
         .map((child, index) =>

--- a/components/molecule/tabs/src/index.js
+++ b/components/molecule/tabs/src/index.js
@@ -13,10 +13,13 @@ const MoleculeTabsWithStateActive = ({children, onChange, ...props}) => {
     Children.forEach(children, (child, index) => {
       if (child) {
         const {active} = child.props
-        if (active) setActiveTab(index + 1)
+        const childrenActiveTab = index + 1
+        if (active && childrenActiveTab !== activeTab) {
+          setActiveTab(childrenActiveTab)
+        }
       }
     })
-  }, []) // eslint-disable-line
+  }, [children]) // eslint-disable-line
 
   const extendedChildren = () => {
     return Children.toArray(children)


### PR DESCRIPTION
## molecule/tabs
#### `❓ Ask` 

### Types of changes

- [X] ✨ New feature (non-breaking change which adds functionality)

### Description, Motivation and Context

Current situation:

Currently, it is not possible to modify the current active tab by modifying the props of a `molecule/tabs` instance. The component maintains the current selected tab on its internal state, so even if props are modified to indicate which tab is the active one, the component doesn't reflect it on its state.

Introduced change:

This PR introduces a small change to detect when the active tab has been modified externally, and properly reflect it on its internal state.