### PR TITLE
fix(components/atom/switch): FullWidth switch should have the text with align left

### DIFF
--- a/components/atom/switch/src/SwitchType/single.js
+++ b/components/atom/switch/src/SwitchType/single.js
@@ -65,6 +65,7 @@ export const SingleSwitchTypeRender = forwardRef(
               name={name}
               text={defaultLabelLeft ? label : labelLeft}
               optionalText={labelOptionalText}
+              inline={fullWidth ? 'left' : 'right'}
             />
           )}
           <button

--- a/components/atom/switch/src/SwitchType/single.js
+++ b/components/atom/switch/src/SwitchType/single.js
@@ -65,7 +65,6 @@ export const SingleSwitchTypeRender = forwardRef(
               name={name}
               text={defaultLabelLeft ? label : labelLeft}
               optionalText={labelOptionalText}
-              inline={fullWidth ? 'left' : 'right'}
             />
           )}
           <button

--- a/components/atom/switch/src/styles/index.scss
+++ b/components/atom/switch/src/styles/index.scss
@@ -259,9 +259,5 @@ $base-class: '.sui-AtomSwitch';
 
   &--fullWidth {
     width: 100%;
-
-    .sui-AtomLabel {
-      text-align: left;
-    }
   }
 }

--- a/components/atom/switch/src/styles/index.scss
+++ b/components/atom/switch/src/styles/index.scss
@@ -259,5 +259,9 @@ $base-class: '.sui-AtomSwitch';
 
   &--fullWidth {
     width: 100%;
+
+    .sui-AtomLabel {
+      text-align: left;
+    }
   }
 }


### PR DESCRIPTION
## atom/switch

`❓ Ask` 

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Types of changes

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
FullWidth switch should have the text with align left