### PR TITLE
fix(components/molecule/dropdownOption): add line-height inherit to d…

### DIFF
--- a/components/molecule/dropdownOption/src/_settings.scss
+++ b/components/molecule/dropdownOption/src/_settings.scss
@@ -17,6 +17,7 @@ $fw-molecule-dropdown-option--highlight-mark: normal !default;
 $lh-molecule-dropdown-option-line-wrap-text: $lh-m !default;
 $ln-molecule-dropdown-option-two-lines-text: $lh-molecule-dropdown-option-line-wrap-text !default; // deprecated
 $ml-molecule-dropdown-option-text: $m-s !default;
+$lh-molecule-dropdown-option-text: inherit !default;
 $c-molecule-dropdown-option-description: $c-gray !default;
 $fz-molecule-dropdown-option-description: inherit !default;
 $mt-molecule-dropdown-option-description: $m-s !default;

--- a/components/molecule/dropdownOption/src/styles/index.scss
+++ b/components/molecule/dropdownOption/src/styles/index.scss
@@ -30,6 +30,7 @@ $base-class: '.sui-MoleculeDropdownOption';
 
   &-text {
     font-size: $fz-molecule-dropdown-option-text;
+    line-height: $lh-molecule-dropdown-option-text;
     flex-basis: 100%;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
…ropdownOption text

## molecule/dropdownOption
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
 #### `🔍 Show`
<!-- #### `❓ Ask`  -->

### Description, Motivation and Context
I've added `line-height: inherit !default;` declaration to sui-MoleculeDropdownOption-text class, so there will be a possibility to add a custom line-height for this component in every vertical. In IJ, for example, we will be able to fix the visual bug (cutting off letters) by adding custom line height. This visual bug appears because the line-height is inherited from body and equals 1.

### Types of changes

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
![Captura de pantalla 2023-04-25 a las 13 28 18](https://user-images.githubusercontent.com/71508330/234264179-bee0e1a3-f854-4860-9190-fe1827e6bdd9.png)
![Captura de pantalla 2023-04-25 a las 13 28 26](https://user-images.githubusercontent.com/71508330/234264186-e129d24c-b57a-422b-bcee-2713470af888.png)
