### PR TITLE
feat(components/atom/videoPlayer): Add muted prop to define if the pl…

### DIFF
--- a/components/atom/videoPlayer/src/components/HLSPlayer.js
+++ b/components/atom/videoPlayer/src/components/HLSPlayer.js
@@ -10,6 +10,7 @@ import {BASE_CLASS, HLS_DEFAULT_TITLE} from '../settings/index.js'
 const HLSPlayer = ({
   autoPlay,
   controls,
+  muted,
   hlsConfig,
   timeLimit,
   timeOffset,
@@ -43,6 +44,7 @@ const HLSPlayer = ({
         onPlaying={startTimeLimitInterval}
         onPause={stopTimeLimitInterval}
         controls={controls}
+        muted={muted}
         className={`${BASE_CLASS}-hlsPlayerVideo`}
         title={title}
         ref={playerRef}
@@ -56,6 +58,7 @@ const HLSPlayer = ({
 HLSPlayer.propTypes = {
   autoPlay: PropTypes.bool,
   controls: PropTypes.bool,
+  muted: PropTypes.bool,
   hlsConfig: PropTypes.object,
   timeLimit: PropTypes.number,
   timeOffset: PropTypes.number,

--- a/components/atom/videoPlayer/src/components/NativePlayer.js
+++ b/components/atom/videoPlayer/src/components/NativePlayer.js
@@ -9,6 +9,7 @@ import {BASE_CLASS, NATIVE_DEFAULT_TITLE} from '../settings/index.js'
 const NativePlayer = ({
   autoPlay,
   controls,
+  muted,
   timeLimit,
   timeOffset,
   src,
@@ -23,6 +24,7 @@ const NativePlayer = ({
       <video
         autoPlay={autoPlay}
         className={`${BASE_CLASS}-nativePlayerVideo`}
+        muted={muted}
         ref={videoNode}
         title={title}
         controls={controls}
@@ -37,6 +39,7 @@ const NativePlayer = ({
 NativePlayer.propTypes = {
   autoPlay: PropTypes.bool,
   controls: PropTypes.bool,
+  muted: PropTypes.bool,
   timeLimit: PropTypes.number,
   timeOffset: PropTypes.number,
   src: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Blob)]),

--- a/components/atom/videoPlayer/src/components/VimeoPlayer.js
+++ b/components/atom/videoPlayer/src/components/VimeoPlayer.js
@@ -11,6 +11,7 @@ import {BASE_CLASS, VIMEO_DEFAULT_TITLE} from '../settings/index.js'
 const VimeoPlayer = ({
   autoPlay,
   controls,
+  muted,
   timeLimit,
   timeOffset,
   src,
@@ -18,8 +19,9 @@ const VimeoPlayer = ({
 }) => {
   const {getEmbeddableUrl} = useVimeoProperties()
   const params = toQueryString({
+    autoplay: autoPlay ? '1' : '0',
     controls: controls ? '1' : '0',
-    autoplay: autoPlay ? '1' : '0'
+    muted: muted ? '1' : '0'
   })
   const time = `#t=${timeOffset}`
   const videoSrc = `${getEmbeddableUrl(src)}?${params}${time}`
@@ -48,6 +50,7 @@ const VimeoPlayer = ({
 VimeoPlayer.propTypes = {
   autoPlay: PropTypes.bool,
   controls: PropTypes.bool,
+  muted: PropTypes.bool,
   timeLimit: PropTypes.number,
   timeOffset: PropTypes.number,
   src: PropTypes.string,

--- a/components/atom/videoPlayer/src/components/YouTubePlayer.js
+++ b/components/atom/videoPlayer/src/components/YouTubePlayer.js
@@ -8,6 +8,7 @@ import {BASE_CLASS, YOUTUBE_DEFAULT_TITLE} from '../settings/index.js'
 const YouTubePlayer = ({
   autoPlay,
   controls,
+  muted,
   timeLimit,
   timeOffset,
   src,
@@ -19,7 +20,8 @@ const YouTubePlayer = ({
     autoplay: autoPlay ? '1' : '0',
     controls: controls ? '1' : '0',
     start: timeOffset || '0',
-    end: timeLimit
+    end: timeLimit,
+    mute: muted ? '1' : '0'
   })
 
   const videoSrc = `${getEmbeddableUrl(src)}?${params}`
@@ -40,6 +42,7 @@ const YouTubePlayer = ({
 YouTubePlayer.propTypes = {
   autoPlay: PropTypes.bool,
   controls: PropTypes.bool,
+  muted: PropTypes.bool,
   timeLimit: PropTypes.number,
   timeOffset: PropTypes.number,
   src: PropTypes.string,

--- a/components/atom/videoPlayer/src/index.js
+++ b/components/atom/videoPlayer/src/index.js
@@ -7,12 +7,20 @@ import {BASE_CLASS} from './settings/index.js'
 
 const AtomVideoPlayer = forwardRef(
   (
-    {autoPlay = false, controls = true, src = '', timeLimit, timeOffset},
+    {
+      autoPlay = false,
+      controls = true,
+      muted = false,
+      src = '',
+      timeLimit,
+      timeOffset
+    },
     forwardedRef
   ) => {
     const [Component, props] = useVideoPlayer({
       autoPlay,
       controls,
+      muted,
       src,
       timeLimit,
       timeOffset
@@ -30,6 +38,7 @@ AtomVideoPlayer.displayName = 'AtomVideoPlayer'
 AtomVideoPlayer.propTypes = {
   autoPlay: PropTypes.bool,
   controls: PropTypes.bool,
+  muted: PropTypes.bool,
   timeLimit: PropTypes.number,
   timeOffset: PropTypes.number,
   src: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Blob)])

--- a/components/atom/videoPlayer/test/index.test.js
+++ b/components/atom/videoPlayer/test/index.test.js
@@ -173,6 +173,22 @@ describe('AtomVideoPlayer', () => {
       // check that the iframe src is the embedable url
       expect(iframeNode.src).to.include('end=15')
     })
+
+    it('should mute the video when the muted prop is set to true', () => {
+      // Given
+      const props = {
+        muted: true,
+        src: 'https://www.youtube.com/embed/1gI_HGDgG7c'
+      }
+
+      // When
+      const component = setup(props)
+
+      // Then
+      const iframeNode = component.getByTitle(YOUTUBE_DEFAULT_TITLE)
+      // check that the iframe src is the embedable url
+      expect(iframeNode.src).to.include('mute=1')
+    })
   })
 
   describe('VIMEO Videos', () => {
@@ -250,6 +266,22 @@ describe('AtomVideoPlayer', () => {
       const iframeNode = component.getByTitle(VIMEO_DEFAULT_TITLE)
       expect(iframeNode.src).to.include('#t=25')
     })
+
+    it('should mute the video when the muted prop is set to true', () => {
+      // Given
+      const props = {
+        muted: true,
+        src: 'https://vimeo.com/54289199'
+      }
+
+      // When
+      const component = setup(props)
+
+      // Then
+      const iframeNode = component.getByTitle(VIMEO_DEFAULT_TITLE)
+      // check that the iframe src is the embedable url
+      expect(iframeNode.src).to.include('muted=1')
+    })
   })
 
   describe('Adaptative streaming player', () => {
@@ -291,6 +323,20 @@ describe('AtomVideoPlayer', () => {
 
       // Then
       expect(component.getByTitle(HLS_DEFAULT_TITLE).controls).to.eql(false)
+    })
+
+    it('should mute the video when muted prop is set to true', () => {
+      // Given
+      const props = {
+        muted: true,
+        src: 'https://media-frontend.yams-pro.mpi-internal.com/api/v1/yams-frontend/statics/vo/surf.mp4/hls.m3u8'
+      }
+
+      // When
+      const component = setup(props)
+
+      // Then
+      expect(component.getByTitle(HLS_DEFAULT_TITLE).muted).to.eql(true)
     })
   })
 
@@ -391,6 +437,20 @@ describe('AtomVideoPlayer', () => {
       // Then
       const {src} = await component.findByTestId('videosrc')
       expect(src).to.include('#t=0,20')
+    })
+
+    it('should mute the video when muted prop is set to true', () => {
+      // Given
+      const props = {
+        muted: true,
+        src: 'https://cdn.coverr.co/videos/coverr-boat-in-the-sea-5656/1080p.mp4'
+      }
+
+      // When
+      const component = setup(props)
+
+      // Then
+      expect(component.getByTitle(NATIVE_DEFAULT_TITLE).muted).to.eql(true)
     })
   })
 })


### PR DESCRIPTION
…ayer should be muted by default

## atom/videoPlayer

#### `🔍 Show`

### Description, Motivation and Context

* Context: Adding video-related features to an Adevinta marketplace.
* Changes: Add the `muted` prop to `atom/videoPlayer` to render the player on a muted state by default.

### Types of changes

- [X] ✨ New feature (non-breaking change which adds functionality)