### PR TITLE
feat(components/molecule/selectPopover): improve overlay behavior

### DIFF
--- a/components/molecule/selectPopover/src/index.js
+++ b/components/molecule/selectPopover/src/index.js
@@ -274,8 +274,7 @@ function MoleculeSelectPopover({
 
   const overlayClassNames = cx(
     `${BASE_CLASS}-overlay`,
-    `${BASE_CLASS}-overlay--${overlayType}`,
-    {'is-open': isOpen}
+    `${BASE_CLASS}-overlay--${overlayType}`
   )
 
   return (
@@ -285,7 +284,7 @@ function MoleculeSelectPopover({
         {renderContentWrapper()}
       </div>
       {hasOverlay && (
-        <Portal as={Fragment}>
+        <Portal as={Fragment} isOpen={isOpen}>
           <div className={overlayClassNames} />
         </Portal>
       )}

--- a/components/molecule/selectPopover/src/styles/index.scss
+++ b/components/molecule/selectPopover/src/styles/index.scss
@@ -110,17 +110,10 @@ $base-class: '.sui-MoleculeSelectPopover ';
         content: '';
         height: 100%;
         left: 0;
-        opacity: $op-select-popover-initial-overlay;
+        opacity: $op-select-popover-overlay;
         position: absolute;
         top: 0;
-        transition: opacity 0.25s ease-in;
         width: 100%;
-
-        &.is-open {
-          $op: map-get($type, op);
-          opacity: $op;
-          pointer-events: none;
-        }
       }
     }
   }

--- a/components/molecule/selectPopover/src/styles/settings.scss
+++ b/components/molecule/selectPopover/src/styles/settings.scss
@@ -22,18 +22,15 @@ $op-select-popover: 0.4 !default;
 
 $z-select-popover-select-popover: $z-tooltips !default;
 
-$op-select-popover-initial-overlay: 0 !default;
-$op-select-popover-finish-overlay: 0.6 !default;
+$op-select-popover-overlay: 0.6 !default;
 $bgc-select-popover-dark-overlay: $c-black !default;
 $bgc-select-popover-light-overlay: $c-white !default;
 
 $molecule-select-popover-overlay-types: (
   dark: (
-    bgc: $bgc-select-popover-dark-overlay,
-    op: $op-select-popover-finish-overlay
+    bgc: $bgc-select-popover-dark-overlay
   ),
   light: (
-    bgc: $bgc-select-popover-light-overlay,
-    op: $op-select-popover-finish-overlay
+    bgc: $bgc-select-popover-light-overlay
   )
 ) !default;


### PR DESCRIPTION
## Molecule/SelectPopover
`🔍 Show`

### Types of changes

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
We add in the dom the node that contains the overlay only when the user interacts with the selectPopover.
This way we avoid adding unnecessary elements in the dom while avoiding some problems with the click events on the elements below the overlay.
