### PR TITLE
fix(components/molecule/select): Keep options even if children changes

### DIFF
--- a/components/molecule/select/src/components/MultipleSelection.js
+++ b/components/molecule/select/src/components/MultipleSelection.js
@@ -8,20 +8,6 @@ import {useDropdown} from '../config.js'
 import MoleculeInputSelect from './MoleculeInputSelect.js'
 import Search from './Search.js'
 
-function removeDuplicateTags(tags) {
-  const tagsSet = new Set()
-  tags.forEach(tag => tagsSet.add(tag))
-
-  return Array.from(tagsSet).filter(Boolean)
-}
-
-function keepSelectedTagsIfRemovedFromDOM(optionsData, values) {
-  return removeDuplicateTags([
-    ...values.map(value => optionsData[value]),
-    ...values
-  ])
-}
-
 const MoleculeSelectFieldMultiSelection = props => {
   /* eslint-disable react/prop-types */
   const {
@@ -44,7 +30,7 @@ const MoleculeSelectFieldMultiSelection = props => {
     maxTags
   } = props
 
-  const tags = keepSelectedTagsIfRemovedFromDOM(optionsData, values)
+  const tags = values.map(value => optionsData[value])
 
   const [focusedFirstOption, setFocusedFirstOption] = useState(false)
   const {hasSearch, isFirstOptionFocused, inputSearch} = useDropdown()

--- a/components/molecule/select/src/index.js
+++ b/components/molecule/select/src/index.js
@@ -51,6 +51,8 @@ const MoleculeSelect = forwardRef((props, forwardedRef) => {
     onSearch
   } = props
 
+  const refOptions = useRef({})
+
   const refMoleculeSelect = useRef(refMoleculeSelectFromProps)
   const refsMoleculeSelectOptions = useRef([])
   const ref = useMergeRefs(forwardedRef, refMoleculeSelect)
@@ -59,7 +61,7 @@ const MoleculeSelect = forwardRef((props, forwardedRef) => {
   const [isOpenState, setIsOpenState] = useState(isOpen || false)
   useEffect(() => setIsOpenState(isOpen), [isOpen, setIsOpenState])
 
-  const [optionsData, setOptionsData] = useState(getOptionData(children))
+  Object.assign(refOptions.current, getOptionData(children))
   const [focus, setFocus] = useState(false)
 
   const extendedChildren = useMemo(
@@ -134,7 +136,7 @@ const MoleculeSelect = forwardRef((props, forwardedRef) => {
   }, [refsMoleculeSelectOptions])
 
   useEffect(() => {
-    setOptionsData(getOptionData(children))
+    Object.assign(refOptions.current, getOptionData(children))
     document.addEventListener('touchend', handleOutsideClick)
     document.addEventListener('mousedown', handleOutsideClick)
 
@@ -212,7 +214,7 @@ const MoleculeSelect = forwardRef((props, forwardedRef) => {
       >
         <Select
           refMoleculeSelect={refMoleculeSelect}
-          optionsData={optionsData}
+          optionsData={refOptions.current}
           isOpen={isOpenState}
           onToggle={handleToggle}
           {...props}


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
`🔍 Show`
<!-- #### `❓ Ask` -->

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

With the introduction of the search input, the displayed option now can change and since the options were tracked based on the provided childrens some references were lost every time the children changed. In order to avoid this error we now use a ref to not create a new options object for every render and we update this ref with the new provided options every time the children changes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool
