### PR TITLE
fix(components/atom/popover): arrow border color inherit from custom type

### DIFF
--- a/components/atom/popover/src/styles/index.scss
+++ b/components/atom/popover/src/styles/index.scss
@@ -83,7 +83,8 @@ $class-arrow: '#{$base-class}-arrow';
     }
 
     @each $type-key, $type-value in $popover-type {
-      &--type-#{$type-key}::after {
+      &--type-#{$type-key}::after,
+      &--type-#{$type-key}::before {
         border-bottom-color: map-get($type-value, bgc);
       }
     }


### PR DESCRIPTION
## atom/popover
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
`🔍 Show`
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
The arrow's border color when using a defined custom type are not inheriting the proper color defied in its token
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
