### PR TITLE
feat(components/atom/videoPlayer): Add autoplay prop to atom videoPlayer

### DIFF
--- a/components/atom/videoPlayer/src/components/NativePlayer.js
+++ b/components/atom/videoPlayer/src/components/NativePlayer.js
@@ -5,13 +5,19 @@ import PropTypes from 'prop-types'
 import useGetBlobAsVideoSrcEffect from '../hooks/useGetBlobAsVideoSrcEffect.js'
 import {BASE_CLASS, NATIVE_DEFAULT_TITLE} from '../settings/index.js'
 
-const NativePlayer = ({controls, src, title = NATIVE_DEFAULT_TITLE}) => {
+const NativePlayer = ({
+  autoPlay,
+  controls,
+  src,
+  title = NATIVE_DEFAULT_TITLE
+}) => {
   const videoNode = useRef(null)
   const videoSrc = useGetBlobAsVideoSrcEffect({src, videoNode})
 
   return (
     <div className={`${BASE_CLASS}-nativePlayer`}>
       <video
+        autoPlay={autoPlay}
         className={`${BASE_CLASS}-nativePlayerVideo`}
         ref={videoNode}
         title={title}
@@ -25,6 +31,7 @@ const NativePlayer = ({controls, src, title = NATIVE_DEFAULT_TITLE}) => {
 }
 
 NativePlayer.propTypes = {
+  autoPlay: PropTypes.bool,
   controls: PropTypes.bool,
   src: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Blob)]),
   title: PropTypes.string

--- a/components/atom/videoPlayer/src/components/VimeoPlayer.js
+++ b/components/atom/videoPlayer/src/components/VimeoPlayer.js
@@ -1,11 +1,24 @@
 import PropTypes from 'prop-types'
 
+import {toQueryString} from '@s-ui/js/lib/string'
+
 import useVimeoProperties from '../hooks/useVimeoProperties.js'
 import {BASE_CLASS, VIMEO_DEFAULT_TITLE} from '../settings/index.js'
 
-const VimeoPlayer = ({controls, src, title = VIMEO_DEFAULT_TITLE}) => {
+const VimeoPlayer = ({
+  autoPlay,
+  controls,
+  src,
+  title = VIMEO_DEFAULT_TITLE
+}) => {
   const {getEmbeddableUrl} = useVimeoProperties()
-  const videoSrc = `${getEmbeddableUrl(src)}${!controls ? '?controls=0' : ''}`
+
+  const params = toQueryString({
+    controls: controls ? '1' : '0',
+    autoplay: autoPlay ? '1' : '0'
+  })
+
+  const videoSrc = `${getEmbeddableUrl(src)}?${params}`
 
   return (
     <div className={`${BASE_CLASS}-vimeoPlayer`}>
@@ -22,6 +35,7 @@ const VimeoPlayer = ({controls, src, title = VIMEO_DEFAULT_TITLE}) => {
 }
 
 VimeoPlayer.propTypes = {
+  autoPlay: PropTypes.bool,
   controls: PropTypes.bool,
   src: PropTypes.string,
   title: PropTypes.string

--- a/components/atom/videoPlayer/src/components/YouTubePlayer.js
+++ b/components/atom/videoPlayer/src/components/YouTubePlayer.js
@@ -1,12 +1,24 @@
 import PropTypes from 'prop-types'
 
+import {toQueryString} from '@s-ui/js/lib/string'
+
 import useYouTubeProperties from '../hooks/useYouTubeProperties.js'
 import {BASE_CLASS, YOUTUBE_DEFAULT_TITLE} from '../settings/index.js'
 
-const YouTubePlayer = ({controls, src, title = YOUTUBE_DEFAULT_TITLE}) => {
+const YouTubePlayer = ({
+  autoPlay,
+  controls,
+  src,
+  title = YOUTUBE_DEFAULT_TITLE
+}) => {
   const {getEmbeddableUrl} = useYouTubeProperties()
-  const videoSrc = `${getEmbeddableUrl(src)}${!controls ? '?controls=0' : ''}`
 
+  const params = toQueryString({
+    controls: controls ? '1' : '0',
+    autoplay: autoPlay ? '1' : '0'
+  })
+
+  const videoSrc = `${getEmbeddableUrl(src)}?${params}`
   return (
     <div className={`${BASE_CLASS}-youtubePlayer`}>
       <iframe
@@ -22,6 +34,7 @@ const YouTubePlayer = ({controls, src, title = YOUTUBE_DEFAULT_TITLE}) => {
 }
 
 YouTubePlayer.propTypes = {
+  autoPlay: PropTypes.bool,
   controls: PropTypes.bool,
   src: PropTypes.string,
   title: PropTypes.string

--- a/components/atom/videoPlayer/src/index.js
+++ b/components/atom/videoPlayer/src/index.js
@@ -5,21 +5,25 @@ import PropTypes from 'prop-types'
 import useVideoPlayer from './hooks/useVideoPlayer.js'
 import {BASE_CLASS} from './settings/index.js'
 
-const AtomVideoPlayer = forwardRef(({controls = true, src}, forwardedRef) => {
-  const [Component, props] = useVideoPlayer({
-    controls,
-    src
-  })
-  return (
-    <div ref={forwardedRef} className={BASE_CLASS}>
-      <Component {...props} />
-    </div>
-  )
-})
+const AtomVideoPlayer = forwardRef(
+  ({autoPlay = false, controls = true, src}, forwardedRef) => {
+    const [Component, props] = useVideoPlayer({
+      autoPlay,
+      controls,
+      src
+    })
+    return (
+      <div ref={forwardedRef} className={BASE_CLASS}>
+        <Component {...props} />
+      </div>
+    )
+  }
+)
 
 AtomVideoPlayer.displayName = 'AtomVideoPlayer'
 
 AtomVideoPlayer.propTypes = {
+  autoPlay: PropTypes.bool,
   controls: PropTypes.bool,
   src: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Blob)])
     .isRequired

--- a/components/atom/videoPlayer/test/index.test.js
+++ b/components/atom/videoPlayer/test/index.test.js
@@ -158,6 +158,20 @@ describe('AtomVideoPlayer', () => {
       // Then
       expect(component.getByTitle(NATIVE_DEFAULT_TITLE).controls).to.eql(false)
     })
+
+    it('should autoplay the video if autoPlay prop is set to true', () => {
+      // Given
+      const props = {
+        autoPlay: true,
+        src: 'https://cdn.coverr.co/videos/coverr-boat-in-the-sea-5656/1080p.mp4'
+      }
+
+      // When
+      const component = setup(props)
+
+      // Then
+      expect(component.getByTitle(NATIVE_DEFAULT_TITLE).autoplay).to.eql(true)
+    })
   })
 
   describe('YouTube Videos', () => {
@@ -186,7 +200,7 @@ describe('AtomVideoPlayer', () => {
       // Then
       const iframeNode = component.getByTitle(YOUTUBE_DEFAULT_TITLE)
       // check that the iframe src is the embedable url
-      expect(iframeNode.src).to.equal(
+      expect(iframeNode.src).to.include(
         'https://www.youtube.com/embed/1gI_HGDgG7c'
       )
     })
@@ -203,7 +217,7 @@ describe('AtomVideoPlayer', () => {
       // Then
       const iframeNode = component.getByTitle(YOUTUBE_DEFAULT_TITLE)
       // check that the iframe src is the embedable url
-      expect(iframeNode.src).to.equal(
+      expect(iframeNode.src).to.include(
         'https://www.youtube.com/embed/1gI_HGDgG7c'
       )
     })
@@ -222,6 +236,22 @@ describe('AtomVideoPlayer', () => {
       const iframeNode = component.getByTitle(YOUTUBE_DEFAULT_TITLE)
       // check that the iframe src is the embedable url
       expect(iframeNode.src).to.include('controls=0')
+    })
+
+    it('should autoplay the video if the autoPlay prop is set to true', () => {
+      // Given
+      const props = {
+        autoPlay: true,
+        src: 'https://www.youtube.com/embed/1gI_HGDgG7c'
+      }
+
+      // When
+      const component = setup(props)
+
+      // Then
+      const iframeNode = component.getByTitle(YOUTUBE_DEFAULT_TITLE)
+      // check that the iframe src is the embedable url
+      expect(iframeNode.src).to.include('autoplay=1')
     })
   })
 
@@ -268,8 +298,22 @@ describe('AtomVideoPlayer', () => {
 
       // Then
       const iframeNode = component.getByTitle(VIMEO_DEFAULT_TITLE)
-      // check that the iframe src is the embedable url
       expect(iframeNode.src).to.include('controls=0')
+    })
+
+    it('should autoplay the video if the prop autoPlay is set to true', () => {
+      // Given
+      const props = {
+        autoPlay: true,
+        src: 'https://vimeo.com/54289199'
+      }
+
+      // When
+      const component = setup(props)
+
+      // Then
+      const iframeNode = component.getByTitle(VIMEO_DEFAULT_TITLE)
+      expect(iframeNode.src).to.include('autoplay=1')
     })
   })
 })


### PR DESCRIPTION
## atom/videoPlayer

#### `🔍 Show`

### Description, Motivation and Context
Implementing video-related features in Adevinta.

Add a prop to programmatically indicate if the videoplayer should autoplay or not.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] ✨ New feature (non-breaking change which adds functionality)