### PR TITLE
Feat/add props photouploader

### DIFF
--- a/components/molecule/photoUploader/src/EmptyView/config.js
+++ b/components/molecule/photoUploader/src/EmptyView/config.js
@@ -1,7 +1,7 @@
 import {BASE_CLASS_NAME} from '../config.js'
 
-export const INITIAL_STATE_CLASS_NAME = `${BASE_CLASS_NAME}-initialState`
-export const ICON_INITIAL_STATE_CLASS_NAME = `${BASE_CLASS_NAME}-iconInitialState`
+export const EMPTY_VIEW_CLASS_NAME = `${BASE_CLASS_NAME}-emptyView`
+export const ICON_EMPTY_VIEW_CLASS_NAME = `${BASE_CLASS_NAME}-iconEmptyView`
 export const TEXT_STATE_CLASS_NAME = `${BASE_CLASS_NAME}-textState`
 export const TEXT_STATE_TEXT_CLASS_NAME = `${BASE_CLASS_NAME}-textStateText`
 export const TEXT_STATE_DIVIDER_CLASS_NAME = `${BASE_CLASS_NAME}-textStateDivider`

--- a/components/molecule/photoUploader/src/EmptyView/index.js
+++ b/components/molecule/photoUploader/src/EmptyView/index.js
@@ -10,14 +10,14 @@ import {
   BUTTON_DESIGN,
   BUTTON_SIZE,
   BUTTON_STATE_CLASS_NAME,
-  ICON_INITIAL_STATE_CLASS_NAME,
-  INITIAL_STATE_CLASS_NAME,
+  EMPTY_VIEW_CLASS_NAME,
+  ICON_EMPTY_VIEW_CLASS_NAME,
   TEXT_STATE_CLASS_NAME,
   TEXT_STATE_DIVIDER_CLASS_NAME,
   TEXT_STATE_TEXT_CLASS_NAME
 } from './config.js'
 
-const InitialState = ({
+const EmptyView = ({
   buttonDesign = BUTTON_DESIGN,
   buttonColor = BUTTON_COLOR,
   buttonText,
@@ -29,8 +29,8 @@ const InitialState = ({
   dividerText = ALTERNATIVE_ACTION_TEXT
 }) => {
   return (
-    <div onClick={onClick} className={INITIAL_STATE_CLASS_NAME}>
-      <div className={ICON_INITIAL_STATE_CLASS_NAME}>
+    <div onClick={onClick} className={EMPTY_VIEW_CLASS_NAME}>
+      <div className={ICON_EMPTY_VIEW_CLASS_NAME}>
         <AtomIcon size={ATOM_ICON_SIZES.extraLarge}>{icon}</AtomIcon>
       </div>
       <div className={TEXT_STATE_CLASS_NAME}>
@@ -59,9 +59,9 @@ const InitialState = ({
   )
 }
 
-InitialState.displayName = 'InitialState'
+EmptyView.displayName = 'EmptyView'
 
-InitialState.propTypes = {
+EmptyView.propTypes = {
   buttonColor: PropTypes.string,
   buttonDesign: PropTypes.string,
   buttonText: PropTypes.string.isRequired,
@@ -73,4 +73,4 @@ InitialState.propTypes = {
   onClick: PropTypes.func
 }
 
-export default InitialState
+export default EmptyView

--- a/components/molecule/photoUploader/src/InitialState/index.js
+++ b/components/molecule/photoUploader/src/InitialState/index.js
@@ -25,10 +25,11 @@ const InitialState = ({
   buttonSize = BUTTON_SIZE,
   icon,
   text,
+  onClick,
   dividerText = ALTERNATIVE_ACTION_TEXT
 }) => {
   return (
-    <div className={INITIAL_STATE_CLASS_NAME}>
+    <div onClick={onClick} className={INITIAL_STATE_CLASS_NAME}>
       <div className={ICON_INITIAL_STATE_CLASS_NAME}>
         <AtomIcon size={ATOM_ICON_SIZES.extraLarge}>{icon}</AtomIcon>
       </div>
@@ -68,7 +69,8 @@ InitialState.propTypes = {
   buttonSize: PropTypes.string,
   icon: PropTypes.node.isRequired,
   text: PropTypes.string.isRequired,
-  dividerText: PropTypes.string
+  dividerText: PropTypes.string,
+  onClick: PropTypes.func
 }
 
 export default InitialState

--- a/components/molecule/photoUploader/src/index.js
+++ b/components/molecule/photoUploader/src/index.js
@@ -74,6 +74,7 @@ const MoleculePhotoUploader = forwardRef(
       notificationErrorFormatPhotoUploaded,
       onDropFiles = noop,
       onFileDialogOpen = noop,
+      onInitialStateClick = noop,
       outputImageAspectRatio = DEFAULT_IMAGE_ASPECT_RATIO,
       outputImageAspectRatioDisabled = false,
       rejectPhotosIcon,
@@ -81,7 +82,8 @@ const MoleculePhotoUploader = forwardRef(
       rotateIcon,
       rotationDirection = ROTATION_DIRECTION.counterclockwise,
       thumbIconSize,
-      uploadingPhotosText
+      uploadingPhotosText,
+      disabled = false
     },
     forwardedRef
   ) => {
@@ -224,6 +226,7 @@ const MoleculePhotoUploader = forwardRef(
     } = useDropzone({
       noClick: isPhotoUploaderFully(),
       noKeyboard: isPhotoUploaderFully(),
+      disabled,
       accept: acceptedFileTypes,
       onDrop: onDropFiles,
       onFileDialogOpen,
@@ -262,6 +265,7 @@ const MoleculePhotoUploader = forwardRef(
             <input {...getInputProps()} ref={inputRef} />
             {isPhotoUploaderEmpty && !isDragActive && (
               <InitialState
+                onClick={onInitialStateClick}
                 buttonColor={addPhotoButtonColor}
                 buttonDesign={addPhotoButtonDesign}
                 buttonText={addPhotoTextButton}
@@ -520,7 +524,13 @@ MoleculePhotoUploader.propTypes = {
   uploadingPhotosText: PropTypes.string.isRequired,
 
   /** Icon size inside action buttons in thumb card */
-  thumbIconSize: PropTypes.oneOf(Object.keys(ATOM_ICON_SIZES))
+  thumbIconSize: PropTypes.oneOf(Object.keys(ATOM_ICON_SIZES)),
+
+  /** Func to be executed when file dialog is clicked */
+  onInitialStateClick: PropTypes.func,
+
+  /** Disable the file dialog area */
+  disabled: PropTypes.bool
 }
 
 export default MoleculePhotoUploader

--- a/components/molecule/photoUploader/src/index.js
+++ b/components/molecule/photoUploader/src/index.js
@@ -83,7 +83,7 @@ const MoleculePhotoUploader = forwardRef(
       rotationDirection = ROTATION_DIRECTION.counterclockwise,
       thumbIconSize,
       uploadingPhotosText,
-      disabled = false
+      noClick = false
     },
     forwardedRef
   ) => {
@@ -224,9 +224,8 @@ const MoleculePhotoUploader = forwardRef(
       isDragReject,
       inputRef: dropzoneInputRef
     } = useDropzone({
-      noClick: isPhotoUploaderFully(),
+      noClick: isPhotoUploaderFully() || noClick,
       noKeyboard: isPhotoUploaderFully(),
-      disabled,
       accept: acceptedFileTypes,
       onDrop: onDropFiles,
       onFileDialogOpen,
@@ -529,8 +528,8 @@ MoleculePhotoUploader.propTypes = {
   /** Func to be executed when file dialog is clicked */
   onInitialStateClick: PropTypes.func,
 
-  /** Disable the file dialog area */
-  disabled: PropTypes.bool
+  /** A boolean to disable click in dropzone area */
+  noClick: PropTypes.bool
 }
 
 export default MoleculePhotoUploader

--- a/components/molecule/photoUploader/src/index.js
+++ b/components/molecule/photoUploader/src/index.js
@@ -83,7 +83,7 @@ const MoleculePhotoUploader = forwardRef(
       rotationDirection = ROTATION_DIRECTION.counterclockwise,
       thumbIconSize,
       uploadingPhotosText,
-      noClick = false
+      isClickable = true
     },
     forwardedRef
   ) => {
@@ -224,7 +224,7 @@ const MoleculePhotoUploader = forwardRef(
       isDragReject,
       inputRef: dropzoneInputRef
     } = useDropzone({
-      noClick: isPhotoUploaderFully() || noClick,
+      noClick: isPhotoUploaderFully() || !isClickable,
       noKeyboard: isPhotoUploaderFully(),
       accept: acceptedFileTypes,
       onDrop: onDropFiles,
@@ -528,8 +528,8 @@ MoleculePhotoUploader.propTypes = {
   /** Func to be executed when dropzone area is clicked */
   onInitialStateClick: PropTypes.func,
 
-  /** A boolean to disable click in dropzone area */
-  noClick: PropTypes.bool
+  /** A boolean to enable click in dropzone area */
+  isClickable: PropTypes.bool
 }
 
 export default MoleculePhotoUploader

--- a/components/molecule/photoUploader/src/index.js
+++ b/components/molecule/photoUploader/src/index.js
@@ -525,7 +525,7 @@ MoleculePhotoUploader.propTypes = {
   /** Icon size inside action buttons in thumb card */
   thumbIconSize: PropTypes.oneOf(Object.keys(ATOM_ICON_SIZES)),
 
-  /** Func to be executed when file dialog is clicked */
+  /** Func to be executed when dropzone area is clicked */
   onInitialStateClick: PropTypes.func,
 
   /** A boolean to disable click in dropzone area */

--- a/components/molecule/photoUploader/src/index.js
+++ b/components/molecule/photoUploader/src/index.js
@@ -11,7 +11,7 @@ import useMount from '@s-ui/react-hooks/lib/useMount'
 
 import DragNotification from './DragNotification/index.js'
 import DragState from './DragState/index.js'
-import InitialState from './InitialState/index.js'
+import EmptyView from './EmptyView/index.js'
 import PhotosPreview from './PhotosPreview/index.js'
 import {
   ACTIONS,
@@ -263,7 +263,7 @@ const MoleculePhotoUploader = forwardRef(
           <div {...getRootProps({className: dropzoneClassName})}>
             <input {...getInputProps()} ref={inputRef} />
             {isPhotoUploaderEmpty && !isDragActive && (
-              <InitialState
+              <EmptyView
                 onClick={onEmptyViewClick}
                 buttonColor={addPhotoButtonColor}
                 buttonDesign={addPhotoButtonDesign}

--- a/components/molecule/photoUploader/src/index.js
+++ b/components/molecule/photoUploader/src/index.js
@@ -74,7 +74,7 @@ const MoleculePhotoUploader = forwardRef(
       notificationErrorFormatPhotoUploaded,
       onDropFiles = noop,
       onFileDialogOpen = noop,
-      onInitialStateClick = noop,
+      onEmptyViewClick = noop,
       outputImageAspectRatio = DEFAULT_IMAGE_ASPECT_RATIO,
       outputImageAspectRatioDisabled = false,
       rejectPhotosIcon,
@@ -264,7 +264,7 @@ const MoleculePhotoUploader = forwardRef(
             <input {...getInputProps()} ref={inputRef} />
             {isPhotoUploaderEmpty && !isDragActive && (
               <InitialState
-                onClick={onInitialStateClick}
+                onClick={onEmptyViewClick}
                 buttonColor={addPhotoButtonColor}
                 buttonDesign={addPhotoButtonDesign}
                 buttonText={addPhotoTextButton}
@@ -526,7 +526,7 @@ MoleculePhotoUploader.propTypes = {
   thumbIconSize: PropTypes.oneOf(Object.keys(ATOM_ICON_SIZES)),
 
   /** Func to be executed when dropzone area is clicked */
-  onInitialStateClick: PropTypes.func,
+  onEmptyViewClick: PropTypes.func,
 
   /** A boolean to enable click in dropzone area */
   isClickable: PropTypes.bool

--- a/components/molecule/photoUploader/src/styles/index.scss
+++ b/components/molecule/photoUploader/src/styles/index.scss
@@ -30,7 +30,7 @@ $skeleton-class: '#{$base-class}-skeleton';
       cursor: no-drop;
     }
   }
-  &-initialState {
+  &-emptyView {
     align-items: center;
     padding: $p-photo-uploader-initial-state;
     background: $bg-photo-uploader-initial-state;


### PR DESCRIPTION
## Category/Component

🔍 Show

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context

Given the need to show a modal only the first time you click on the photo uploader component. We found the need to add the following props:

- Add `isClickable` boolean prop  to enable or disable click in dropzone area
- Add `onEmptyViewClick` func prop to handle the event when user click in dropzone initialState area. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
![Recording 2023-03-22 at 18 57 21](https://user-images.githubusercontent.com/38266840/226995737-7d45fb1f-ed98-4aad-99f3-7956ee9e5673.gif)
