### PR TITLE
feat(components/molecule/select): Disable options when tag limit is exceeded

### DIFF
--- a/components/molecule/select/src/components/MultipleSelection.js
+++ b/components/molecule/select/src/components/MultipleSelection.js
@@ -1,4 +1,4 @@
-import {useState} from 'react'
+import {Children, cloneElement, useMemo, useState} from 'react'
 
 import {inputTypes} from '@s-ui/react-atom-input'
 import MoleculeDropdownList from '@s-ui/react-molecule-dropdown-list'
@@ -35,6 +35,8 @@ const MoleculeSelectFieldMultiSelection = props => {
   const [focusedFirstOption, setFocusedFirstOption] = useState(false)
   const {hasSearch, isFirstOptionFocused, inputSearch} = useDropdown()
 
+  const isFull = maxTags && tags?.length >= maxTags
+
   const handleMultiSelection = (ev, {value: valueOptionSelected}) => {
     const handleToggle = ev => {
       const {key} = ev
@@ -50,11 +52,9 @@ const MoleculeSelectFieldMultiSelection = props => {
 
     const addToValues = () => [...values, valueOptionSelected]
 
-    const isFull = () => maxTags && tags?.length >= maxTags
-
     if (isValueSelectedAlreadySelected()) {
       onChange(ev, {value: removeFromValues()})
-    } else if (!isFull()) {
+    } else if (!isFull) {
       onChange(ev, {value: addToValues()})
     }
     handleToggle(ev)
@@ -78,6 +78,18 @@ const MoleculeSelectFieldMultiSelection = props => {
       focusedFirstOption && setTimeout(() => inputSearch?.focus())
     }
   }
+
+  const extendedChildren = useMemo(
+    () =>
+      Children.toArray(children)
+        .filter(Boolean)
+        .map(child => {
+          return cloneElement(child, {
+            disabled: !values.includes(child.props.value) && isFull
+          })
+        }),
+    [children, isFull, values]
+  )
 
   return (
     <>
@@ -110,7 +122,7 @@ const MoleculeSelectFieldMultiSelection = props => {
         onKeyDown={handleKeyDown}
         value={values}
       >
-        {children}
+        {extendedChildren}
       </MoleculeDropdownList>
     </>
   )


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
`🔍 Show`
<!-- #### `❓ Ask` -->

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
We need to let the user now when he has exceeded the max tags allowed in the the select, in order to do that we have decided to disable the options that are not selected yet

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<img width="1087" alt="image" src="https://user-images.githubusercontent.com/21960669/236442474-f1af4223-ee42-4421-a77f-75a4688a810c.png">
