### PR TITLE
Feature/add left addon prop

### DIFF
--- a/components/molecule/dropdownOption/demo/ArticleLeftAddons.js
+++ b/components/molecule/dropdownOption/demo/ArticleLeftAddons.js
@@ -1,0 +1,103 @@
+import {useState} from 'react'
+
+import PropTypes from 'prop-types'
+
+import {
+  Article,
+  Cell,
+  Code,
+  Grid,
+  H2,
+  Input,
+  Label,
+  Paragraph
+} from '@s-ui/documentation-library'
+
+import MoleculeDropdownOption from '../src/index.js'
+import {CLASS_DEMO_OPTION, OPTIONS_WITH_LEFT_ADDON} from './config.js'
+
+const ArticleBehavior = ({className}) => {
+  const [singleData, setSingleData] = useState([])
+  const [multipleData, setMultipleData] = useState([])
+
+  const handleSelectSingle = (event, {value, selected}) => {
+    setSingleData(selected ? [value] : [])
+  }
+
+  const handleSelectMultiple = (event, {value, selected}) => {
+    setMultipleData(
+      selected
+        ? [...multipleData, value]
+        : [...multipleData.filter(data => data !== value)]
+    )
+  }
+
+  return (
+    <Article className={className}>
+      <H2>LEFT ADDON</H2>
+      <Paragraph>
+        Every option can have an optional left addon, defined with{' '}
+        <Code>leftAddon</Code> (react-node) prop.
+      </Paragraph>
+      <Grid cols={2} gutter={[8, 8]}>
+        <Cell>
+          <Label>Single</Label>
+        </Cell>
+        <Cell>
+          <Label>Multiple</Label>
+        </Cell>
+        <Cell className={CLASS_DEMO_OPTION}>
+          {OPTIONS_WITH_LEFT_ADDON.map(({option, leftAddon}) => (
+            <MoleculeDropdownOption
+              key={option}
+              value={option}
+              leftAddon={leftAddon}
+              onSelect={handleSelectSingle}
+              selected={singleData.includes(option)}
+            >
+              {option}
+            </MoleculeDropdownOption>
+          ))}
+        </Cell>
+        <Cell className={CLASS_DEMO_OPTION}>
+          {OPTIONS_WITH_LEFT_ADDON.map(({option, leftAddon}) => (
+            <MoleculeDropdownOption
+              key={option}
+              value={option}
+              leftAddon={leftAddon}
+              textWrap={'noWrap'}
+              onSelect={handleSelectMultiple}
+              selected={multipleData.includes(option)}
+            >
+              {option}
+            </MoleculeDropdownOption>
+          ))}
+        </Cell>
+        <Cell>
+          <Input
+            readOnly
+            disabled
+            fullWidth
+            value={JSON.stringify(singleData, null, 2)}
+          />
+        </Cell>
+        <Cell>
+          <Input
+            readOnly
+            disabled
+            fullWidth
+            value={JSON.stringify(multipleData, null, 2)}
+          />
+        </Cell>
+      </Grid>
+    </Article>
+  )
+}
+
+ArticleBehavior.displayName = 'ArticleBehavior'
+
+ArticleBehavior.propTypes = {
+  className: PropTypes.string
+}
+
+export default ArticleBehavior

--- a/components/molecule/dropdownOption/demo/config.js
+++ b/components/molecule/dropdownOption/demo/config.js
@@ -1,3 +1,5 @@
+import AtomImage from '@s-ui/react-atom-image'
+
 export const BASE_CLASS_DEMO = 'DemoMoleculeDropdownOption'
 export const CLASS_DEMO_SECTION = `${BASE_CLASS_DEMO}-section`
 export const CLASS_DEMO_OPTION = `${BASE_CLASS_DEMO}-option`
@@ -10,4 +12,35 @@ export const OPTIONS = [
   'Option 5',
   'Option 6',
   'Option 7'
+]
+
+export const OPTIONS_WITH_LEFT_ADDON = [
+  {
+    option: 'Option 1',
+    leftAddon: (
+      <AtomImage
+        className="DemoMoleculeDropdownOption-image"
+        src={`https://imgur.com/sE9QMkm.png`}
+      />
+    )
+  },
+  {
+    option: 'Option 2',
+    leftAddon: (
+      <AtomImage
+        className="DemoMoleculeDropdownOption-image"
+        src={`https://imgur.com/1CAYX6G.png`}
+      />
+    )
+  },
+  {
+    option: 'Option 3',
+    leftAddon: (
+      <AtomImage
+        className="DemoMoleculeDropdownOption-image"
+        src={`https://imgur.com/DgwFO1R.png`}
+      />
+    )
+  },
+  {option: 'Option with no addon'}
 ]

--- a/components/molecule/dropdownOption/demo/index.js
+++ b/components/molecule/dropdownOption/demo/index.js
@@ -4,6 +4,7 @@ import ArticleBehavior from './ArticleBehavior.js'
 import ArticleDefault from './ArticleDefault.js'
 import ArticleDescription from './ArticleDescription.js'
 import ArticleHighLight from './ArticleHighLight.js'
+import ArticleLeftAddons from './ArticleLeftAddons.js'
 import ArticleTextWrap from './ArticleTextWrap.js'
 import {CLASS_DEMO_SECTION} from './config.js'
 
@@ -25,6 +26,8 @@ const Demo = () => (
     <ArticleDescription className={CLASS_DEMO_SECTION} />
     <br />
     <ArticleTextWrap className={CLASS_DEMO_SECTION} />
+    <br />
+    <ArticleLeftAddons className={CLASS_DEMO_SECTION} />
   </div>
 )
 

--- a/components/molecule/dropdownOption/demo/index.scss
+++ b/components/molecule/dropdownOption/demo/index.scss
@@ -1,4 +1,5 @@
 @import '../src/index';
+@import '~@s-ui/react-atom-image/lib/index';
 
 .DemoMoleculeDropdownOption {
   padding: 20px;
@@ -11,5 +12,11 @@
   pre {
     padding: 16px;
     width: 300px;
+  }
+
+  &-image {
+    display: flex;
+    height: $sz-icon-m;
+    width: $sz-icon-m;
   }
 }

--- a/components/molecule/dropdownOption/demo/package.json
+++ b/components/molecule/dropdownOption/demo/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@s-ui/react-atom-image": "2",
     "@s-ui/react-atom-input": "5",
     "@s-ui/react-hooks": "1",
     "lorem-ipsum": "2.0.4"

--- a/components/molecule/dropdownOption/src/_settings.scss
+++ b/components/molecule/dropdownOption/src/_settings.scss
@@ -23,6 +23,7 @@ $mt-molecule-dropdown-option-description: $m-s !default;
 $mr-molecule-dropdown-option-description: 0 !default;
 $mb-molecule-dropdown-option-description: 0 !default;
 $ml-molecule-dropdown-option-description: $m-s !default;
+$g-molecule-dropdown-option: $m-m !default;
 $p-molecule-dropdown-option: $p-l !default;
 $pl-molecule-dropdown-option: $p-molecule-dropdown-option !default;
 $pr-molecule-dropdown-option: $p-molecule-dropdown-option !default;

--- a/components/molecule/dropdownOption/src/config.js
+++ b/components/molecule/dropdownOption/src/config.js
@@ -10,6 +10,7 @@ export const CLASS_DISABLED = `${BASE_CLASS}--disabled`
 export const CLASS_WITH_DESCRIPTION = `${BASE_CLASS}--withDescription`
 export const CLASS_HIGHLIGHTED = `is-highlighted`
 export const CLASS_HIGHLIGHTED_MARK = `${BASE_CLASS}-mark`
+export const CLASS_LEFT_ADDON = `${BASE_CLASS}-leftAddon`
 
 export const TEXT_WRAP_STYLES = {
   NO_WRAP: 'noWrap',

--- a/components/molecule/dropdownOption/src/index.js
+++ b/components/molecule/dropdownOption/src/index.js
@@ -16,6 +16,7 @@ import {
   CLASS_DISABLED,
   CLASS_HIGHLIGHTED,
   CLASS_HIGHLIGHTED_MARK,
+  CLASS_LEFT_ADDON,
   CLASS_TEXT,
   CLASS_WITH_DESCRIPTION,
   MODIFIER_LINE_WRAP,
@@ -35,6 +36,7 @@ const MoleculeDropdownOption = forwardRef(
       highlightQuery,
       highlightValue,
       innerRef,
+      leftAddon,
       selectKey,
       onSelect,
       selected,
@@ -140,9 +142,14 @@ const MoleculeDropdownOption = forwardRef(
         {highlightQuery ? (
           renderHighlightOption(highlightValue || children)
         ) : (
-          <span onFocus={handleInnerFocus} className={innerClassName}>
-            {children}
-          </span>
+          <>
+            {leftAddon ? (
+              <span className={CLASS_LEFT_ADDON}>{leftAddon}</span>
+            ) : null}
+            <span onFocus={handleInnerFocus} className={innerClassName}>
+              {children}
+            </span>
+          </>
         )}
         {description && (
           <span className={CLASS_DESCRIPTION}>{description}</span>
@@ -168,6 +175,8 @@ MoleculeDropdownOption.propTypes = {
   checkboxProps: PropTypes.object,
   /** Is disabled */
   disabled: PropTypes.bool,
+  /** Custom element set at left side of an option */
+  leftAddon: PropTypes.node,
   /** onSelect callback (ev, {value}) */
   onSelect: PropTypes.func,
   /** Selected html controlled property */

--- a/components/molecule/dropdownOption/src/styles/index.scss
+++ b/components/molecule/dropdownOption/src/styles/index.scss
@@ -5,6 +5,7 @@ $base-class: '.sui-MoleculeDropdownOption';
   border-radius: $bdrs-molecule-dropdown-option;
   color: $c-dropdown-option;
   display: flex;
+  gap: $g-molecule-dropdown-option;
   min-height: $mih-dropdown-option;
   padding: $pt-molecule-dropdown-option $pr-molecule-dropdown-option
     $pb-molecule-dropdown-option $pl-molecule-dropdown-option;
@@ -23,12 +24,19 @@ $base-class: '.sui-MoleculeDropdownOption';
     padding-left: $p-s;
   }
 
+  &-leftAddon {
+    margin-left: $ml-molecule-dropdown-option-text;
+  }
+
   &-text {
     font-size: $fz-molecule-dropdown-option-text;
     flex-basis: 100%;
     overflow: hidden;
-    margin-left: $ml-molecule-dropdown-option-text;
     text-overflow: ellipsis;
+
+    &:first-child {
+      margin-left: $ml-molecule-dropdown-option-text;
+    }
 
     &--noWrap {
       white-space: nowrap;


### PR DESCRIPTION
## Molecule/DropdownOption
#### `❓ Ask`

### Description, Motivation and Context

We need to add icons to options on a dropdown. Apps (Android and iOS) have this feature, and we need to replicate it, to show more intuitive and fancier dropdown options.

### Types of changes

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [x] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations

<img width="338" alt="image" src="https://user-images.githubusercontent.com/37936498/226593800-9c31ce91-ffa3-4986-ae2d-2aff899bd76c.png">
