### PR TITLE
feat(components/atom/pinInput): Create justify content key

### DIFF
--- a/components/atom/pinInput/demo/ArticleJustifyContent.js
+++ b/components/atom/pinInput/demo/ArticleJustifyContent.js
@@ -1,0 +1,68 @@
+import {useState} from 'react'
+
+import PropTypes from 'prop-types'
+
+import {
+  Article,
+  Code,
+  H2,
+  Paragraph,
+  RadioButton,
+  RadioButtonGroup
+} from '@s-ui/documentation-library'
+
+import {JUSTIFY_CONTENT} from '../src/config.js'
+import PinInput from '../src/index.js'
+
+const ArticleJustifyContent = ({className}) => {
+  const [code, setCode] = useState('')
+  const [justifyContentValue, setJustifyContentValue] = useState()
+
+  const onChangeHandler = (event, args) => {
+    setCode(args.value)
+  }
+
+  const onJustifyContentChangeValue = (event, value) => {
+    setJustifyContentValue(value)
+  }
+
+  return (
+    <Article className={className}>
+      <H2>Justify Content</H2>
+      <Paragraph>
+        You can change the justify content of the input fields by the prop
+        <Code>justifyContent</Code>.
+      </Paragraph>
+      <RadioButtonGroup
+        value={justifyContentValue}
+        onChange={onJustifyContentChangeValue}
+      >
+        {[undefined, ...Object.values(JUSTIFY_CONTENT)].map(
+          (statusValue, key) => {
+            return (
+              <RadioButton
+                checked={statusValue === justifyContentValue}
+                value={statusValue}
+                key={key}
+                label={statusValue || 'undefined'}
+              />
+            )
+          }
+        )}
+      </RadioButtonGroup>
+      <br />
+      <br />
+      <PinInput
+        justifyContent={justifyContentValue}
+        onChangeHandler={onChangeHandler}
+        defaultValue={code}
+      />
+    </Article>
+  )
+}
+
+ArticleJustifyContent.propTypes = {
+  className: PropTypes.string
+}
+
+export default ArticleJustifyContent

--- a/components/atom/pinInput/demo/index.js
+++ b/components/atom/pinInput/demo/index.js
@@ -4,6 +4,7 @@ import ArticleAutoFocus from './ArticleAutoFocus.js'
 import ArticleChildren from './ArticleChildren.js'
 import ArticleDefault from './ArticleDefault.js'
 import ArticleDisabled from './ArticleDisabled.js'
+import ArticleJustifyContent from './ArticleJustifyContent.js'
 import ArticleLength from './ArticleLength.js'
 import ArticleMask from './ArticleMask.js'
 import ArticlePassword from './ArticlePassword.js'
@@ -48,6 +49,8 @@ export default () => {
         <ArticleChildren className={CLASS_SECTION} />
         <br />
         <ArticleReferenced className={CLASS_SECTION} />
+        <br />
+        <ArticleJustifyContent className={CLASS_SECTION} />
       </div>
     </div>
   )

--- a/components/atom/pinInput/src/PinInputChildren.js
+++ b/components/atom/pinInput/src/PinInputChildren.js
@@ -1,11 +1,19 @@
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 
 import {BASE_CLASSNAME} from './config.js'
 import PinInputField from './PinInputField.js'
 
-const CLASSNAME = `${BASE_CLASSNAME}FieldsWrapper`
-
-const PinInputChildren = ({autoFocus = false, length, children}) => {
+const PinInputChildren = ({
+  autoFocus = false,
+  length,
+  children,
+  justifyContent
+}) => {
+  const CLASSNAME = cx(`${BASE_CLASSNAME}FieldsWrapper`, {
+    [`${BASE_CLASSNAME}FieldsWrapper--justify-${justifyContent}`]:
+      justifyContent
+  })
   if (children) return children
   return (
     <div className={CLASSNAME}>
@@ -27,7 +35,9 @@ PinInputChildren.propTypes = {
   /** number of input */
   length: PropTypes.number,
   /** children to be rendered */
-  children: PropTypes.node
+  children: PropTypes.node,
+  /** justify content */
+  justifyContent: PropTypes.string
 }
 
 export default PinInputChildren

--- a/components/atom/pinInput/src/PinInputChildren.scss
+++ b/components/atom/pinInput/src/PinInputChildren.scss
@@ -8,4 +8,10 @@
   > .sui-PinInputField {
     margin: 0 math.div($m-pin-input-children, 2);
   }
+
+  @each $justify-key, $justify-value in $justify-pin-input-field {
+    &--justify-#{$justify-key} {
+      justify-content: $justify-value;
+    }
+  }
 }

--- a/components/atom/pinInput/src/config.js
+++ b/components/atom/pinInput/src/config.js
@@ -20,6 +20,13 @@ export const MASK = {
   ALPHANUMERIC: '[A-Za-z0-9]'
 }
 
+export const JUSTIFY_CONTENT = {
+  FLEX_START: 'start',
+  CENTER: 'center',
+  FLEX_END: 'end',
+  SPACE_BETWEEN: 'between'
+}
+
 export const valueChecker =
   ({length = 1, mask}) =>
   (value = '') => {

--- a/components/atom/pinInput/src/config.scss
+++ b/components/atom/pinInput/src/config.scss
@@ -23,6 +23,13 @@ $s-pin-input-field: (
   xxsmall: $p-base * 2
 ) !default;
 
+$justify-pin-input-field: (
+  start: flex-start,
+  center: center,
+  end: flex-end,
+  between: space-between
+) !default;
+
 $pin-input-field-status: (
   error: $c-error,
   success: $c-success,

--- a/components/atom/pinInput/src/index.js
+++ b/components/atom/pinInput/src/index.js
@@ -10,7 +10,14 @@ import {
   actions as pinInputActions,
   usePinInputReducer
 } from './reducer/index.js'
-import {BASE_CLASSNAME, getValueType, MASK, SIZES, STATUS} from './config.js'
+import {
+  BASE_CLASSNAME,
+  getValueType,
+  JUSTIFY_CONTENT,
+  MASK,
+  SIZES,
+  STATUS
+} from './config.js'
 import PinInputChildren from './PinInputChildren.js'
 import {PinInputContextProvider} from './PinInputContext.js'
 import PinInputField from './PinInputField.js'
@@ -31,6 +38,7 @@ const PinInput = forwardRef(
       mask,
       onChange,
       placeholder = '',
+      justifyContent,
       size = SIZES.MEDIUM,
       status,
       value,
@@ -104,7 +112,11 @@ const PinInput = forwardRef(
           targetRef={innerRef}
           value={innerValue}
         >
-          <PinInputChildren length={length} autoFocus={autoFocus}>
+          <PinInputChildren
+            justifyContent={justifyContent}
+            length={length}
+            autoFocus={autoFocus}
+          >
             {children}
           </PinInputChildren>
         </PinInputContextProvider>
@@ -137,6 +149,8 @@ PinInput.propTypes = {
   isOneTimeCode: PropTypes.bool,
   /** true to make the input type password false for text */
   isPassword: PropTypes.bool,
+  /** set the justify content of the input (FLEX_START, CENTER, FLEX_END) */
+  justifyContent: PropTypes.string,
   /** defines the number of cells */
   length: PropTypes.number,
   /** name of the custom mask (NUMBER, ALPHABETIC, ALPHANUMERIC) */
@@ -165,5 +179,6 @@ export {
   MASK as pinInputMask,
   SIZES as pinInputSizes,
   STATUS as pinInputStatus,
-  getValueType as getPinInputValueType
+  getValueType as getPinInputValueType,
+  JUSTIFY_CONTENT as pinInputJustifyContent
 }

--- a/components/atom/pinInput/test/index.test.js
+++ b/components/atom/pinInput/test/index.test.js
@@ -35,6 +35,7 @@ describe(json.name, () => {
       'PinInputField',
       'pinInputMask',
       'pinInputSizes',
+      'pinInputJustifyContent',
       'pinInputStatus',
       'getPinInputValueType',
       'default'
@@ -47,6 +48,7 @@ describe(json.name, () => {
       pinInputSizes,
       pinInputStatus,
       getPinInputValueType,
+      pinInputJustifyContent,
       default: AtomPinInput,
       ...others
     } = library
@@ -2122,6 +2124,42 @@ describe(json.name, () => {
       // When
       const {pinInputStatus: actual} = library
       const {ERROR, SUCCESS, ALERT, ...others} = actual
+
+      // Then
+      expect(Object.keys(others).length).to.equal(0)
+      expect(Object.keys(actual)).to.have.members(Object.keys(expected))
+      Object.entries(expected).forEach(([expectedKey, expectedValue]) => {
+        expect(Object.keys(actual).includes(expectedKey)).to.be.true
+        expect(actual[expectedKey]).to.equal(expectedValue)
+      })
+    })
+  })
+
+  describe('pinInputJustifyContent', () => {
+    it('value must be an object enum', () => {
+      // Given
+      const library = pkg
+
+      // When
+      const {pinInputJustifyContent: actual} = library
+
+      // Then
+      expect(actual).to.be.an('object')
+    })
+
+    it('value must be a defined string-key pair filled', () => {
+      // Given
+      const library = pkg
+      const expected = {
+        FLEX_START: 'start',
+        CENTER: 'center',
+        FLEX_END: 'end',
+        SPACE_BETWEEN: 'between'
+      }
+
+      // When
+      const {pinInputJustifyContent: actual} = library
+      const {FLEX_START, CENTER, FLEX_END, SPACE_BETWEEN, ...others} = actual
 
       // Then
       expect(Object.keys(others).length).to.equal(0)


### PR DESCRIPTION
## atom/pinInput
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
`🔍 Show`
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: [<!--- #issueID -->](https://jira.ets.mpi-internal.com/browse/SCMI-98905)

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

Create a justify content key to control how the inputs will be displayed inside a container, nowadays its always set to flex start and if we have a container with x size we can't fill it.  Also added some testing to it 🧪.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [x] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->

<img width="716" alt="image" src="https://github.com/SUI-Components/sui-components/assets/59662722/36639c9f-9319-4405-833e-4250a391e73f">
<img width="1512" alt="image" src="https://github.com/SUI-Components/sui-components/assets/59662722/8d06d239-9b90-4d26-aebf-2257db5525a9">
<img width="1512" alt="image" src="https://github.com/SUI-Components/sui-components/assets/59662722/dca3e1c4-2f04-4545-aed0-40b19cd68f55">
<img width="1512" alt="image" src="https://github.com/SUI-Components/sui-components/assets/59662722/04fee07d-6299-477b-8b83-3e71dd471415">

