### PR TITLE
2380 demo panel all thumbnails should be 100px squares

### DIFF
--- a/components/atom/panel/demo/PanelAsImage/ArticleHorizontallyCropped.js
+++ b/components/atom/panel/demo/PanelAsImage/ArticleHorizontallyCropped.js
@@ -20,30 +20,30 @@ const ArticleHorizontallyCropped = ({className}) => {
           </div>
           <span>Original</span>
         </div>
-        <div style={Object.assign({}, flexItem, {width: '180px'})}>
+        <div style={Object.assign({}, flexItem, {width: '100px'})}>
           <AtomPanel
             src="https://picsum.photos/250/200"
             horizontalAlign={atomPanelHorizontalAlign.LEFT}
           >
-            <div style={{height: '200px'}} />
+            <div style={{height: '100px'}} />
           </AtomPanel>
           <span>Align to the left</span>
         </div>
-        <div style={Object.assign({}, flexItem, {width: '180px'})}>
+        <div style={Object.assign({}, flexItem, {width: '100px'})}>
           <AtomPanel
             src="https://picsum.photos/250/200"
             horizontalAlign={atomPanelHorizontalAlign.CENTER}
           >
-            <div style={{height: '200px'}} />
+            <div style={{height: '100px'}} />
           </AtomPanel>
           <span>Centered</span>
         </div>
-        <div style={Object.assign({}, flexItem, {width: '180px'})}>
+        <div style={Object.assign({}, flexItem, {width: '100px'})}>
           <AtomPanel
             src="https://picsum.photos/250/200"
             horizontalAlign={atomPanelHorizontalAlign.RIGHT}
           >
-            <div style={{height: '200px'}} />
+            <div style={{height: '100px'}} />
           </AtomPanel>
           <span>Align to the right</span>
         </div>

--- a/components/atom/panel/demo/PanelAsImage/ArticleOverlay.js
+++ b/components/atom/panel/demo/PanelAsImage/ArticleOverlay.js
@@ -20,14 +20,14 @@ const ArticleOverlay = ({className}) => {
             {Object.keys(atomPanelAlpha).map((alpha, index) => (
               <div
                 key={index}
-                style={Object.assign({}, flexItem, {width: '250px'})}
+                style={Object.assign({}, flexItem, {width: '100px'})}
               >
                 <AtomPanel
                   src="https://picsum.photos/250/200"
                   overlayColor={atomPanelColors[color]}
                   overlayAlpha={atomPanelAlpha[alpha]}
                 >
-                  <div style={{height: '150px'}} />
+                  <div style={{height: '100px'}} />
                 </AtomPanel>
                 <span>
                   {color} {alpha}

--- a/components/atom/panel/demo/PanelAsImage/ArticleOverlay.js
+++ b/components/atom/panel/demo/PanelAsImage/ArticleOverlay.js
@@ -23,7 +23,7 @@ const ArticleOverlay = ({className}) => {
                 style={Object.assign({}, flexItem, {width: '100px'})}
               >
                 <AtomPanel
-                  src="https://picsum.photos/250/200"
+                  src="https://picsum.photos/100/100"
                   overlayColor={atomPanelColors[color]}
                   overlayAlpha={atomPanelAlpha[alpha]}
                 >

--- a/components/atom/panel/demo/PanelAsImage/ArticlePlaceholder.js
+++ b/components/atom/panel/demo/PanelAsImage/ArticlePlaceholder.js
@@ -13,12 +13,12 @@ const ArticlePlaceholder = ({className}) => {
         This is the structure for the <Code>placeholder</Code>
       </Paragraph>
       <div style={{backgroundColor: 'white'}}>
-        <div style={{width: '200px', margin: 'auto'}}>
+        <div style={{width: '100px', margin: 'auto'}}>
           <AtomPanel
-            src="https://satyr.io/200/a3a3a3?delay=3g"
+            src="https://satyr.io/100/a3a3a3?delay=3g"
             color={atomPanelColors.BASE}
           >
-            <div style={{height: '210px'}} />
+            <div style={{height: '100px'}} />
           </AtomPanel>
         </div>
       </div>

--- a/components/atom/panel/demo/PanelAsImage/ArticleVerticallyCropped.js
+++ b/components/atom/panel/demo/PanelAsImage/ArticleVerticallyCropped.js
@@ -28,30 +28,30 @@ const ArticleVerticallyCropped = ({className}) => {
           </div>
           <span>Original</span>
         </div>
-        <div style={Object.assign({}, flexItem, {width: '250px'})}>
+        <div style={Object.assign({}, flexItem, {width: '100px'})}>
           <AtomPanel
             src="https://picsum.photos/250/200"
             verticalAlign={atomPanelVerticalAlign.TOP}
           >
-            <div style={{height: '150px'}} />
+            <div style={{height: '100px'}} />
           </AtomPanel>
           <span>Top</span>
         </div>
-        <div style={Object.assign({}, flexItem, {width: '250px'})}>
+        <div style={Object.assign({}, flexItem, {width: '100px'})}>
           <AtomPanel
             src="https://picsum.photos/250/200"
             verticalAlign={atomPanelVerticalAlign.CENTER}
           >
-            <div style={{height: '150px'}} />
+            <div style={{height: '100px'}} />
           </AtomPanel>
           <span>Center</span>
         </div>
-        <div style={Object.assign({}, flexItem, {width: '250px'})}>
+        <div style={Object.assign({}, flexItem, {width: '100px'})}>
           <AtomPanel
             src="https://picsum.photos/250/200"
             verticalAlign={atomPanelVerticalAlign.BOTTOM}
           >
-            <div style={{height: '150px'}} />
+            <div style={{height: '100px'}} />
           </AtomPanel>
           <span>Bottom</span>
         </div>


### PR DESCRIPTION
## ATOM/PANEL

#### `🔍 Show`

**TASK**: #2380 

### Types of changes

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
I've updated only the Articles that make sense have fixed the sizes. 

### Screenshots - Animations

<img width="919" alt="image" src="https://user-images.githubusercontent.com/3933098/197153313-9f65b818-9d13-4674-a470-cb006f519cca.png">


<img width="941" alt="image" src="https://user-images.githubusercontent.com/3933098/197152961-f3fc7a3c-5f23-4adc-addc-d2ba0f69d79d.png">

<img width="717" alt="image" src="https://user-images.githubusercontent.com/3933098/197153394-953f04af-0cc1-4919-93e4-4eb1687abab2.png">
