### PR TITLE
feat(components/atom/videoPlayer): Add a prop to configure if control…

### DIFF
--- a/components/atom/videoPlayer/src/components/HLSPlayer.js
+++ b/components/atom/videoPlayer/src/components/HLSPlayer.js
@@ -7,6 +7,7 @@ import {BASE_CLASS, HLS_DEFAULT_TITLE} from '../settings/index.js'
 
 const HLSPlayer = ({
   autoPlay,
+  controls,
   hlsConfig,
   playerRef = createRef(),
   src,
@@ -86,7 +87,7 @@ const HLSPlayer = ({
   return (
     <div className={`${BASE_CLASS}-hlsPlayer`}>
       <video
-        controls
+        controls={controls}
         className={`${BASE_CLASS}-hlsPlayerVideo`}
         title={title}
         ref={playerRef}
@@ -99,6 +100,7 @@ const HLSPlayer = ({
 
 HLSPlayer.propTypes = {
   autoPlay: PropTypes.bool,
+  controls: PropTypes.bool,
   hlsConfig: PropTypes.object,
   playerRef: PropTypes.object,
   src: PropTypes.string,

--- a/components/atom/videoPlayer/src/components/NativePlayer.js
+++ b/components/atom/videoPlayer/src/components/NativePlayer.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types'
 import useGetBlobAsVideoSrcEffect from '../hooks/useGetBlobAsVideoSrcEffect.js'
 import {BASE_CLASS, NATIVE_DEFAULT_TITLE} from '../settings/index.js'
 
-const NativePlayer = ({src, title = NATIVE_DEFAULT_TITLE}) => {
+const NativePlayer = ({controls, src, title = NATIVE_DEFAULT_TITLE}) => {
   const videoNode = useRef(null)
   const videoSrc = useGetBlobAsVideoSrcEffect({src, videoNode})
 
@@ -15,7 +15,7 @@ const NativePlayer = ({src, title = NATIVE_DEFAULT_TITLE}) => {
         className={`${BASE_CLASS}-nativePlayerVideo`}
         ref={videoNode}
         title={title}
-        controls
+        controls={controls}
       >
         {videoSrc !== null && <source data-testid="videosrc" src={videoSrc} />}
         Your browser does not support the video tag.
@@ -25,6 +25,7 @@ const NativePlayer = ({src, title = NATIVE_DEFAULT_TITLE}) => {
 }
 
 NativePlayer.propTypes = {
+  controls: PropTypes.bool,
   src: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Blob)]),
   title: PropTypes.string
 }

--- a/components/atom/videoPlayer/src/components/VimeoPlayer.js
+++ b/components/atom/videoPlayer/src/components/VimeoPlayer.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types'
 import useVimeoProperties from '../hooks/useVimeoProperties.js'
 import {BASE_CLASS, VIMEO_DEFAULT_TITLE} from '../settings/index.js'
 
-const VimeoPlayer = ({src, title = VIMEO_DEFAULT_TITLE}) => {
+const VimeoPlayer = ({controls, src, title = VIMEO_DEFAULT_TITLE}) => {
   const {getEmbeddableUrl} = useVimeoProperties()
-  const videoSrc = getEmbeddableUrl(src)
+  const videoSrc = `${getEmbeddableUrl(src)}${!controls ? '?controls=0' : ''}`
 
   return (
     <div className={`${BASE_CLASS}-vimeoPlayer`}>
@@ -22,6 +22,7 @@ const VimeoPlayer = ({src, title = VIMEO_DEFAULT_TITLE}) => {
 }
 
 VimeoPlayer.propTypes = {
+  controls: PropTypes.bool,
   src: PropTypes.string,
   title: PropTypes.string
 }

--- a/components/atom/videoPlayer/src/components/YouTubePlayer.js
+++ b/components/atom/videoPlayer/src/components/YouTubePlayer.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types'
 import useYouTubeProperties from '../hooks/useYouTubeProperties.js'
 import {BASE_CLASS, YOUTUBE_DEFAULT_TITLE} from '../settings/index.js'
 
-const YouTubePlayer = ({src, title = YOUTUBE_DEFAULT_TITLE}) => {
+const YouTubePlayer = ({controls, src, title = YOUTUBE_DEFAULT_TITLE}) => {
   const {getEmbeddableUrl} = useYouTubeProperties()
-  const videoSrc = getEmbeddableUrl(src)
+  const videoSrc = `${getEmbeddableUrl(src)}${!controls ? '?controls=0' : ''}`
 
   return (
     <div className={`${BASE_CLASS}-youtubePlayer`}>
@@ -22,6 +22,7 @@ const YouTubePlayer = ({src, title = YOUTUBE_DEFAULT_TITLE}) => {
 }
 
 YouTubePlayer.propTypes = {
+  controls: PropTypes.bool,
   src: PropTypes.string,
   title: PropTypes.string
 }

--- a/components/atom/videoPlayer/src/index.js
+++ b/components/atom/videoPlayer/src/index.js
@@ -5,8 +5,11 @@ import PropTypes from 'prop-types'
 import useVideoPlayer from './hooks/useVideoPlayer.js'
 import {BASE_CLASS} from './settings/index.js'
 
-const AtomVideoPlayer = forwardRef(({src = ''}, forwardedRef) => {
-  const [Component, props] = useVideoPlayer({src})
+const AtomVideoPlayer = forwardRef(({controls = true, src}, forwardedRef) => {
+  const [Component, props] = useVideoPlayer({
+    controls,
+    src
+  })
   return (
     <div ref={forwardedRef} className={BASE_CLASS}>
       <Component {...props} />
@@ -17,7 +20,9 @@ const AtomVideoPlayer = forwardRef(({src = ''}, forwardedRef) => {
 AtomVideoPlayer.displayName = 'AtomVideoPlayer'
 
 AtomVideoPlayer.propTypes = {
+  controls: PropTypes.bool,
   src: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Blob)])
+    .isRequired
 }
 
 export default AtomVideoPlayer

--- a/components/atom/videoPlayer/src/index.scss
+++ b/components/atom/videoPlayer/src/index.scss
@@ -7,11 +7,11 @@ $fourByThreeAspectRatio: calc(100% / 4 * 3);
   position: relative;
 
   &Frame {
+    height: 100%;
+    left: 0;
     position: absolute;
     top: 0;
-    left: 0;
     width: 100%;
-    height: 100%;
   }
 }
 
@@ -29,12 +29,12 @@ $fourByThreeAspectRatio: calc(100% / 4 * 3);
   }
 
   &-vimeoPlayer {
-    padding: $fourByThreeAspectRatio 0 0 0;
     @include atom-videoplayer-external-player;
+    padding: $fourByThreeAspectRatio 0 0 0;
   }
 
   &-youtubePlayer {
-    padding: $sixteenByNineAspectRatio 0 0 0;
     @include atom-videoplayer-external-player;
+    padding: $sixteenByNineAspectRatio 0 0 0;
   }
 }

--- a/components/atom/videoPlayer/test/index.test.js
+++ b/components/atom/videoPlayer/test/index.test.js
@@ -24,7 +24,7 @@ describe('AtomVideoPlayer', () => {
 
   it('should render without crashing', () => {
     // Given
-    const props = {}
+    const props = {src: ''}
 
     // When
     const component = <AtomVideoPlayer {...props} />
@@ -37,7 +37,7 @@ describe('AtomVideoPlayer', () => {
 
   it('should NOT render null', () => {
     // Given
-    const props = {}
+    const props = {src: ''}
 
     // When
     const {container} = setup(props)
@@ -75,6 +75,33 @@ describe('AtomVideoPlayer', () => {
       // Then
       component.getByTitle(HLS_DEFAULT_TITLE)
     })
+
+    it('should display controls by default', () => {
+      // Given
+      const props = {
+        src: 'https://media-frontend.yams-pro.mpi-internal.com/api/v1/yams-frontend/statics/vo/surf.mp4/hls.m3u8'
+      }
+
+      // When
+      const component = setup(props)
+
+      // Then
+      expect(component.getByTitle(HLS_DEFAULT_TITLE).controls).to.eql(true)
+    })
+
+    it('should avoid displaying controls if controls prop is set to false', () => {
+      // Given
+      const props = {
+        controls: false,
+        src: 'https://media-frontend.yams-pro.mpi-internal.com/api/v1/yams-frontend/statics/vo/surf.mp4/hls.m3u8'
+      }
+
+      // When
+      const component = setup(props)
+
+      // Then
+      expect(component.getByTitle(HLS_DEFAULT_TITLE).controls).to.eql(false)
+    })
   })
 
   describe('Native video player', () => {
@@ -103,6 +130,33 @@ describe('AtomVideoPlayer', () => {
       // Then
       const {src} = await component.findByTestId('videosrc')
       expect(src).to.eql('data:video/mp4;base64,ZmFrZVZpZGVv')
+    })
+
+    it('should display controls by default', () => {
+      // Given
+      const props = {
+        src: 'https://cdn.coverr.co/videos/coverr-boat-in-the-sea-5656/1080p.mp4'
+      }
+
+      // When
+      const component = setup(props)
+
+      // Then
+      expect(component.getByTitle(NATIVE_DEFAULT_TITLE).controls).to.eql(true)
+    })
+
+    it('should avoid displaying controls if controls prop is set to false', () => {
+      // Given
+      const props = {
+        controls: false,
+        src: 'https://cdn.coverr.co/videos/coverr-boat-in-the-sea-5656/1080p.mp4'
+      }
+
+      // When
+      const component = setup(props)
+
+      // Then
+      expect(component.getByTitle(NATIVE_DEFAULT_TITLE).controls).to.eql(false)
     })
   })
 
@@ -153,6 +207,22 @@ describe('AtomVideoPlayer', () => {
         'https://www.youtube.com/embed/1gI_HGDgG7c'
       )
     })
+
+    it('should avoid displaying controls if controls prop is set to false', () => {
+      // Given
+      const props = {
+        controls: false,
+        src: 'https://www.youtube.com/embed/1gI_HGDgG7c'
+      }
+
+      // When
+      const component = setup(props)
+
+      // Then
+      const iframeNode = component.getByTitle(YOUTUBE_DEFAULT_TITLE)
+      // check that the iframe src is the embedable url
+      expect(iframeNode.src).to.include('controls=0')
+    })
   })
 
   describe('VIMEO Videos', () => {
@@ -184,6 +254,22 @@ describe('AtomVideoPlayer', () => {
       expect(iframeNode.src).to.include(
         'https://player.vimeo.com/video/54289199'
       )
+    })
+
+    it('should avoid displaying controls if controls prop is set to false', () => {
+      // Given
+      const props = {
+        controls: false,
+        src: 'https://vimeo.com/54289199'
+      }
+
+      // When
+      const component = setup(props)
+
+      // Then
+      const iframeNode = component.getByTitle(VIMEO_DEFAULT_TITLE)
+      // check that the iframe src is the embedable url
+      expect(iframeNode.src).to.include('controls=0')
     })
   })
 })


### PR DESCRIPTION
…s should be displayed

## atom/videoPlayer

#### `🔍 Show`

### Description, Motivation and Context

**Context**
Implementing video-related features in Adevinta.

**Description**
Add a prop to programmatically indicate if the videoplayer should display controls or not.

### Types of changes

- [X] ✨ New feature (non-breaking change which adds functionality)