### PR TITLE
fix(components/molecule/autosuggest): call on blur after typing

### DIFF
--- a/components/molecule/autosuggest/src/index.js
+++ b/components/molecule/autosuggest/src/index.js
@@ -163,8 +163,8 @@ const MoleculeAutosuggest = ({
           closeList(ev)
         } else {
           setFocus(false)
-          typeof onBlur === 'function' && onBlur()
         }
+        typeof onBlur === 'function' && onBlur()
       }
     }, 1)
     setFocus(true)

--- a/components/molecule/autosuggest/test/index.test.js
+++ b/components/molecule/autosuggest/test/index.test.js
@@ -12,7 +12,7 @@ import chai, {expect} from 'chai'
 import chaiDOM from 'chai-dom'
 import sinon from 'sinon'
 
-import {fireEvent} from '@testing-library/react'
+import {fireEvent, waitFor} from '@testing-library/react'
 
 import MoleculeDropDownOption from '@s-ui/react-molecule-dropdown-option'
 
@@ -416,6 +416,43 @@ describe(json.name, () => {
             )
             sinon.assert.called(spy)
           })
+        })
+      })
+      describe('onBlur', () => {
+        it('should call onBlur handler when clicking outside', async () => {
+          const onBlurSpy = sinon.spy()
+
+          const props = {
+            onBlur: onBlurSpy
+          }
+
+          const {getByRole} = setup(props)
+
+          const $textBox = getByRole('textbox')
+
+          $textBox.focus()
+          $textBox.blur()
+
+          await waitFor(() => expect(sinon.assert.called(onBlurSpy)))
+        })
+
+        it('should call onBlur handler when clicking outside after input a text', async () => {
+          const onBlurSpy = sinon.spy()
+
+          const props = {
+            onBlur: onBlurSpy
+          }
+
+          const {getByRole} = setup(props)
+          const $textBox = getByRole('textbox')
+          const changeEvent = {target: {value: 'asdf'}}
+
+          fireEvent.change(getByRole('textbox'), changeEvent)
+
+          $textBox.focus()
+          $textBox.blur()
+
+          await waitFor(() => expect(sinon.assert.called(onBlurSpy)))
         })
       })
     })


### PR DESCRIPTION
## molecule/autosuggest
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->

<!-- #### `🔍 Show` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**:  #2463 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
Onblur not being called after typing and/or selecting an option

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
