### PR TITLE
fix(components/molecule/progressSteps): Add overflow: hidden to stepp…

### DIFF
--- a/components/molecule/progressSteps/src/styles/index.scss
+++ b/components/molecule/progressSteps/src/styles/index.scss
@@ -9,6 +9,7 @@ $base-class-stepper-bar: '#{$base-class-stepper-path}Connector';
   display: flex;
   flex-direction: column;
   gap: 8px;
+  overflow: hidden;
   #{$base-class-stepper} {
     max-width: $mw-progress-steps-path;
     #{$base-class-stepper-bar} {

--- a/components/molecule/progressSteps/src/styles/index.scss
+++ b/components/molecule/progressSteps/src/styles/index.scss
@@ -9,7 +9,7 @@ $base-class-stepper-bar: '#{$base-class-stepper-path}Connector';
   display: flex;
   flex-direction: column;
   gap: 8px;
-  overflow: hidden;
+  overflow: $o-progress-steps;
   #{$base-class-stepper} {
     max-width: $mw-progress-steps-path;
     #{$base-class-stepper-bar} {

--- a/components/molecule/progressSteps/src/styles/settings.scss
+++ b/components/molecule/progressSteps/src/styles/settings.scss
@@ -1,5 +1,7 @@
 @import '~@s-ui/react-molecule-stepper/lib/styles/settings.scss';
 
+$o-progress-steps: visible !default;
+
 // Colors
 $c-progress-steps-bar: $c-stepper !default;
 $c-progress-steps-label: $c-stepper-label !default;


### PR DESCRIPTION
…er container to prevent horizon

## molecule/progressSteps
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
 #### `🔍 Show`
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
Add overflow: hidden to progressSteps container. This change is required because the label space (100px and 180px in IJ, class="sui-MoleculeStepperStepLabel") in the compressed horizontal stepper generates a horizontal scroll in mobile.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<img width="435" alt="Captura de pantalla 2023-05-10 a las 10 12 31" src="https://github.com/SUI-Components/sui-components/assets/71508330/39c9f87a-ba5a-4304-8885-514c88e6e4b4">
