### PR TITLE
Fix/1795 input number safari

### DIFF
--- a/components/atom/input/src/helper.js
+++ b/components/atom/input/src/helper.js
@@ -1,0 +1,7 @@
+export const checkIfValidNumberInput = event => {
+  // Check if input type number is valid as input type number doesn't currently work in browsers like Safari and Firefox
+  // Allowing: Integers | Backspace | Tab | Delete | Left & Right arrow keys
+  const allowedCharacter = /(^\d*$)|(Backspace|Tab|Delete|ArrowLeft|ArrowRight)/
+
+  return !event.key.match(allowedCharacter) && event.preventDefault()
+}

--- a/components/atom/input/src/index.js
+++ b/components/atom/input/src/index.js
@@ -17,7 +17,7 @@ const AtomInput = forwardRef(({type, ...props}, ref) => {
     case 'number':
       return (
         <Input
-          onKeyDown={e => checkIfValidNumberInput(e)}
+          onKeyDown={checkIfValidNumberInput}
           ref={ref}
           type={type}
           {...props}

--- a/components/atom/input/src/index.js
+++ b/components/atom/input/src/index.js
@@ -8,11 +8,29 @@ import Password from './Password/index.js'
 import {INPUT_SHAPES, TYPES} from './config.js'
 
 const AtomInput = forwardRef(({type, ...props}, ref) => {
+  const checkIfValidNumberInput = event => {
+    // Check if input type number is valid as input type number doesn't currently work in browsers like Safari and Firefox
+    // Allowing: Integers | Backspace | Tab | Delete | Left & Right arrow keys
+    const allowedCharacter =
+      /(^\d*$)|(Backspace|Tab|Delete|ArrowLeft|ArrowRight)/
+
+    return !event.key.match(allowedCharacter) && event.preventDefault()
+  }
   switch (type) {
     case 'sui-password':
       return <Password ref={ref} {...props} />
     case 'mask':
       return <Mask ref={ref} {...props} />
+    case 'number':
+      return (
+        <Input
+          ref={ref}
+          {...props}
+          type={type}
+          onKeyDown={e => checkIfValidNumberInput(e)}
+        />
+      )
+
     default:
       return <Input ref={ref} {...props} type={type} />
   }

--- a/components/atom/input/src/index.js
+++ b/components/atom/input/src/index.js
@@ -24,10 +24,10 @@ const AtomInput = forwardRef(({type, ...props}, ref) => {
     case 'number':
       return (
         <Input
-          ref={ref}
-          {...props}
-          type={type}
           onKeyDown={e => checkIfValidNumberInput(e)}
+          ref={ref}
+          type={type}
+          {...props}
         />
       )
 

--- a/components/atom/input/src/index.js
+++ b/components/atom/input/src/index.js
@@ -6,16 +6,9 @@ import Input, {inputSizes, inputStates} from './Input/index.js'
 import Mask from './Mask/index.js'
 import Password from './Password/index.js'
 import {INPUT_SHAPES, TYPES} from './config.js'
+import {checkIfValidNumberInput} from './helper.js'
 
 const AtomInput = forwardRef(({type, ...props}, ref) => {
-  const checkIfValidNumberInput = event => {
-    // Check if input type number is valid as input type number doesn't currently work in browsers like Safari and Firefox
-    // Allowing: Integers | Backspace | Tab | Delete | Left & Right arrow keys
-    const allowedCharacter =
-      /(^\d*$)|(Backspace|Tab|Delete|ArrowLeft|ArrowRight)/
-
-    return !event.key.match(allowedCharacter) && event.preventDefault()
-  }
   switch (type) {
     case 'sui-password':
       return <Password ref={ref} {...props} />

--- a/components/molecule/avatar/package.json
+++ b/components/molecule/avatar/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "@s-ui/react-atom-image": "2",
-    "@s-ui/react-atom-skeleton": "1"
+    "@s-ui/react-atom-skeleton": "1",
+    "@s-ui/react-primitive-injector": "1"
   },
   "peerDependencies": {
     "@s-ui/component-dependencies": "1"

--- a/components/molecule/avatar/src/index.js
+++ b/components/molecule/avatar/src/index.js
@@ -1,10 +1,4 @@
-import {
-  Children,
-  cloneElement,
-  forwardRef,
-  isValidElement,
-  useCallback
-} from 'react'
+import {forwardRef, useCallback} from 'react'
 
 import cx from 'classnames'
 import PropTypes from 'prop-types'
@@ -14,6 +8,7 @@ import AtomSkeleton, {
   ATOM_SKELETON_ANIMATIONS,
   ATOM_SKELETON_VARIANTS
 } from '@s-ui/react-atom-skeleton'
+import Injector from '@s-ui/react-primitive-injector'
 
 import AvatarBadge, {
   AVATAR_BADGE_PLACEMENTS,
@@ -42,15 +37,12 @@ const MoleculeAvatar = forwardRef(
       style,
       isLoading,
       imageProps = {},
-      children: childrenProp,
+      children,
       ...others
     },
     forwardedRef
   ) => {
     const className = cx(baseClassName, `${baseClassName}--${size}`)
-    const children = Children.toArray(childrenProp)
-      .filter(child => isValidElement(child))
-      .map(child => cloneElement(child, {size}))
 
     const renderContent = useCallback(() => {
       if (isLoading) {
@@ -73,7 +65,7 @@ const MoleculeAvatar = forwardRef(
           ) : (
             fallback
           )}
-          {!isLoading && children}
+          {!isLoading && <Injector size={size}>{children}</Injector>}
         </>
       )
     }, [


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**:  #1795 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
- Input type number accepts other characters in the Safari and Firefox browser
- To fix the issue an additional validator function was added to the input type number

