### PR TITLE
fix(components/molecule/select): Avoid problems when auto-focusing first select option

### DIFF
--- a/components/molecule/select/src/index.js
+++ b/components/molecule/select/src/index.js
@@ -51,8 +51,6 @@ const MoleculeSelect = forwardRef((props, forwardedRef) => {
   const [optionsData, setOptionsData] = useState(getOptionData(children))
   const [focus, setFocus] = useState(false)
 
-  const options = refsMoleculeSelectOptions.current.map(getTarget)
-
   const extendedChildren = Children.toArray(children)
     .filter(Boolean)
     .map((child, index) => {
@@ -100,6 +98,9 @@ const MoleculeSelect = forwardRef((props, forwardedRef) => {
   }, [children, handleOutsideClick])
 
   const focusFirstOption = ev => {
+    const options = refsMoleculeSelectOptions.current.map(option =>
+      getTarget(option.current)
+    )
     options[0] && options[0].focus()
     ev.preventDefault()
     ev.stopPropagation()


### PR DESCRIPTION
## Molecule/Select

#### `🔍 Show`

### Description, Motivation and Context

**Co-author**

/w @davidmartin84 

**Motivation**

In CNET PRO, the vehicle form was not usable enough as it was not operable with key shortcuts. The main issue was that the tab key was not being properly recognized, and the user was not able to navigate between fields and select their value just by tabulating and selecting values.

**Changes**

There were race conditions in the way the variable `options` (which is a list of the option elements available to be selected) was calculated.

The `options` variable was calculated during the render process, but then it was required to auto-select the first available option when the select was clicked.

This was causing a race condition in which the `options` variable had un-updated values, and because of this the first option was not auto-focused when the select was opened. At the end, this resulted in not being able of operating the molecule select component by the keyboard.

### Types of changes

- [X] 🪲 Bug fix (non-breaking change which fixes an issue)
