### PR TITLE
fix(components/molecule/stepper): Set width to zero for a label of no…

### DIFF
--- a/components/molecule/stepper/src/Step/DefaultStep.js
+++ b/components/molecule/stepper/src/Step/DefaultStep.js
@@ -39,6 +39,13 @@ const DefaultStep = ({
               marginLeft: `calc(-${(step - 1) * 100}% - ${(step - 1) * 8}px)`
             }
           })}
+        {...(design === DESIGN.COMPRESSED &&
+          !current &&
+          alignment === ALIGNMENT.HORIZONTAL && {
+            style: {
+              width: '0'
+            }
+          })}
       >
         {showLabel && getLabel({steps, step, design, label, current})}
       </div>


### PR DESCRIPTION
…n-current steps in compressed s

## molecule/stepper
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
#### `🔍 Show`
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
Set width to zero for a label of non-current steps in the compressed horizontal stepper.
This change is required because the label space (100px and 180px in IJ, class="sui-MoleculeStepperStepLabel") in the compressed horizontal stepper generates a horizontal scroll in mobile.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<img width="435" alt="Captura de pantalla 2023-05-10 a las 10 12 31" src="https://github.com/SUI-Components/sui-components/assets/71508330/e3f59352-f0e8-40a9-b1d8-1238c124a6f6">
