### PR TITLE
feat(components/molecule/dataCounter): control nan values unpon clear…

### DIFF
--- a/components/molecule/dataCounter/src/index.js
+++ b/components/molecule/dataCounter/src/index.js
@@ -96,9 +96,12 @@ const MoleculeDataCounter = forwardRef(
     }
 
     const handleChange = (event, {value}) => {
-      const newValue = parseInt(value, 10)
+      const parsedIntNewValue = parseInt(value, 10)
+
+      const diffValue = isNaN(parsedIntNewValue) && 0
+
       assignDiff(event, {
-        diff: isNaN(newValue) ? undefined : 0,
+        diff: diffValue,
         lastAction: ACTIONS.CHANGE
       })
     }

--- a/components/molecule/dataCounter/test/index.test.js
+++ b/components/molecule/dataCounter/test/index.test.js
@@ -10,6 +10,8 @@ import ReactDOM from 'react-dom'
 import chai, {expect} from 'chai'
 import chaiDOM from 'chai-dom'
 
+import userEvents from '@testing-library/user-event'
+
 import json from '../package.json'
 import * as pkg from '../src/index.js'
 
@@ -91,6 +93,20 @@ describe(json.name, () => {
 
       // Then
       expect(findClassName(container.innerHTML)).to.be.null
+    })
+
+    it('should not allow to reach NaN values', () => {
+      // Given
+
+      // When
+      const {getByRole, getByDisplayValue} = setup({value: 10})
+
+      const dataCounterInputTextBox = getByRole('textbox')
+
+      userEvents.clear(dataCounterInputTextBox)
+
+      // Then
+      expect(getByDisplayValue(10)).to.exist
     })
   })
 

--- a/components/molecule/dataCounter/test/index.test.js
+++ b/components/molecule/dataCounter/test/index.test.js
@@ -97,12 +97,10 @@ describe(json.name, () => {
 
     it('should not allow to reach NaN values', () => {
       // Given
-
-      // When
       const {getByRole, getByDisplayValue} = setup({value: 10})
 
+      // When
       const dataCounterInputTextBox = getByRole('textbox')
-
       userEvents.clear(dataCounterInputTextBox)
 
       // Then


### PR DESCRIPTION
…ing input value

## molecule/dataCounter
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->

#### `🔍 Show`
#### `❓ Ask`

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context
Control if user clears the input, handle NaN values
### Screenshots - Animations
![2022-11-28 15 48 16](https://user-images.githubusercontent.com/22222078/204307396-c067a1ae-e2a2-4053-9093-a61bafacb408.gif)

<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
