### PR TITLE
fix(components/atom/textarea): Fix issue with paddings in textarea

### DIFF
--- a/components/atom/textarea/src/styles/index.scss
+++ b/components/atom/textarea/src/styles/index.scss
@@ -10,8 +10,6 @@ $base-class: '.sui-AtomTextarea';
   font-size: $fz-atom-textarea;
   line-height: $lh-atom-textarea;
   padding: $p-atom-textarea;
-  padding-left: $pl-atom-textarea;
-  padding-top: $pt-atom-textarea;
   resize: $rsz-atom-textarea;
   width: $w-atom-textarea;
 
@@ -31,13 +29,15 @@ $base-class: '.sui-AtomTextarea';
 
   &--short {
     height: calc(
-      (#{$lh-atom-textarea} * #{$short-num-lines-atom-textarea}) + #{$pt-atom-textarea}
+      (#{$lh-atom-textarea} * #{$short-num-lines-atom-textarea}) + #{$p-atom-textarea +
+        $bdw-s} * 2
     );
   }
 
   &--long {
     height: calc(
-      (#{$lh-atom-textarea} * #{$long-num-lines-atom-textarea}) + #{$pt-atom-textarea}
+      (#{$lh-atom-textarea} * #{$long-num-lines-atom-textarea}) + #{$p-atom-textarea +
+        $bdw-s} * 2
     );
   }
 

--- a/components/atom/textarea/src/styles/settings.scss
+++ b/components/atom/textarea/src/styles/settings.scss
@@ -4,7 +4,6 @@ $short-num-lines-atom-textarea: $short-num-lines !default;
 $long-num-lines-atom-textarea: $long-num-lines !default;
 
 $p-atom-textarea: $p-m !default;
-$pl-atom-textarea: $p-l !default;
 $ff-atom-textarea: $ff-sans-serif !default;
 $fz-atom-textarea: $fz-base !default;
 $lh-atom-textarea: $lh-l !default;

--- a/components/atom/textarea/src/styles/settings.scss
+++ b/components/atom/textarea/src/styles/settings.scss
@@ -3,9 +3,7 @@ $long-num-lines: 7 !default;
 $short-num-lines-atom-textarea: $short-num-lines !default;
 $long-num-lines-atom-textarea: $long-num-lines !default;
 
-$p-atom-textarea: 2px !default;
-$pm-atom-textarea: $p-m !default; // deprecated
-$pt-atom-textarea: $pm-atom-textarea !default;
+$p-atom-textarea: $p-m !default;
 $pl-atom-textarea: $p-l !default;
 $ff-atom-textarea: $ff-sans-serif !default;
 $fz-atom-textarea: $fz-base !default;


### PR DESCRIPTION
## atom/textarea
`❓ Ask`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context

There was an issue in the paddings for the text area, it was applying a different size for the box:
- padding-top: 8px vs padding-bottom: 2px
- padding-left: 8px vs padding-right: 2px

Also there was an issue on the height for maximum lines, for example in size=long the if the user typed 7 lines, the scrollbar was shown

### Screenshots - Animations

Padding issue:

![image](https://user-images.githubusercontent.com/3693800/199529860-fbdd13bd-5a1d-43d7-ad70-569f5f98cb05.png)

Fixed:

![image](https://user-images.githubusercontent.com/3693800/199529994-f332f044-309e-4865-9569-d02a86dd2dfe.png)

Scrollbar issue:

![image](https://user-images.githubusercontent.com/3693800/199530087-690665e1-f069-412c-b5d6-a7624ef06b7e.png)

Fixed:

![image](https://user-images.githubusercontent.com/3693800/199530120-a0e91246-9034-4aa8-aa9e-acd6e40b71e5.png)
