### PR TITLE
feat(components/atom/slider): add z-index in tooltip

### DIFF
--- a/components/atom/slider/src/styles/index.scss
+++ b/components/atom/slider/src/styles/index.scss
@@ -147,6 +147,8 @@ $class-tooltip-hidden: '#{$class-tooltip}-hidden';
 }
 
 #{$class-tooltip} {
+  z-index: $z-atom-slider-tooltip;
+
   #{$class-tooltip-inner} {
     background: transparent;
     border-color: transparent;

--- a/components/atom/slider/src/styles/settings.scss
+++ b/components/atom/slider/src/styles/settings.scss
@@ -22,3 +22,5 @@ $h-atom-slider-track: 8px !default;
 $p-atom-slider: $p-l !default;
 
 $mt-atom-slider-mark: 10px !default;
+
+$z-atom-slider-tooltip: auto !default;


### PR DESCRIPTION
## Atom/Slider
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
`🔍 Show`
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [x] 💄 Styles

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
Add z-index in tooltip.

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
**Before**
<img width="387" alt="image" src="https://user-images.githubusercontent.com/11008947/193069122-88b8c041-f9c5-4846-84fa-e2fbb8714906.png">

**After**
<img width="381" alt="image" src="https://user-images.githubusercontent.com/11008947/193069239-9e158e3d-5c01-403b-8451-936e9de9d1bd.png">

