### PR TITLE
feat(components/atom/popover): add icon color type

### DIFF
--- a/components/atom/popover/demo/ArticleType.js
+++ b/components/atom/popover/demo/ArticleType.js
@@ -1,32 +1,68 @@
 import AtomPopover from 'components/atom/popover/src/index.js'
 import PropTypes from 'prop-types'
 
-import {Article, Button, H2, Paragraph} from '@s-ui/documentation-library'
+import IconClose from './Icons/IconClose.js'
+import {
+  Article,
+  Button,
+  H2,
+  Paragraph,
+  Grid,
+  Cell
+} from '@s-ui/documentation-library'
 
 const ArticleType = ({className, content: Content}) => {
   return (
-    <Article className={className} style={{display: 'flex', alignItems: 'end'}}>
-      <div>
-        <H2>Custom Types</H2>
-        <Paragraph>
-          You can even define some other extra types defining your own vertical
-          custom types and looping this defined keys through scss.
-        </Paragraph>
-      </div>
-
-      <AtomPopover type="dark" isVisible content={Content} hideArrow={false}>
-        <Button
-          onClick={() => {}}
-          outline
-          style={{
-            display: 'inline-block',
-            margin: '0 auto',
-            height: 'fit-content'
-          }}
-        >
-          Target
-        </Button>
-      </AtomPopover>
+    <Article className={className}>
+      <H2>Custom Types</H2>
+      <Paragraph>
+        You can even define some other extra types defining your own vertical
+        custom types and looping this defined keys through scss.
+      </Paragraph>
+      <Grid cols={2} gutter={[8, 8]} style={{paddingTop: 150}}>
+        <Cell style={{display: 'flex', justifyContent: 'center'}}>
+          <AtomPopover
+            type="dark"
+            isVisible
+            closeIcon={<IconClose />}
+            content={Content}
+            hideArrow={false}
+          >
+            <Button
+              onClick={() => {}}
+              outline
+              style={{
+                display: 'inline-block',
+                margin: '0 auto',
+                height: 'fit-content'
+              }}
+            >
+              Target
+            </Button>
+          </AtomPopover>
+        </Cell>
+        <Cell style={{display: 'flex', justifyContent: 'center'}}>
+          <AtomPopover
+            type="alert"
+            isVisible
+            closeIcon={<IconClose />}
+            content={Content}
+            hideArrow={false}
+          >
+            <Button
+              onClick={() => {}}
+              outline
+              style={{
+                display: 'inline-block',
+                margin: '0 auto',
+                height: 'fit-content'
+              }}
+            >
+              Target
+            </Button>
+          </AtomPopover>
+        </Cell>
+      </Grid>
     </Article>
   )
 }

--- a/components/atom/popover/demo/index.scss
+++ b/components/atom/popover/demo/index.scss
@@ -1,13 +1,21 @@
 @import '~@s-ui/theme/lib/index';
 
+@import '../src/styles/settings';
+
 $popover-type: (
   dark: (
     bgc: $c-gray-dark-3,
-    bdc: $c-gray-dark-3
+    bdc: $c-gray-dark-3,
+    c-icon: $c-white
+  ),
+  alert: (
+    bgc: $c-alert-dark-3,
+    bdc: $c-alert-dark-3,
+    c-icon: $c-white
   )
 );
 
-@import '../src/index';
+@import '../src/styles/index';
 
 .DemoAtomPopover-section {
   .blink {

--- a/components/atom/popover/src/styles/index.scss
+++ b/components/atom/popover/src/styles/index.scss
@@ -27,10 +27,16 @@ $class-arrow: '#{$base-class}-arrow';
     @each $type-key, $type-value in $popover-type {
       $bgc: map-get($type-value, bgc);
       $bdc: map-get($type-value, bdc);
+      $c-icon: map-get($type-value, c-icon);
 
       &--type-#{$type-key} {
         background-color: $bgc;
         border-color: $bdc;
+        #{$base-class}-closeIcon {
+          svg {
+            fill: $c-icon;
+          }
+        }
       }
     }
   }
@@ -43,7 +49,7 @@ $class-arrow: '#{$base-class}-arrow';
     z-index: $z-tooltips;
 
     svg {
-      fill: $c-atom-popover-close-icon !important;
+      fill: $c-atom-popover-close-icon;
       height: $sz-atom-popover-close-icon;
       width: $sz-atom-popover-close-icon;
     }


### PR DESCRIPTION
## Atom/Popover
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
`🔍 Show`
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
adds the possibility to customize the closing icon color to the different "types" defined

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
