### PR TITLE
refactor(components/molecule/buttonGroup): Replace cloneElement with injector

### DIFF
--- a/components/molecule/buttonGroup/package.json
+++ b/components/molecule/buttonGroup/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "@s-ui/component-dependencies": "1",
     "@s-ui/react-atom-button": "1",
-    "@s-ui/react-primitive-polymorphic-element": "1"
+    "@s-ui/react-primitive-polymorphic-element": "1",
+    "@s-ui/react-primitive-injector": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/molecule/buttonGroup/src/index.js
+++ b/components/molecule/buttonGroup/src/index.js
@@ -21,9 +21,9 @@ const MoleculeButtonGroup = ({
   as = 'div',
   children,
   fullWidth,
-  size: sizeProp,
-  design: designProp,
-  negative: negativeProp,
+  size,
+  design,
+  negative,
   groupPositions,
   onClick,
   ...props
@@ -41,9 +41,9 @@ const MoleculeButtonGroup = ({
       return (
         <Injector
           {...props}
-          negative={negativeProp}
-          size={sizeProp}
-          design={designProp}
+          negative={negative}
+          size={size}
+          design={design}
           groupPosition={groupPosition}
           fullWidth={fullWidth}
           onClick={onClick}

--- a/components/molecule/buttonGroup/src/index.js
+++ b/components/molecule/buttonGroup/src/index.js
@@ -1,9 +1,10 @@
-import {Children, cloneElement} from 'react'
+import {Children} from 'react'
 
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 
 import {atomButtonDesigns, atomButtonSizes} from '@s-ui/react-atom-button'
+import Injector from '@s-ui/react-primitive-injector'
 import Poly from '@s-ui/react-primitive-polymorphic-element'
 
 import {BASE_CLASS, combineProps, isFunction} from './settings.js'
@@ -46,15 +47,20 @@ const MoleculeButtonGroup = ({
         isFunction(onClickChild) && onClickChild(event, ...args)
         isFunction(onClick) && onClick(event, ...args)
       }
-      return cloneElement(child, {
-        ...props,
-        negative: combineProps(negativeChild, negativeProp),
-        size: combineProps(sizeChild, sizeProp),
-        design: combineProps(designChild, designProp),
-        groupPosition,
-        fullWidth,
-        onClick: clickHandler
-      })
+
+      return (
+        <Injector
+          {...props}
+          negative={combineProps(negativeChild, negativeProp)}
+          size={combineProps(sizeChild, sizeProp)}
+          design={combineProps(designChild, designProp)}
+          groupPosition={groupPosition}
+          fullWidth={fullWidth}
+          onClick={clickHandler}
+        >
+          {child}
+        </Injector>
+      )
     })
   return (
     <Poly className={cx(BASE_CLASS, fullWidth && `${BASE_CLASS}--fullWidth`)}>

--- a/components/molecule/buttonGroup/src/index.js
+++ b/components/molecule/buttonGroup/src/index.js
@@ -7,7 +7,7 @@ import {atomButtonDesigns, atomButtonSizes} from '@s-ui/react-atom-button'
 import Injector from '@s-ui/react-primitive-injector'
 import Poly from '@s-ui/react-primitive-polymorphic-element'
 
-import {BASE_CLASS, combineProps, isFunction} from './settings.js'
+import {BASE_CLASS} from './settings.js'
 
 const getGroupPosition =
   ({groupPositions, numChildren}) =>
@@ -36,27 +36,17 @@ const MoleculeButtonGroup = ({
   const extendedChildren = Children.toArray(children)
     .filter(Boolean)
     .map((child, index) => {
-      const {
-        size: sizeChild,
-        design: designChild,
-        negative: negativeChild,
-        onClick: onClickChild
-      } = child.props
       const groupPosition = getGroupPositionByIndex(index)
-      const clickHandler = (event, ...args) => {
-        isFunction(onClickChild) && onClickChild(event, ...args)
-        isFunction(onClick) && onClick(event, ...args)
-      }
 
       return (
         <Injector
           {...props}
-          negative={combineProps(negativeChild, negativeProp)}
-          size={combineProps(sizeChild, sizeProp)}
-          design={combineProps(designChild, designProp)}
+          negative={negativeProp}
+          size={sizeProp}
+          design={designProp}
           groupPosition={groupPosition}
           fullWidth={fullWidth}
-          onClick={clickHandler}
+          onClick={onClick}
         >
           {child}
         </Injector>

--- a/components/molecule/buttonGroup/src/settings.js
+++ b/components/molecule/buttonGroup/src/settings.js
@@ -1,6 +1,1 @@
 export const BASE_CLASS = 'sui-MoleculeButtonGroup'
-
-export const isFunction = fn => typeof fn === 'function'
-
-export const combineProps = (childProp, wrapperProp) =>
-  childProp === undefined ? wrapperProp : childProp


### PR DESCRIPTION
ISSUES CLOSED: #2333

## molecule/buttonGroup

#### `❓ Ask`

**TASK**: #2333

### Types of changes

- [X] 🧠 Refactor

### Description, Motivation and Context

This PRs replaces `cloneElement`statements from `molecule/buttonGroup` in favor of using the sui `Injector` component.
Submitted for the hacktoberfest event. It should not have any visual effect, just a refactor.