### PR TITLE
fix(components/molecule/select): onToggle callback prop was overding …

### DIFF
--- a/components/molecule/select/demo/index.js
+++ b/components/molecule/select/demo/index.js
@@ -247,6 +247,35 @@ const Demo = () => {
         </div>
 
         <div className={CLASS_DEMO_SECTION}>
+          <h3>With onToggle callback</h3>
+          <MoleculeSelectWithState
+            placeholder="Select some countries..."
+            onChange={(_, {value}) => console.log(value)}
+            onToggle={(_, {isOpen}) => console.log(isOpen)}
+            iconCloseTag={<IconCloseTag />}
+            iconArrowDown={<IconArrowDown />}
+            searchIcon={<IconSearch />}
+            hasSearch
+            onSearch={({value}) => setQuery(value)}
+            searchPlaceholder="Search a country..."
+            noResults={
+              <div className="DemoMoleculeSelect-noResults">
+                No results found...
+              </div>
+            }
+            multiselection
+          >
+            {countriesList
+              .filter(country => country.includes(query))
+              .map((country, i) => (
+                <MoleculeSelectOption key={i} value={country}>
+                  {country}
+                </MoleculeSelectOption>
+              ))}
+          </MoleculeSelectWithState>
+        </div>
+
+        <div className={CLASS_DEMO_SECTION}>
           <h3>With preselected Value</h3>
           <MoleculeSelectWithState
             placeholder="Select some countries..."

--- a/components/molecule/select/src/components/MultipleSelection.js
+++ b/components/molecule/select/src/components/MultipleSelection.js
@@ -84,7 +84,7 @@ const MoleculeSelectFieldMultiSelection = props => {
       <MoleculeInputSelect
         id={id}
         tags={tags}
-        onClick={onToggle}
+        onClick={ev => onToggle(ev, {isOpen: !isOpen})}
         tagsCloseIcon={iconCloseTag}
         iconArrowDown={iconArrowDown}
         onChangeTags={handleChangeTags}

--- a/components/molecule/select/src/components/SingleSelection.js
+++ b/components/molecule/select/src/components/SingleSelection.js
@@ -60,7 +60,7 @@ const MoleculeSelectSingleSelection = props => {
         id={id}
         isOpen={isOpen}
         value={optionsData[value] || ''}
-        onClick={onToggle}
+        onClick={ev => onToggle(ev, {isOpen: !isOpen})}
         leftIcon={leftIcon}
         iconArrowDown={iconArrowDown}
         placeholder={placeholder}

--- a/components/molecule/select/test/index.test.js
+++ b/components/molecule/select/test/index.test.js
@@ -143,6 +143,44 @@ describe(json.name, () => {
       await waitFor(() => sinon.assert.callCount(spy, 1))
       sinon.assert.calledWith(spy, {value: 'abc'})
     })
+
+    it('should call the onToggle callback when input clicked', async () => {
+      const spy = sinon.spy()
+
+      const props = {
+        onToggle: (ev, {isOpen}) => spy(isOpen)
+      }
+
+      // When
+      const {getByRole} = setup(props)
+      const textBox = getByRole('textbox')
+
+      textBox.focus()
+      fireEvent.click(textBox)
+
+      // Then
+      await waitFor(() => sinon.assert.callCount(spy, 1))
+      sinon.assert.calledWith(spy, true)
+    })
+
+    it('should call the onToggle callback when enter key pressed', async () => {
+      const spy = sinon.spy()
+
+      const props = {
+        onToggle: (ev, {isOpen}) => spy(isOpen)
+      }
+
+      // When
+      const {getByRole} = setup(props)
+      const textBox = getByRole('textbox')
+
+      textBox.focus()
+      fireEvent.keyDown(textBox, {key: 'Enter'})
+
+      // Then
+      await waitFor(() => sinon.assert.callCount(spy, 1))
+      sinon.assert.calledWith(spy, true)
+    })
   })
 
   describe('moleculeSelectDropdownListSizes', () => {


### PR DESCRIPTION
…the defined inside the componen

## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
`🔍 Show`
<!-- #### `❓ Ask` -->

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

when onToggle prop was used the select broke and could not open at all because the prop was overriding the onToggle function defined inside the component.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool


