### PR TITLE
refactor(components/molecule/avatar): Replace cloneElement with injector

### DIFF
--- a/components/molecule/avatar/src/index.js
+++ b/components/molecule/avatar/src/index.js
@@ -1,10 +1,4 @@
-import {
-  Children,
-  cloneElement,
-  forwardRef,
-  isValidElement,
-  useCallback
-} from 'react'
+import {Children, forwardRef, isValidElement, useCallback} from 'react'
 
 import cx from 'classnames'
 import PropTypes from 'prop-types'
@@ -14,6 +8,7 @@ import AtomSkeleton, {
   ATOM_SKELETON_ANIMATIONS,
   ATOM_SKELETON_VARIANTS
 } from '@s-ui/react-atom-skeleton'
+import Injector from '@s-ui/react-primitive-injector'
 
 import AvatarBadge, {
   AVATAR_BADGE_PLACEMENTS,
@@ -50,7 +45,7 @@ const MoleculeAvatar = forwardRef(
     const className = cx(baseClassName, `${baseClassName}--${size}`)
     const children = Children.toArray(childrenProp)
       .filter(child => isValidElement(child))
-      .map(child => cloneElement(child, {size}))
+      .map(child => <Injector size={size}>{child}</Injector>)
 
     const renderContent = useCallback(() => {
       if (isLoading) {


### PR DESCRIPTION
ISSUES CLOSED: #2329

## molecule/avatar

#### `❓ Ask`

**TASK**: #2329

### Types of changes

- [X] 🧠 Refactor

### Description, Motivation and Context

This PRs replaces `cloneElement`statements from  remaining places of the `molecule/avatar` component in favor of the sui `Injector` component.

Submitted for the hacktoberfest event. It should not have any visual effect, just a refactor.

Do not merge before https://github.com/SUI-Components/sui-components/pull/2345 to avoid missing dependency problems.