### PR TITLE
fix(components/atom/tag): substitute outline for border property in outline tag styles

### DIFF
--- a/components/atom/tag/src/styles/index.scss
+++ b/components/atom/tag/src/styles/index.scss
@@ -104,7 +104,7 @@ $base-class: '.sui-AtomTag';
     }
 
     &#{$self}--outline {
-      border-color: $c-atom-tag-actionable-invert;
+      outline-color: $c-atom-tag-actionable-invert;
       color: $c-atom-tag-actionable-invert;
       fill: $c-atom-tag-actionable-invert;
 
@@ -184,7 +184,7 @@ $base-class: '.sui-AtomTag';
 
   &--outline {
     background-color: $bgc-atom-tag-outline;
-    border: $bdw-atom-tag-outline solid $bc-atom-tag-outline;
+    outline: $bdw-atom-tag-outline solid $bc-atom-tag-outline;
   }
 
   @each $name, $type in $atom-tag-types {


### PR DESCRIPTION

## atom/tag
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
#### `🔍 Show`
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
Substitute outline for border property in outline tag styles. This change is required because the outline tag width is bigger than the other tags' width.
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
