### PR TITLE
feat(components/molecule/coachmark): create sui coachmark component skeleton

### DIFF
--- a/components/molecule/coachmark/.gitignore
+++ b/components/molecule/coachmark/.gitignore
@@ -1,0 +1,2 @@
+lib
+node_modules

--- a/components/molecule/coachmark/.npmignore
+++ b/components/molecule/coachmark/.npmignore
@@ -1,0 +1,4 @@
+assets
+demo
+src
+test

--- a/components/molecule/coachmark/README.md
+++ b/components/molecule/coachmark/README.md
@@ -1,0 +1,32 @@
+# MoleculeCoachmark
+
+`MoleculeCoachmark` is a wrapper of the [react-joyride](https://react-joyride.com/) library in order to create smooth guided tours in the apps to explain new features to the users
+
+## Installation
+
+```sh
+$ npm install @s-ui/react-molecule-coachmark
+```
+
+## Usage
+
+### Basic usage
+
+#### Import package and use the component
+
+```js
+import MoleculeCoachmark from '@s-ui/react-molecule-coachmark'
+
+return (<MoleculeCoachmark />)
+```
+
+#### Import the styles (Sass)
+
+```css
+@import '~@s-ui/theme/lib/index';
+/* @import 'your theme'; */
+@import '~@s-ui/react-molecule-coachmark/lib/index';
+```
+
+
+> **Find full description and more examples in the [demo page](#).**

--- a/components/molecule/coachmark/demo/index.js
+++ b/components/molecule/coachmark/demo/index.js
@@ -1,0 +1,2 @@
+import MoleculeCoachmark from 'components/molecule/coachmark/src'
+export default () => <MoleculeCoachmark />

--- a/components/molecule/coachmark/demo/package.json
+++ b/components/molecule/coachmark/demo/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@s-ui/react-molecule-coachmark-demo",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Demo for @s-ui/react-molecule-coachmark"
+}

--- a/components/molecule/coachmark/package.json
+++ b/components/molecule/coachmark/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@s-ui/react-molecule-coachmark",
+  "version": "0.0.0",
+  "description": "",
+  "main": "lib/index.js",
+  "scripts": {
+    "prepublishOnly": "rimraf lib && npm run build:js && npm run build:styles",
+    "build:js": "babel --presets sui ./src --out-dir ./lib",
+    "build:styles": "cpx './src/**/*.scss' ./lib"
+  },
+  "peerDependencies": {
+    "@s-ui/theme": "8"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SUI-Components/sui-components"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT"
+}

--- a/components/molecule/coachmark/src/index.js
+++ b/components/molecule/coachmark/src/index.js
@@ -1,0 +1,12 @@
+// import PropTypes from 'prop-types'
+
+export default function MoleculeCoachmark() {
+  return (
+    <div className="react-MoleculeCoachmark">
+      <h1>MoleculeCoachmark</h1>
+    </div>
+  )
+}
+
+MoleculeCoachmark.displayName = 'MoleculeCoachmark'
+MoleculeCoachmark.propTypes = {}

--- a/components/molecule/coachmark/src/index.scss
+++ b/components/molecule/coachmark/src/index.scss
@@ -1,0 +1,5 @@
+@import '~@s-ui/theme/lib/index';
+
+.react-MoleculeCoachmark {
+  // Do your magic
+}

--- a/components/molecule/coachmark/test/index.test.js
+++ b/components/molecule/coachmark/test/index.test.js
@@ -1,0 +1,56 @@
+/*
+ * Remember: YOUR COMPONENT IS DEFINED GLOBALLY
+ * */
+
+/* eslint react/jsx-no-undef:0 */
+/* eslint no-undef:0 */
+
+import ReactDOM from 'react-dom'
+
+import chai, {expect} from 'chai'
+import chaiDOM from 'chai-dom'
+import Component from '../src/index.js'
+
+chai.use(chaiDOM)
+
+describe('MoleculeCoachmark', () => {
+  const setup = setupEnvironment(Component)
+
+  it('should render without crashing', () => {
+    // Given
+    const props = {}
+
+    // When
+    const component = <Component {...props} />
+
+    // Then
+    const div = document.createElement('div')
+    ReactDOM.render(component, div)
+    ReactDOM.unmountComponentAtNode(div)
+  })
+
+  it('should NOT render null', () => {
+    // Given
+    const props = {}
+
+    // When
+    const {container} = setup(props)
+
+    // Then
+    expect(container.innerHTML).to.be.a('string')
+    expect(container.innerHTML).to.not.have.lengthOf(0)
+  })
+
+  it.skip('should NOT extend classNames', () => {
+    // Given
+    const props = {className: 'extended-classNames'}
+    const findSentence = str => string => string.match(new RegExp(`S*${str}S*`))
+
+    // When
+    const {container} = setup(props)
+    const findClassName = findSentence(props.className)
+
+    // Then
+    expect(findClassName(container.innerHTML)).to.be.null
+  })
+})


### PR DESCRIPTION
## Molecule/Coachmark
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
#### `🔍 Show` 

### Description, Motivation and Context
<!--- Describe your changes in detail -->

From motor we are going to start working in a creation of the react-joyride wrapper in order to have a way to use guided tours in our apps from a SUI component. This is the first pr, just the skeleton of the component (without anything implemented)

A version 0 is created to show that this is still WIP and it shouldn't be used in any app.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

