### PR TITLE
fix(components/atom/tag): Avoid rendering an empty label if there is …

### DIFF
--- a/components/atom/tag/src/Actionable/index.js
+++ b/components/atom/tag/src/Actionable/index.js
@@ -42,9 +42,11 @@ const ActionableTag = function ({
       {icon && iconPlacement === LEFT_ICON_PLACEMENT && (
         <span className="sui-AtomTag-icon">{icon}</span>
       )}
-      <span className="sui-AtomTag-label" title={title || label}>
-        {label}
-      </span>
+      {label ? (
+        <span className="sui-AtomTag-label" title={title || label}>
+          {label}
+        </span>
+      ) : null}
       {icon && iconPlacement === RIGHT_ICON_PLACEMENT && (
         <span className="sui-AtomTag-secondary-icon">{icon}</span>
       )}

--- a/components/atom/tag/src/Standard.js
+++ b/components/atom/tag/src/Standard.js
@@ -22,9 +22,11 @@ const StandardTag = ({
       {...(readOnly && !disabled && {'aria-readonly': readOnly})}
     >
       {icon && <span className="sui-AtomTag-icon">{icon}</span>}
-      <span className="sui-AtomTag-label" title={title || label}>
-        {label}
-      </span>
+      {label ? (
+        <span className="sui-AtomTag-label" title={title || label}>
+          {label}
+        </span>
+      ) : null}
       {closeIcon && !(disabled || readOnly) && (
         <span
           className="sui-AtomTag-closeable"


### PR DESCRIPTION
## atom/tag
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
`❓ Ask`

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
Remove the "span" from the label when it is not necessary. Centre the content of the tag (in this case the icon).

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->

**BEFORE:**
![Captura de Pantalla 2022-11-17 a las 13 37 49](https://user-images.githubusercontent.com/6562273/202456525-b902c88d-8ea7-4d7b-b138-ec1611c13031.png)


**AFTER:**
![Captura de Pantalla 2022-11-17 a las 13 38 07](https://user-images.githubusercontent.com/6562273/202456577-69c64878-1c83-4c8f-91b0-205c560e7362.png)


