### PR TITLE
feat(components/atom/button): button inner inherits text decoration

### DIFF
--- a/components/atom/button/src/styles/index.scss
+++ b/components/atom/button/src/styles/index.scss
@@ -72,6 +72,7 @@ $base-class: '.sui-AtomButton';
     display: inline-flex;
     height: 100%;
     pointer-events: none;
+    text-decoration: inherit;
   }
 
   &--loading {


### PR DESCRIPTION
## Atom/Button
#### `🔍 Show`

### Description, Motivation, and Context
The text-decoration of ALL atom buttons with link style was removed on Coches.net.
The cause was a bug fix on Chrome. The inner container SHOULD NOT inherit the text-decoration of its parent.
Believing it was a Firefox bug, a user opened a bug on Mozilla 6 years ago: https://bugzilla.mozilla.org/show_bug.cgi?id=1344545
The same engineer that replied that it was a Chrome bug, remembered this issue 3 months ago and sent the bug to the Chromium team: https://bugs.chromium.org/p/chromium/issues/detail?id=1414859

So, back to SUI Components, the fix proposed here it's to ensure the inheritance of the text-decoration on the inner element, as it was the expected behavior.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 💄 Styles

### Screenshots - Animations
BEFORE: 
<img width="486" alt="image" src="https://github.com/SUI-Components/sui-components/assets/37936498/5f9a2646-14bf-4f22-9e05-e472d4dcf45a">

NOW (expected):
<img width="462" alt="image" src="https://github.com/SUI-Components/sui-components/assets/37936498/580dc6e6-3134-46d4-8d92-d08940c992fc">

