### PR TITLE
feat(components/atom/radioButton): wrap with forward ref

### DIFF
--- a/components/atom/radioButton/src/index.js
+++ b/components/atom/radioButton/src/index.js
@@ -1,41 +1,41 @@
+import {forwardRef} from 'react'
+
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 
 import {BASE_CLASS, CLASS_HIDDEN} from './settings.js'
 
-const AtomRadioButton = ({
-  id,
-  disabled,
-  checked = false,
-  onChange,
-  isHidden,
-  value,
-  ...props
-}) => {
-  const handleChange = ev => {
-    if (!disabled) {
-      const {name, value, checked} = ev.target
-      typeof onChange === 'function' && onChange(ev, {name, value, checked})
+const AtomRadioButton = forwardRef(
+  (
+    {id, disabled, checked = false, onChange, isHidden, value, ...props},
+    ref
+  ) => {
+    const handleChange = ev => {
+      if (!disabled) {
+        const {name, value, checked} = ev.target
+        typeof onChange === 'function' && onChange(ev, {name, value, checked})
+      }
     }
+
+    const className = cx(BASE_CLASS, {
+      [CLASS_HIDDEN]: isHidden
+    })
+
+    return (
+      <input
+        className={className}
+        value={value}
+        type="radio"
+        id={id}
+        disabled={disabled}
+        checked={checked}
+        onChange={handleChange}
+        ref={ref}
+        {...props}
+      />
+    )
   }
-
-  const className = cx(BASE_CLASS, {
-    [CLASS_HIDDEN]: isHidden
-  })
-
-  return (
-    <input
-      className={className}
-      value={value}
-      type="radio"
-      id={id}
-      disabled={disabled}
-      checked={checked}
-      onChange={handleChange}
-      {...props}
-    />
-  )
-}
+)
 
 AtomRadioButton.displayName = 'AtomRadioButton'
 

--- a/components/atom/radioButton/test/index.test.js
+++ b/components/atom/radioButton/test/index.test.js
@@ -5,6 +5,7 @@
 /* eslint react/jsx-no-undef:0 */
 /* eslint no-undef:0 */
 
+import {createRef} from 'react'
 import ReactDOM from 'react-dom'
 
 import chai, {expect} from 'chai'
@@ -60,6 +61,22 @@ describe(json.name, () => {
       // Then
       expect(container.innerHTML).to.be.a('string')
       expect(container.innerHTML).to.not.have.lengthOf(0)
+    })
+
+    describe('forwardRef', () => {
+      it('should return forwardRef html input element when giving a ref to the component', () => {
+        // Given
+        const ref = createRef()
+
+        // When
+        const component = <Component ref={ref} />
+        const div = document.createElement('div')
+        ReactDOM.render(component, div)
+
+        // Then
+        expect(ref.current).to.not.equal(undefined)
+        expect(ref.current.nodeName).to.equal('INPUT')
+      })
     })
   })
 


### PR DESCRIPTION
## Atom/RadioButtom
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->

<!-- #### `🔍 Show` -->


<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context

Given that a need of business, we need to be able scroll until the `input` of `SUIAtomRadioButtom` so that we need to access to the DOM reference using `forwardRef`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations

I've published a beta to check the correct behaviour doing `npm i @s-ui/react-atom-radio-button@forwardref` and with this new version it works very good in our project using `ref`

![Screenshot 2023-03-21 at 16 51 26](https://user-images.githubusercontent.com/1263588/226665016-14540fd1-a763-420a-bf90-291f8fb447f2.png)


![Screenshot 2023-03-21 at 16 47 31](https://user-images.githubusercontent.com/1263588/226663889-9c15218d-2999-4fa8-a606-276671605847.png)

