### PR TITLE
feat(components/atom/panel): fix xxl and giant calculation

### DIFF
--- a/components/atom/panel/src/styles/settings.scss
+++ b/components/atom/panel/src/styles/settings.scss
@@ -2,8 +2,8 @@ $bdrs-atom-panel-rounded: (
   'm': $bdrs-m,
   'l': $bdrs-m * 2,
   'xl': $bdrs-m * 3,
-  'xxl': $bdrs-m * 6,
-  'giant': $bdrs-m * 8
+  'xxl': $bdrs-m * 4,
+  'giant': $bdrs-m * 6
 ) !default;
 
 $bxsh-atom-panel-elevation: (


### PR DESCRIPTION
## Category/Component
`🚢 Ship`

### Description, Motivation and Context
Fix wrong calculation of xxl and giante rounded prop

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
![Captura de Pantalla 2023-03-27 a las 13 49 36](https://user-images.githubusercontent.com/10154499/227933354-d2ea599a-4b17-4d1f-94d5-3571ecef84b5.png)
