### PR TITLE
feat(components/atom/tag): Customize background for close icon

### DIFF
--- a/components/atom/tag/demo/articles/ArticleTypes.js
+++ b/components/atom/tag/demo/articles/ArticleTypes.js
@@ -16,11 +16,30 @@ import {
 
 const noop = () => null
 
-const ArticleTypes = ({className, icon: iconProp}) => {
+const ArticleTypes = ({className, icon, closeIcon}) => {
   const [disabled, setDisabled] = useState(false)
   const [outlined, setOutlined] = useState(false)
   const [actionable, setActionable] = useState(false)
-  const [icon, setIcon] = useState(null)
+  const [showIcon, setShowIcon] = useState(false)
+  const [closeable, setCloseable] = useState(false)
+
+  const props = {
+    actionable,
+    disabled,
+    design: outlined ? atomTagDesigns.OUTLINE : atomTagDesigns.SOLID,
+    icon: showIcon ? icon : null,
+    closeIcon: closeable ? closeIcon : null,
+    onClick: actionable ? noop : null
+  }
+
+  const availableFeatures = [
+    {label: 'Actionable', value: actionable, action: setActionable},
+    {label: 'Disabled', value: disabled, action: setDisabled},
+    {label: 'Outline', value: outlined, action: setOutlined},
+    {label: 'Icon', value: showIcon, action: setShowIcon},
+    {label: 'Closeicon', value: closeable, action: setCloseable}
+  ]
+
   return (
     <Article className={className}>
       <H2>Types</H2>
@@ -28,137 +47,46 @@ const ArticleTypes = ({className, icon: iconProp}) => {
         Use the <Code>type</Code> in order to color it as desired from a high
         order component.
       </Paragraph>
-      <Grid cols={4} gutter={[8, 8]} style={{maxWidth: 500}}>
-        <Cell>
-          <Grid cols={2} gutter={[8, 8]}>
-            <Cell
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'flex-end'
-              }}
-            >
-              <Label>Actionable</Label>
-            </Cell>
-            <Cell>
-              <RadioButton
-                value={actionable}
-                label={`${actionable}`}
-                onClick={() => setActionable(!actionable)}
-                fullWidth
-              />
-            </Cell>
-          </Grid>
-        </Cell>
-        <Cell>
-          <Grid cols={2} gutter={[8, 8]}>
-            <Cell
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'flex-end'
-              }}
-            >
-              <Label>Disabled</Label>
-            </Cell>
-            <Cell>
-              <RadioButton
-                value={disabled}
-                label={`${disabled}`}
-                onClick={() => setDisabled(!disabled)}
-                fullWidth
-              />
-            </Cell>
-          </Grid>
-        </Cell>
-        <Cell>
-          <Grid cols={2} gutter={[8, 8]}>
-            <Cell
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'flex-end'
-              }}
-            >
-              <Label>Outline</Label>
-            </Cell>
-            <Cell>
-              <RadioButton
-                value={outlined}
-                label={`${outlined}`}
-                onClick={() => setOutlined(!outlined)}
-                fullWidth
-              />
-            </Cell>
-          </Grid>
-        </Cell>
-        <Cell>
-          <Grid cols={2} gutter={[8, 8]}>
-            <Cell
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'flex-end'
-              }}
-            >
-              <Label>Icon</Label>
-            </Cell>
-            <Cell>
-              <RadioButton
-                value={!!icon}
-                label={`${!!icon}`}
-                onClick={() => setIcon(icon ? null : iconProp)}
-                fullWidth
-              />
-            </Cell>
-          </Grid>
-        </Cell>
+
+      <Grid cols={5} gutter={[8, 8]} style={{maxWidth: 500}}>
+        {availableFeatures.map(({label, value, action}) => (
+          <Cell>
+            <Grid cols={2} gutter={[8, 8]}>
+              <Cell
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'flex-end'
+                }}
+              >
+                <Label>{label}</Label>
+              </Cell>
+              <Cell>
+                <RadioButton
+                  value={value}
+                  label={String(value)}
+                  onClick={() => action(val => !val)}
+                  fullWidth
+                />
+              </Cell>
+            </Grid>
+          </Cell>
+        ))}
       </Grid>
       <br />
       <br />
 
-      <AtomTag
-        label="Alert"
-        type="alert"
-        disabled={disabled}
-        design={outlined ? atomTagDesigns.OUTLINE : atomTagDesigns.SOLID}
-        icon={icon}
-        {...{...(actionable && {onClick: noop})}}
-      />
-
-      <AtomTag
-        label="Warning"
-        type="warning"
-        disabled={disabled}
-        design={outlined ? atomTagDesigns.OUTLINE : atomTagDesigns.SOLID}
-        icon={icon}
-        {...{...(actionable && {onClick: noop})}}
-      />
-
-      <AtomTag
-        label="Special"
-        type="special"
-        disabled={disabled}
-        design={outlined ? atomTagDesigns.OUTLINE : atomTagDesigns.SOLID}
-        icon={icon}
-        {...{...(actionable && {onClick: noop})}}
-      />
-
-      <AtomTag
-        label="5 min ago"
-        type="date"
-        disabled={disabled}
-        design={outlined ? atomTagDesigns.OUTLINE : atomTagDesigns.SOLID}
-        icon={icon}
-        {...{...(actionable && {onClick: noop})}}
-      />
+      {['Alert', 'Warning', 'Special', 'Date'].map(type => (
+        <AtomTag label={type} type={type.toLocaleLowerCase()} {...props} />
+      ))}
     </Article>
   )
 }
 
 ArticleTypes.propTypes = {
   className: PropTypes.string,
-  icon: PropTypes.node
+  icon: PropTypes.node,
+  closeIcon: PropTypes.node
 }
 
 export default ArticleTypes

--- a/components/atom/tag/demo/index.js
+++ b/components/atom/tag/demo/index.js
@@ -6,7 +6,7 @@ import ArticleIcons from './articles/ArticleIcons.js'
 import ArticleIsFitted from './articles/ArticleIsFitted.js'
 import ArticleSize from './articles/ArticleSize.js'
 import ArticleTypes from './articles/ArticleTypes.js'
-import {CLASS_SECTION, icon} from './settings.js'
+import {CLASS_SECTION, closeIcon, icon} from './settings.js'
 
 import './index.scss'
 
@@ -27,7 +27,7 @@ export default () => (
     <br />
     <Article className={CLASS_SECTION}></Article>
     <br />
-    <ArticleTypes className={CLASS_SECTION} icon={icon} />
+    <ArticleTypes className={CLASS_SECTION} icon={icon} closeIcon={closeIcon} />
     <br />
     <ArticleIsFitted className={CLASS_SECTION} icon={icon} />
   </div>

--- a/components/atom/tag/demo/index.scss
+++ b/components/atom/tag/demo/index.scss
@@ -12,8 +12,10 @@ $atom-tag-types: (
   'warning': (
     bgc: orange,
     c: white,
-    bgc-hover: color-variation(orange, 2),
-    c-hover: white
+    c-hover: white,
+    c-icon-close: blue,
+    c-icon-close-hover: blue,
+    bgc-icon-close-hover: color-variation(blue, 2)
   ),
   'special': (
     bgc: blue,

--- a/components/atom/tag/src/styles/index.scss
+++ b/components/atom/tag/src/styles/index.scss
@@ -196,6 +196,9 @@ $base-class: '.sui-AtomTag';
     $bds: map-get($type, bds);
     $bdw: map-get($type, bdw);
     $bdc-hover: map-get($type, bdc-hover);
+    $c-icon-close: map-get($type, c-icon-close);
+    $c-icon-close-hover: map-get($type, c-icon-close-hover);
+    $bgc-icon-close-hover: map-get($type, bgc-icon-close-hover);
 
     &--#{$name} {
       background-color: $bgc;
@@ -206,6 +209,7 @@ $base-class: '.sui-AtomTag';
       fill: $c;
 
       &#{$self}-actionable {
+        border: 1px solid;
         background-color: $bgc;
         border-color: $bdc;
         color: $c;
@@ -217,6 +221,18 @@ $base-class: '.sui-AtomTag';
         color: $bgc;
         background-color: $c;
         fill: $bgc;
+      }
+
+      & > #{$self}-closeable {
+        color: $c-icon-close;
+      }
+
+      #{$self}-closeable > #{$self}-closeableIcon {
+        color: $c-icon-close;
+        &:hover {
+          color: $c-icon-close-hover;
+          background-color: $bgc-icon-close-hover;
+        }
       }
 
       @if $bgc-hover or $c-hover {

--- a/components/atom/tag/src/styles/index.scss
+++ b/components/atom/tag/src/styles/index.scss
@@ -209,7 +209,6 @@ $base-class: '.sui-AtomTag';
       fill: $c;
 
       &#{$self}-actionable {
-        border: 1px solid;
         background-color: $bgc;
         border-color: $bdc;
         color: $c;


### PR DESCRIPTION
Allows to customize the close icon background and color when mouse hover

## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
`❓ Ask`

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**:  https://jira.scmspain.com/browse/PI-52232

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
In jobs we want to customize the close icon hover color to improve the UX
https://www.figma.com/file/x80a9OA3Q6bk182smlfZsl/CV_Refactor?node-id=2002%3A334&t=RsscI4T8ihl0YsBp-0
### Screenshots - Animations
We want to customize this default close icon color
![image](https://user-images.githubusercontent.com/3693800/201067142-24166d2d-a557-460f-915d-69f664890686.png)

According to this we want to customize this default close icon background color (when hover)
![image](https://user-images.githubusercontent.com/3693800/201066912-9a4aa073-c3db-4196-ad14-5031511b2b3b.png)

The custom type config for the icon color
![image](https://user-images.githubusercontent.com/3693800/201068590-76166236-fa12-41c4-bbfa-559b9ff65b31.png)

The custom type config for the icon background (when hover)
![image](https://user-images.githubusercontent.com/3693800/201068798-50acb86e-f627-47f4-8a54-2e867b8ff13d.png)
