### PR TITLE
feat(components/molecule/avatar): handle background color for avatar

### DIFF
--- a/components/molecule/avatar/demo/ArticleImage.js
+++ b/components/molecule/avatar/demo/ArticleImage.js
@@ -20,6 +20,8 @@ const ArticleImage = ({className}) => {
   const [src, setSrc] = useState(
     'https://randomuser.me/api/portraits/men/1.jpg'
   )
+  const [brokenSrc, setBrokenSrc] = useState('https://brokenimagesrc')
+  const [name, setName] = useState('John Doe')
   const [fallbackIcon, setFallbackIcon] = useState()
   return (
     <Article className={className}>
@@ -87,6 +89,46 @@ const ArticleImage = ({className}) => {
       </RadioButtonGroup>
       <br />
       <MoleculeAvatar
+        fallbackIcon={
+          fallbackIcon ? (
+            <AtomIcon>
+              <AntDesignIcon
+                icon={fallbackIcon}
+                style={{color: 'currentColor'}}
+              />
+            </AtomIcon>
+          ) : undefined
+        }
+      />
+      <H2>Fallback Name</H2>
+      <Paragraph>
+        If the provided image fails on loading and the <Code>name</Code>{' '}
+        property is passed, the avatar will display the name initials with a
+        colored background.
+      </Paragraph>
+      <Input
+        value={brokenSrc}
+        onChange={event => {
+          setBrokenSrc(event.target.value)
+        }}
+        placeholder="image"
+        fullWidth
+      />
+      <br />
+      <br />
+      <Input
+        value={name}
+        onChange={event => {
+          setName(event.target.value)
+        }}
+        placeholder="image"
+        fullWidth
+      />
+      <br />
+      <br />
+      <MoleculeAvatar
+        src={brokenSrc}
+        name={name}
         fallbackIcon={
           fallbackIcon ? (
             <AtomIcon>

--- a/components/molecule/avatar/src/AvatarFallbackName/index.js
+++ b/components/molecule/avatar/src/AvatarFallbackName/index.js
@@ -1,6 +1,7 @@
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 
+import useConvertStringToHex from '../useConvertStringToHex.js'
 import {BASE_CLASS_NAME} from './settings.js'
 
 const MoleculeAvatarFallbackName = ({
@@ -20,9 +21,16 @@ const MoleculeAvatarFallbackName = ({
       ? `${firstName.charAt(0)}${lastName.charAt(0)}`
       : firstName.charAt(0)
 
+  const backgroundColor = useConvertStringToHex(nameProp)
+
   return (
-    <div className={className} aria-label={nameProp} {...others}>
-      {name.toUpperCase()}
+    <div
+      className={className}
+      aria-label={nameProp}
+      style={{backgroundColor}}
+      {...others}
+    >
+      {name}
     </div>
   )
 }

--- a/components/molecule/avatar/src/AvatarFallbackName/index.scss
+++ b/components/molecule/avatar/src/AvatarFallbackName/index.scss
@@ -1,5 +1,11 @@
-$base-class-fallback-name: '#{$base-class}FallbackName';
+$base-class-fallback-name: #{$base-class}FallbackName;
 
 #{$base-class-fallback-name} {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   color: $c-avatar-fallback-name;
+  text-transform: uppercase;
 }

--- a/components/molecule/avatar/src/index.js
+++ b/components/molecule/avatar/src/index.js
@@ -22,7 +22,6 @@ import AvatarBadge, {
 } from './AvatarBadge/index.js'
 import AvatarFallback from './AvatarFallback/index.js'
 import {AVATAR_SIZES, baseClassName} from './settings.js'
-import useConvertStringToHex from './useConvertStringToHex.js'
 
 const MoleculeAvatar = forwardRef(
   (
@@ -49,7 +48,6 @@ const MoleculeAvatar = forwardRef(
     forwardedRef
   ) => {
     const className = cx(baseClassName, `${baseClassName}--${size}`)
-    const backgroundColor = useConvertStringToHex(name)
     const children = Children.toArray(childrenProp)
       .filter(child => isValidElement(child))
       .map(child => cloneElement(child, {size}))
@@ -90,15 +88,7 @@ const MoleculeAvatar = forwardRef(
     ])
 
     return (
-      <span
-        style={{
-          ...(!src && {backgroundColor}),
-          ...style
-        }}
-        className={className}
-        {...others}
-        ref={forwardedRef}
-      >
+      <span style={style} className={className} {...others} ref={forwardedRef}>
         {renderContent()}
       </span>
     )

--- a/components/molecule/avatar/src/styles/index.scss
+++ b/components/molecule/avatar/src/styles/index.scss
@@ -31,3 +31,5 @@ $base-class: '.sui-MoleculeAvatar';
     }
   }
 }
+
+@import '../AvatarFallback/index.scss';

--- a/components/molecule/avatar/test/index.test.js
+++ b/components/molecule/avatar/test/index.test.js
@@ -192,7 +192,7 @@ describe(json.name, () => {
       const {getByText} = setup(props)
 
       // Then
-      expect(getByText('JS')).to.be.visible
+      expect(getByText('js')).to.be.visible
     })
 
     describe('forwardRef', () => {


### PR DESCRIPTION
## molecule/avatar
🔍 Show

### Types of changes

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
When a passed src image was erroring and the `name` property was passed, the background-color for the fallback was not applied correctly.
