### PR TITLE
fix(components/atom/panel): Fix border radius on overlay

### DIFF
--- a/components/atom/panel/src/styles/index.scss
+++ b/components/atom/panel/src/styles/index.scss
@@ -4,6 +4,9 @@ $base-class: '.sui-atom-panel';
   @each $type, $attr in $bdrs-atom-panel-rounded {
     &--rounded-#{$type} {
       border-radius: $attr;
+      &::before {
+        border-radius: $attr;
+      }
     }
   }
 


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [x] 💄 Styles

### Description, Motivation and Context
<!--- Describe your changes in detail -->

Add border radius on 'Panel' when we are using the props overlay and rounded at the same time. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
