### PR TITLE
fix(components/molecule/drawer): avoid add a listener for keydown tha…

### DIFF
--- a/components/molecule/drawer/src/index.js
+++ b/components/molecule/drawer/src/index.js
@@ -39,7 +39,6 @@ const MoleculeDrawer = forwardRef(
 
     useEventListener('keydown', event => {
       if (isOpen === false) return
-      event.preventDefault()
       if (event.key === 'Escape') {
         onClose(event, {isOpen: false})
       }


### PR DESCRIPTION
…t prevents the default behaviou

## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
 #### `🔍 Show` 
<!-- #### `❓ Ask` -->

### Types of changes
Do not prevent the default for the keydown listener

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
Due to the listener for keydown that the drawer was registering with the preventDefault any other keydown was being captured by this listener so for instance the inputs text wasn't working at all.

