### PR TITLE
feat(components/molecule/avatar): make optional hex background of fallback name

### DIFF
--- a/components/molecule/avatar/src/AvatarFallbackName/index.js
+++ b/components/molecule/avatar/src/AvatarFallbackName/index.js
@@ -29,7 +29,7 @@ const MoleculeAvatarFallbackName = ({
     <div
       className={className}
       aria-label={nameProp}
-      style={backgroundColor}
+      style={{backgroundColor}}
       {...others}
     >
       {name}

--- a/components/molecule/avatar/src/AvatarFallbackName/index.js
+++ b/components/molecule/avatar/src/AvatarFallbackName/index.js
@@ -8,6 +8,7 @@ const MoleculeAvatarFallbackName = ({
   name: nameProp,
   size,
   className: classNameProp,
+  isHexBackground = true,
   ...others
 }) => {
   const className = cx(
@@ -27,7 +28,7 @@ const MoleculeAvatarFallbackName = ({
     <div
       className={className}
       aria-label={nameProp}
-      style={{backgroundColor}}
+      {...(isHexBackground && {style: {backgroundColor}})}
       {...others}
     >
       {name}
@@ -38,6 +39,7 @@ const MoleculeAvatarFallbackName = ({
 MoleculeAvatarFallbackName.displayName = 'MoleculeAvatarFallbackName'
 MoleculeAvatarFallbackName.propTypes = {
   className: PropTypes.string,
+  isHexBackground: PropTypes.bool,
   name: PropTypes.string,
   src: PropTypes.string,
   size: PropTypes.string

--- a/components/molecule/avatar/src/AvatarFallbackName/index.js
+++ b/components/molecule/avatar/src/AvatarFallbackName/index.js
@@ -1,14 +1,14 @@
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 
-import useConvertStringToHex from '../useConvertStringToHex.js'
+import useBackgroundColor from '../useBackgroundColor.js'
 import {BASE_CLASS_NAME} from './settings.js'
 
 const MoleculeAvatarFallbackName = ({
   name: nameProp,
   size,
   className: classNameProp,
-  fallbackColor: backgroundColorProp,
+  backgroundColor: backgroundColorProp,
   ...others
 }) => {
   const className = cx(
@@ -22,8 +22,10 @@ const MoleculeAvatarFallbackName = ({
       ? `${firstName.charAt(0)}${lastName.charAt(0)}`
       : firstName.charAt(0)
 
-  const stringToHexBackgroundColor = useConvertStringToHex(nameProp)
-  const backgroundColor = backgroundColorProp || stringToHexBackgroundColor
+  const backgroundColor = useBackgroundColor({
+    name: nameProp,
+    backgroundColor: backgroundColorProp
+  })
 
   return (
     <div
@@ -40,7 +42,7 @@ const MoleculeAvatarFallbackName = ({
 MoleculeAvatarFallbackName.displayName = 'MoleculeAvatarFallbackName'
 MoleculeAvatarFallbackName.propTypes = {
   className: PropTypes.string,
-  fallbackColor: PropTypes.string,
+  backgroundColor: PropTypes.string,
   name: PropTypes.string,
   src: PropTypes.string,
   size: PropTypes.string

--- a/components/molecule/avatar/src/AvatarFallbackName/index.js
+++ b/components/molecule/avatar/src/AvatarFallbackName/index.js
@@ -29,7 +29,7 @@ const MoleculeAvatarFallbackName = ({
     <div
       className={className}
       aria-label={nameProp}
-      {...{style: {backgroundColor}}}
+      style={backgroundColor}
       {...others}
     >
       {name}

--- a/components/molecule/avatar/src/AvatarFallbackName/index.js
+++ b/components/molecule/avatar/src/AvatarFallbackName/index.js
@@ -8,7 +8,7 @@ const MoleculeAvatarFallbackName = ({
   name: nameProp,
   size,
   className: classNameProp,
-  isHexBackground = true,
+  fallbackColor: backgroundColorProp,
   ...others
 }) => {
   const className = cx(
@@ -22,13 +22,14 @@ const MoleculeAvatarFallbackName = ({
       ? `${firstName.charAt(0)}${lastName.charAt(0)}`
       : firstName.charAt(0)
 
-  const backgroundColor = useConvertStringToHex(nameProp)
+  const stringToHexBackgroundColor = useConvertStringToHex(nameProp)
+  const backgroundColor = backgroundColorProp || stringToHexBackgroundColor
 
   return (
     <div
       className={className}
       aria-label={nameProp}
-      {...(isHexBackground && {style: {backgroundColor}})}
+      {...{style: {backgroundColor}}}
       {...others}
     >
       {name}
@@ -39,7 +40,7 @@ const MoleculeAvatarFallbackName = ({
 MoleculeAvatarFallbackName.displayName = 'MoleculeAvatarFallbackName'
 MoleculeAvatarFallbackName.propTypes = {
   className: PropTypes.string,
-  isHexBackground: PropTypes.bool,
+  fallbackColor: PropTypes.string,
   name: PropTypes.string,
   src: PropTypes.string,
   size: PropTypes.string

--- a/components/molecule/avatar/src/index.js
+++ b/components/molecule/avatar/src/index.js
@@ -33,6 +33,7 @@ const MoleculeAvatar = forwardRef(
       ),
       name,
       src,
+      fallbackColor,
       fallbackIcon,
       style,
       isLoading,
@@ -54,7 +55,7 @@ const MoleculeAvatar = forwardRef(
           name={name}
           size={size}
           icon={fallbackIcon}
-          {...others}
+          backgroundColor={fallbackColor}
         />
       )
 
@@ -75,14 +76,14 @@ const MoleculeAvatar = forwardRef(
       )
     }, [
       children,
+      fallbackColor,
       fallbackIcon,
       isLoading,
       name,
       size,
       skeleton,
       src,
-      imageProps,
-      others
+      imageProps
     ])
 
     return (
@@ -99,6 +100,7 @@ MoleculeAvatar.propTypes = {
   name: PropTypes.string,
   src: PropTypes.string,
   style: PropTypes.object,
+  fallbackColor: PropTypes.string,
   fallbackIcon: PropTypes.element,
   skeleton: PropTypes.element,
   isLoading: PropTypes.bool,

--- a/components/molecule/avatar/src/index.js
+++ b/components/molecule/avatar/src/index.js
@@ -50,7 +50,12 @@ const MoleculeAvatar = forwardRef(
       }
 
       const fallback = (
-        <AvatarFallback name={name} size={size} icon={fallbackIcon} />
+        <AvatarFallback
+          name={name}
+          size={size}
+          icon={fallbackIcon}
+          {...others}
+        />
       )
 
       return (
@@ -76,7 +81,8 @@ const MoleculeAvatar = forwardRef(
       size,
       skeleton,
       src,
-      imageProps
+      imageProps,
+      others
     ])
 
     return (

--- a/components/molecule/avatar/src/useBackgroundColor.js
+++ b/components/molecule/avatar/src/useBackgroundColor.js
@@ -22,10 +22,11 @@ const convertStringToHex = str => {
   return color
 }
 
-const useConvertStringToHex = str => {
+const useBackgroundColor = ({name, backgroundColor}) => {
   return useMemo(() => {
-    return str ? convertStringToHex(str) : undefined
-  }, [str])
+    if (backgroundColor) return backgroundColor
+    return name ? convertStringToHex(name) : undefined
+  }, [name, backgroundColor])
 }
 
-export default useConvertStringToHex
+export default useBackgroundColor


### PR DESCRIPTION
## Molecule/Avatar
#### `🔍 Show`

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)

### Description, Motivation and Context
Until now, name fallback has a randomly generated background color from the name.
At motor, we need to use a defined background color for every name fallback avatar.