### PR TITLE
feat(components/atom/pinInput): create new token to be able to overwr…

### DIFF
--- a/components/atom/pinInput/src/PinInputField.scss
+++ b/components/atom/pinInput/src/PinInputField.scss
@@ -10,6 +10,10 @@
   padding: 0;
   text-align: center;
 
+  &::placeholder {
+    color: $c-pin-input-placeholder;
+  }
+
   &:focus {
     border: $bdw-s solid $c-primary-dark;
     cursor: text;

--- a/components/atom/pinInput/src/config.scss
+++ b/components/atom/pinInput/src/config.scss
@@ -4,6 +4,7 @@ $bdw-pin-input-field: $bdw-s !default;
 $fw-pin-input-field: $fw-regular !default;
 $lh-pin-input-field: $lh-m !default;
 $m-pin-input-children: $m-m !default;
+$c-pin-input-placeholder: inherit !default;
 
 $s-pin-input-field: (
   // 64px

--- a/components/atom/pinInput/src/config.scss
+++ b/components/atom/pinInput/src/config.scss
@@ -4,7 +4,7 @@ $bdw-pin-input-field: $bdw-s !default;
 $fw-pin-input-field: $fw-regular !default;
 $lh-pin-input-field: $lh-m !default;
 $m-pin-input-children: $m-m !default;
-$c-pin-input-placeholder: inherit !default;
+$c-pin-input-placeholder: auto !default;
 
 $s-pin-input-field: (
   // 64px


### PR DESCRIPTION
## Atom/PinInput

#### `🔍 Show` 


### Types of changes

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [X] 💄 Styles

### Description, Motivation and Context
 Create new token to be able to overwrite the placeholder color
