### PR TITLE
feat(components/molecule/collapsible): add alignButtonText

### DIFF
--- a/components/molecule/collapsible/demo/ArticleButtonTextAlignment.js
+++ b/components/molecule/collapsible/demo/ArticleButtonTextAlignment.js
@@ -1,0 +1,77 @@
+import PropTypes from 'prop-types'
+
+import {Article, Code, H2, Paragraph} from '@s-ui/documentation-library'
+
+import MoleculeCollapsible, {
+  moleculeCollapsibleButtonAlign
+} from '../src/index.js'
+import {DemoWrapper, Text} from './config/index.js'
+
+const ArticleButtonTextAlignment = ({className, icon, showText, hideText}) => {
+  return (
+    <Article className={className}>
+      <H2>Collapsible Button Text Alignment</H2>
+      <Paragraph>
+        These are the options for the prop <Code> alignButtonText</Code>
+      </Paragraph>
+      <br />
+      <br />
+      <DemoWrapper>
+        <div style={{display: 'flex', flexDirection: 'column', maxWidth: 400}}>
+          <span>Buton Text Left</span>
+          <div
+            style={{
+              backgroundColor: '#fff',
+              fontSize: 14,
+              padding: 16
+            }}
+          >
+            <MoleculeCollapsible
+              icon={icon}
+              showText={showText}
+              hideText={hideText}
+              alignButtonText={moleculeCollapsibleButtonAlign.LEFT}
+            >
+              <Text />
+            </MoleculeCollapsible>
+          </div>
+        </div>
+        <div style={{display: 'flex', flexDirection: 'column', maxWidth: 400}}>
+          <span>Buton Text Center</span>
+          <div style={{backgroundColor: '#fff', fontSize: 14, padding: 16}}>
+            <MoleculeCollapsible
+              icon={icon}
+              showText={showText}
+              hideText={hideText}
+              alignButtonText={moleculeCollapsibleButtonAlign.CENTER}
+            >
+              <Text />
+            </MoleculeCollapsible>
+          </div>
+        </div>
+        <div style={{display: 'flex', flexDirection: 'column', maxWidth: 400}}>
+          <span>Buton Text Right</span>
+          <div style={{backgroundColor: '#fff', fontSize: 14, padding: 16}}>
+            <MoleculeCollapsible
+              icon={icon}
+              showText={showText}
+              hideText={hideText}
+              alignButtonText={moleculeCollapsibleButtonAlign.RIGHT}
+            >
+              <Text />
+            </MoleculeCollapsible>
+          </div>
+        </div>
+      </DemoWrapper>
+    </Article>
+  )
+}
+
+ArticleButtonTextAlignment.propTypes = {
+  className: PropTypes.string,
+  icon: PropTypes.node,
+  showText: PropTypes.string,
+  hideText: PropTypes.string
+}
+
+export default ArticleButtonTextAlignment

--- a/components/molecule/collapsible/demo/index.js
+++ b/components/molecule/collapsible/demo/index.js
@@ -2,6 +2,7 @@ import {Paragraph} from '@s-ui/documentation-library'
 
 import {GetIcon} from './config/index.js'
 import ArticleAlignment from './ArticleAlignment.js'
+import ArticleButtonTextAlignment from './ArticleButtonTextAlignment.js'
 import ArticleCustomHeight from './ArticleCustomHeight.js'
 import ArticleGradient from './ArticleGradient.js'
 import ArticleNoCollapse from './ArticleNoCollapse.js'
@@ -23,6 +24,13 @@ const Demo = () => {
           section.
         </Paragraph>
         <ArticleAlignment icon={icon} showText={showText} hideText={hideText} />
+        <br />
+        <br />
+        <ArticleButtonTextAlignment
+          icon={icon}
+          showText={showText}
+          hideText={hideText}
+        />
         <br />
         <br />
         <ArticleGradient icon={icon} showText={showText} hideText={hideText} />

--- a/components/molecule/collapsible/src/index.js
+++ b/components/molecule/collapsible/src/index.js
@@ -7,6 +7,7 @@ import {
   BASE_CLASS,
   BUTTON_CLASS,
   BUTTON_CONTENT_CLASS,
+  BUTTON_TEXT_ALIGN,
   COLLAPSED_CLASS,
   CONTAINER_BUTTON_CLASS,
   CONTENT_ALIGN,
@@ -18,6 +19,7 @@ import {
 const MoleculeCollapsible = ({
   onClose = () => {},
   onOpen = () => {},
+  alignButtonText,
   alignContainer,
   children,
   height = MIN_HEIGHT,
@@ -56,6 +58,8 @@ const MoleculeCollapsible = ({
   })
   const containerClassName = cx(`${CONTAINER_BUTTON_CLASS}`, {
     [`${CONTAINER_BUTTON_CLASS}--withGradient`]: withGradient,
+    [`${CONTAINER_BUTTON_CLASS}--alignButtonText-${alignButtonText}`]:
+      alignButtonText,
     [COLLAPSED_CLASS]: collapsed
   })
   const contentClassName = cx(`${CONTENT_CLASS}`, {
@@ -94,6 +98,10 @@ const MoleculeCollapsible = ({
 MoleculeCollapsible.displayName = 'MoleculeCollapsible'
 
 MoleculeCollapsible.propTypes = {
+  /**
+   * Button text align center || right || left
+   */
+  alignButtonText: PropTypes.oneOf(Object.values(BUTTON_TEXT_ALIGN)),
   /**
    * Container align center || right
    */
@@ -142,4 +150,8 @@ MoleculeCollapsible.propTypes = {
 
 export default MoleculeCollapsible
 
-export {CONTENT_ALIGN, CONTENT_ALIGN as moleculeCollapsibleContentAlign}
+export {
+  CONTENT_ALIGN,
+  CONTENT_ALIGN as moleculeCollapsibleContentAlign,
+  BUTTON_TEXT_ALIGN as moleculeCollapsibleButtonAlign
+}

--- a/components/molecule/collapsible/src/settings.js
+++ b/components/molecule/collapsible/src/settings.js
@@ -12,3 +12,9 @@ export const CONTENT_ALIGN = {
   CENTER: 'center',
   RIGHT: 'right'
 }
+
+export const BUTTON_TEXT_ALIGN = {
+  CENTER: 'center',
+  RIGHT: 'right',
+  LEFT: 'left'
+}

--- a/components/molecule/collapsible/src/styles/index.scss
+++ b/components/molecule/collapsible/src/styles/index.scss
@@ -61,6 +61,20 @@ $base-class: '.sui-MoleculeCollapsible';
     text-align: $ta-collapsible-container;
     width: 100%;
 
+    &--alignButtonText {
+      &-center {
+        text-align: center;
+      }
+
+      &-right {
+        text-align: right;
+      }
+
+      &-left {
+        text-align: left;
+      }
+    }
+
     &#{&}--withGradient.is-collapsed {
       &::before {
         background: $bg-collapsible-container-gradient;

--- a/components/molecule/collapsible/test/index.test.js
+++ b/components/molecule/collapsible/test/index.test.js
@@ -25,6 +25,7 @@ describe(json.name, () => {
     const libraryExportedMembers = [
       'CONTENT_ALIGN',
       'moleculeCollapsibleContentAlign',
+      'moleculeCollapsibleButtonAlign',
       'default'
     ]
 
@@ -32,6 +33,7 @@ describe(json.name, () => {
     const {
       CONTENT_ALIGN,
       moleculeCollapsibleContentAlign,
+      moleculeCollapsibleButtonAlign,
       default: MoleculeCollapsible,
       ...others
     } = library
@@ -118,6 +120,41 @@ describe(json.name, () => {
       // When
       const {moleculeCollapsibleContentAlign: actual} = library
       const {CENTER, RIGHT, ...others} = actual
+
+      // Then
+      expect(Object.keys(others).length).to.equal(0)
+      expect(Object.keys(actual)).to.have.members(Object.keys(expected))
+      Object.entries(expected).forEach(([expectedKey, expectedValue]) => {
+        expect(Object.keys(actual).includes(expectedKey)).to.be.true
+        expect(actual[expectedKey]).to.equal(expectedValue)
+      })
+    })
+  })
+
+  describe('moleculeCollapsibleButtonAlign', () => {
+    it('value must be an object enum', () => {
+      // Given
+      const library = pkg
+
+      // When
+      const {moleculeCollapsibleButtonAlign: actual} = library
+
+      // Then
+      expect(actual).to.be.an('object')
+    })
+
+    it('value must be a defined string-key pair filled', () => {
+      // Given
+      const library = pkg
+      const expected = {
+        CENTER: 'center',
+        RIGHT: 'right',
+        LEFT: 'left'
+      }
+
+      // When
+      const {moleculeCollapsibleButtonAlign: actual} = library
+      const {CENTER, RIGHT, LEFT, ...others} = actual
 
       // Then
       expect(Object.keys(others).length).to.equal(0)


### PR DESCRIPTION
## Category/Component

 #### `🔍 Show` 

### Description, Motivation and Context
Add new alignButtonText prop to be able to define if we want to align the text of the collapsible button on the left, center, or right of the component.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
![Captura de Pantalla 2023-04-13 a las 15 35 46](https://user-images.githubusercontent.com/10154499/231776719-97b2236b-73ff-4998-902f-56bc94579bd8.png)
