### PR TITLE
refactor(components/molecule/selectPopover): Add missing dependency o…

### DIFF
--- a/components/molecule/selectPopover/src/index.js
+++ b/components/molecule/selectPopover/src/index.js
@@ -52,51 +52,45 @@ function MoleculeSelectPopover({
   const selectRef = useRef()
   const contentWrapperRef = useRef()
 
-  const getPopoverClassName = () => {
-    const {left, right} =
-      contentWrapperRef.current?.getBoundingClientRect() || {}
-    const outFromTheLeftSide = left < 0
-    const outFromTheRightSide =
-      right > (window.innerWidth || document.documentElement.clientWidth)
-
-    if (outFromTheRightSide) {
-      return cx(`${popoverBaseClass}`, `${popoverBaseClass}--left`)
-    } else if (outFromTheLeftSide) {
-      return cx(`${popoverBaseClass}`, `${popoverBaseClass}--right`)
-    }
-
-    return popoverClassName
-  }
-
   useEffect(() => {
     /**
      * Only run open events:
      *  - After first render
      *  - When isOpen actually changes
+     *  - When placement changes
      **/
     if (typeof previousIsOpen === 'undefined' || isOpen === previousIsOpen) {
       return
     }
 
-    if (
-      isOpen &&
-      [PLACEMENTS.AUTO_END, PLACEMENTS.AUTO_START].includes(placement)
-    ) {
-      setPopoverClassName(getPopoverClassName())
-    }
+    const getPopoverClassName = () => {
+      if (
+        isOpen &&
+        [PLACEMENTS.AUTO_END, PLACEMENTS.AUTO_START].includes(placement)
+      ) {
+        const {left, right} =
+          contentWrapperRef.current?.getBoundingClientRect() || {}
+        const outFromTheLeftSide = left < 0
+        const outFromTheRightSide =
+          right > (window.innerWidth || document.documentElement.clientWidth)
 
-    const openEvent = isOpen ? onOpen : onClose
-    openEvent()
-  }, [isOpen, onClose, onOpen, previousIsOpen, getPopoverClassName])
+        if (outFromTheRightSide) {
+          return cx(`${popoverBaseClass}`, `${popoverBaseClass}--left`)
+        } else if (outFromTheLeftSide) {
+          return cx(`${popoverBaseClass}`, `${popoverBaseClass}--right`)
+        }
+      }
 
-  useEffect(() => {
-    setPopoverClassName(
-      cx(
+      return cx(
         `${popoverBaseClass}`,
         `${popoverBaseClass}--${getPlacement(placement)}`
       )
-    )
-  }, [placement])
+    }
+
+    setPopoverClassName(getPopoverClassName())
+    const openEvent = isOpen ? onOpen : onClose
+    openEvent()
+  }, [isOpen, onClose, onOpen, previousIsOpen, placement])
 
   const selectClassName = cx(
     `${BASE_CLASS}-select`,

--- a/components/molecule/selectPopover/test/index.test.js
+++ b/components/molecule/selectPopover/test/index.test.js
@@ -10,7 +10,10 @@ import ReactDOM from 'react-dom'
 import chai, {expect} from 'chai'
 import chaiDOM from 'chai-dom'
 
+import {fireEvent} from '@testing-library/react'
+
 import json from '../package.json'
+import {PLACEMENTS} from '../src/config.js'
 import * as pkg from '../src/index.js'
 
 chai.use(chaiDOM)
@@ -170,6 +173,55 @@ describe(json.name, () => {
         expect(Object.keys(actual).includes(expectedKey)).to.be.true
         expect(actual[expectedKey]).to.equal(expectedValue)
       })
+    })
+  })
+
+  describe('should render appropriate popoverclass for placement', () => {
+    it('should render appropriate popoverclass for Auto start placement', () => {
+      // Given
+      const props = {
+        acceptButtonText: 'acceptButtonText',
+        cancelButtonText: 'cancelButtonText',
+        iconArrowDown: () => <svg />,
+        selectText: 'selectText',
+        children: 'children',
+        placement: PLACEMENTS.AUTO_START
+      }
+
+      // When
+      const {container} = setup(props)
+
+      // Then
+      const select = container.querySelector(
+        '[class="sui-MoleculeSelectPopover-selectIcon"]'
+      )
+      fireEvent.click(select)
+      expect(container.innerHTML).to.include(
+        'sui-MoleculeSelectPopover-popover--left'
+      )
+    })
+    it('should render appropriate popoverclass for Auto end placement', () => {
+      // Given
+      const props = {
+        acceptButtonText: 'acceptButtonText',
+        cancelButtonText: 'cancelButtonText',
+        iconArrowDown: () => <svg />,
+        selectText: 'selectText',
+        children: 'children',
+        placement: PLACEMENTS.AUTO_END
+      }
+
+      // When
+      const {container} = setup(props)
+
+      // Then
+      const select = container.querySelector(
+        '[class="sui-MoleculeSelectPopover-selectIcon"]'
+      )
+      fireEvent.click(select)
+      expect(container.innerHTML).to.include(
+        'sui-MoleculeSelectPopover-popover--right'
+      )
     })
   })
 })


### PR DESCRIPTION
Add placement as a dependency to UseEffect

ISSUES CLOSED: #2404

## Molecule/SelectPopover
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**:
Moved the method of setpopoverclass to single location and used placement as dependency

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [x] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
Based on placement, popover class is modified. Hence the component needs to be reloaded whenever
placement changes. This is to address that and also take care of the linting issue

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
