### PR TITLE
feat(components/molecule/photoUploader): send extended info on photos uploaded callback

### DIFF
--- a/components/molecule/photoUploader/src/index.js
+++ b/components/molecule/photoUploader/src/index.js
@@ -122,17 +122,10 @@ const MoleculePhotoUploader = forwardRef(
 
     const _callbackPhotosUploaded = (list, ...rest) => {
       const blobsArray = list.reduce((array, currentFile) => {
-        const {blob, url, isNew, isModified, hasErrors, file, preview, id} =
-          currentFile
+        const {originalBase64, preview, ...restOfCurrentFile} = currentFile
         array.push({
-          blob,
-          url,
-          isNew,
-          isModified,
-          hasErrors,
-          file,
           previewUrl: preview,
-          id
+          ...restOfCurrentFile
         })
         return [...array]
       }, [])


### PR DESCRIPTION
## molecule/photoUploader
#### `🔍 Show`

Send all current file properties on photos uploaded callback, with the exception of original base 64 image.

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)

### Description, Motivation and Context
At motor, we need to access more current file properties when this callback is executed.
We ignore here the original base 64 file to prevent unnecessary extra work with big images.