### PR TITLE
fix(components/molecule/dropdownOption): do not use a default prop for innerRef

### DIFF
--- a/components/molecule/dropdownOption/src/index.js
+++ b/components/molecule/dropdownOption/src/index.js
@@ -49,7 +49,7 @@ const MoleculeDropdownOption = forwardRef(
     },
     forwardedRef
   ) => {
-    const ref = useMergeRefs(innerRef, forwardedRef)
+    const ref = useMergeRefs(innerRef || createRef(), forwardedRef)
     const [innerSelected, setInnerSelected] = useControlledState(
       selected,
       defaultSelected
@@ -205,8 +205,7 @@ MoleculeDropdownOption.defaultProps = {
   disabled: false,
   onSelect: () => {},
   defaultSelected: false,
-  selectKey: 'Enter',
-  innerRef: createRef()
+  selectKey: 'Enter'
 }
 export default MoleculeDropdownOption
 export {handlersFactory}


### PR DESCRIPTION

## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
 #### `🔍 Show` 
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

The component was defining a default prop for the innerRef resulting in sharing the same ref over each child

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
