### PR TITLE
feat(components/atom/videoPlayer): Add support to play native videos

### DIFF
--- a/components/atom/videoPlayer/demo/index.js
+++ b/components/atom/videoPlayer/demo/index.js
@@ -1,3 +1,30 @@
+import {useState} from 'react'
+
 import AtomVideoPlayer from 'components/atom/videoPlayer/src'
 
-export default () => <AtomVideoPlayer src="https://vimeo.com/54289199" />
+export default () => {
+  const [selectedFile, setSelectedFile] = useState('')
+
+  return (
+    <>
+      <h1>YouTube</h1>
+      <AtomVideoPlayer src="https://www.youtube.com/embed/1gI_HGDgG7c" />
+
+      <h1>VIMEO</h1>
+      <AtomVideoPlayer src="https://vimeo.com/54289199" />
+
+      <h1>Native from remote url</h1>
+      <AtomVideoPlayer src="https://cdn.coverr.co/videos/coverr-boat-in-the-sea-5656/1080p.mp4" />
+
+      <h1>Native from a blob</h1>
+      <input
+        type="file"
+        accept="video/*"
+        onChange={e => {
+          setSelectedFile(event.target.files[0])
+        }}
+      />
+      <AtomVideoPlayer src={selectedFile} />
+    </>
+  )
+}

--- a/components/atom/videoPlayer/src/components/NativePlayer.js
+++ b/components/atom/videoPlayer/src/components/NativePlayer.js
@@ -17,7 +17,7 @@ const NativePlayer = ({src}) => {
 }
 
 NativePlayer.propTypes = {
-  src: PropTypes.string
+  src: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Blob)])
 }
 
 export default NativePlayer

--- a/components/atom/videoPlayer/src/components/NativePlayer.js
+++ b/components/atom/videoPlayer/src/components/NativePlayer.js
@@ -1,0 +1,23 @@
+import {useRef} from 'react'
+
+import PropTypes from 'prop-types'
+
+import useGetBlobAsVideoSrcEffect from '../hooks/useGetBlobAsVideoSrcEffect.js'
+
+const NativePlayer = ({src}) => {
+  const videoNode = useRef(null)
+  const videoSrc = useGetBlobAsVideoSrcEffect({src, videoNode})
+
+  return (
+    <video ref={videoNode} title="Native video player" controls>
+      {videoSrc !== null && <source data-testid="videosrc" src={videoSrc} />}
+      Your browser does not support the video tag.
+    </video>
+  )
+}
+
+NativePlayer.propTypes = {
+  src: PropTypes.string
+}
+
+export default NativePlayer

--- a/components/atom/videoPlayer/src/components/Switcher.js
+++ b/components/atom/videoPlayer/src/components/Switcher.js
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types'
 
 import useDetectVideoType from '../hooks/useDetectVideoType.js'
-import {VIMEO, YOUTUBE} from '../settings.js'
+import {NATIVE, VIMEO, YOUTUBE} from '../settings.js'
+import NativePlayer from './NativePlayer.js'
 import VimeoPlayer from './VimeoPlayer.js'
 import YouTubePlayer from './YouTubePlayer.js'
 
@@ -9,6 +10,9 @@ const Switcher = ({src}) => {
   const {detectVideoType} = useDetectVideoType()
   const videoType = detectVideoType(src)
   switch (videoType) {
+    case NATIVE.VIDEO_TYPE:
+      return <NativePlayer src={src} />
+
     case VIMEO.VIDEO_TYPE:
       return <VimeoPlayer src={src} />
 

--- a/components/atom/videoPlayer/src/components/Switcher.js
+++ b/components/atom/videoPlayer/src/components/Switcher.js
@@ -25,7 +25,7 @@ const Switcher = ({src}) => {
 }
 
 Switcher.propTypes = {
-  src: PropTypes.string
+  src: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Blob)])
 }
 
 export default Switcher

--- a/components/atom/videoPlayer/src/components/VimeoPlayer.js
+++ b/components/atom/videoPlayer/src/components/VimeoPlayer.js
@@ -8,20 +8,16 @@ const VimeoPlayer = ({src}) => {
   const videoSrc = getEmbeddableUrl(src)
 
   return (
-    <>
-      <div className={`${BASE_CLASS}-vimeoPlayer`}>
-        <iframe
-          className={`${BASE_CLASS}-vimeoPlayerFrame`}
-          title="VIMEO video player"
-          src={videoSrc}
-          frameBorder="0"
-          allow="autoplay; fullscreen; picture-in-picture"
-          allowFullScreen
-        ></iframe>
-      </div>
-      {/* Is this really needed? */}
-      {/* <script src="https://player.vimeo.com/api/player.js"></script> */}
-    </>
+    <div className={`${BASE_CLASS}-vimeoPlayer`}>
+      <iframe
+        className={`${BASE_CLASS}-vimeoPlayerFrame`}
+        title="VIMEO video player"
+        src={videoSrc}
+        frameBorder="0"
+        allow="autoplay; fullscreen; picture-in-picture"
+        allowFullScreen
+      />
+    </div>
   )
 }
 

--- a/components/atom/videoPlayer/src/components/YouTubePlayer.js
+++ b/components/atom/videoPlayer/src/components/YouTubePlayer.js
@@ -14,7 +14,7 @@ const YouTubePlayer = ({src}) => {
       frameBorder="0"
       allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
       allowFullScreen
-    ></iframe>
+    />
   )
 }
 

--- a/components/atom/videoPlayer/src/hooks/useDetectVideoType.js
+++ b/components/atom/videoPlayer/src/hooks/useDetectVideoType.js
@@ -1,7 +1,21 @@
-import {UNKNOWN, VIMEO, YOUTUBE} from '../settings.js'
+import {NATIVE, UNKNOWN, VIMEO, YOUTUBE} from '../settings.js'
 
 const useDetectVideoType = () => {
+  const getVideoExtension = src => {
+    if (typeof src !== 'string') {
+      return ''
+    }
+
+    const srcSplittedByPoints = src.split('.')
+    const extension = srcSplittedByPoints[srcSplittedByPoints.length - 1]
+    return extension
+  }
+
   const detectVideoType = src => {
+    const extension = getVideoExtension(src)
+    if (src instanceof Blob || NATIVE.VIDEO_FORMATS.includes(extension))
+      return NATIVE.VIDEO_TYPE
+
     if (src.includes(YOUTUBE.VIDEO_TYPE) || src.includes(YOUTUBE.SHORT_URL))
       return YOUTUBE.VIDEO_TYPE
 

--- a/components/atom/videoPlayer/src/hooks/useGetBlobAsVideoSrcEffect.js
+++ b/components/atom/videoPlayer/src/hooks/useGetBlobAsVideoSrcEffect.js
@@ -1,0 +1,22 @@
+import {useEffect, useState} from 'react'
+
+const useGetBlobAsVideoSrcEffect = ({src, videoNode}) => {
+  const [videoSrc, setVideoSrc] = useState(typeof src === 'string' ? src : null)
+
+  useEffect(() => {
+    if (videoSrc !== null) return
+
+    const reader = new FileReader()
+
+    reader.onload = function (e) {
+      setVideoSrc(e.target.result)
+      videoNode.current?.load()
+    }
+
+    reader.readAsDataURL(src)
+  }, [src, videoNode, videoSrc])
+
+  return videoSrc
+}
+
+export default useGetBlobAsVideoSrcEffect

--- a/components/atom/videoPlayer/src/index.js
+++ b/components/atom/videoPlayer/src/index.js
@@ -1,16 +1,21 @@
+import {forwardRef} from 'react'
+
 import PropTypes from 'prop-types'
 
 import Switcher from './components/Switcher.js'
 import {BASE_CLASS} from './settings.js'
-export default function AtomVideoPlayer({src = ''}) {
+
+const AtomVideoPlayer = forwardRef(({src = ''}, forwardedRef) => {
   return (
-    <div className={BASE_CLASS}>
+    <div ref={forwardedRef} className={BASE_CLASS}>
       <Switcher src={src} />
     </div>
   )
-}
+})
 
 AtomVideoPlayer.displayName = 'AtomVideoPlayer'
 AtomVideoPlayer.propTypes = {
   src: PropTypes.string
 }
+
+export default AtomVideoPlayer

--- a/components/atom/videoPlayer/src/index.js
+++ b/components/atom/videoPlayer/src/index.js
@@ -14,8 +14,9 @@ const AtomVideoPlayer = forwardRef(({src = ''}, forwardedRef) => {
 })
 
 AtomVideoPlayer.displayName = 'AtomVideoPlayer'
+
 AtomVideoPlayer.propTypes = {
-  src: PropTypes.string
+  src: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Blob)])
 }
 
 export default AtomVideoPlayer

--- a/components/atom/videoPlayer/src/settings.js
+++ b/components/atom/videoPlayer/src/settings.js
@@ -1,5 +1,10 @@
 export const BASE_CLASS = 'sui-AtomVideoPlayer'
 
+export const NATIVE = {
+  VIDEO_FORMATS: ['mp4', 'ogg', 'webm'],
+  VIDEO_TYPE: 'native'
+}
+
 export const VIMEO = {
   EMBEDDABLE_URL: 'https://player.vimeo.com/video/',
   STANDARD_URL: 'https://vimeo.com/',

--- a/components/atom/videoPlayer/test/index.test.js
+++ b/components/atom/videoPlayer/test/index.test.js
@@ -55,6 +55,35 @@ describe('AtomVideoPlayer', () => {
     })
   })
 
+  describe('Native video player', () => {
+    it('should try to play the video using the native player if it is a remote file with a known extension', () => {
+      // Given
+      const props = {
+        src: 'https://cdn.coverr.co/videos/coverr-boat-in-the-sea-5656/1080p.mp4'
+      }
+
+      // When
+      const component = setup(props)
+
+      // Then
+      component.getByTitle('Native video player')
+    })
+
+    it('should try to play the video using the native player when receiving a blob object as src', async () => {
+      // Given
+      const props = {
+        src: new File(['fakeVideo'], 'hello.mp4', {type: 'video/mp4'})
+      }
+
+      // When
+      const component = setup(props)
+
+      // Then
+      const {src} = await component.findByTestId('videosrc')
+      expect(src).to.eql('data:video/mp4;base64,ZmFrZVZpZGVv')
+    })
+  })
+
   describe('YouTube Videos', () => {
     it('should embed the youtube video player if src is a youtube video', () => {
       // Given


### PR DESCRIPTION
## atom/videoPlayer

#### `🔍 Show`

### Description, Motivation and Context

**Context**

Implementing video-related features.

**Description**

Introducing the possibility of playing standard videos with the browser native player, both by receiving an external url, and a file blob.

Additionaly, we've added `ref` forwarding as recently suggested by Andrés.

### Types of changes

- [X] ✨ New feature (non-breaking change which adds functionality)
