### PR TITLE
feat(components/molecule/photoUploader): Allow extra params on photo uploaded

### DIFF
--- a/components/molecule/photoUploader/src/PhotosPreview/index.js
+++ b/components/molecule/photoUploader/src/PhotosPreview/index.js
@@ -94,11 +94,13 @@ const PhotosPreview = ({
         list[index].blob = blob
         list[index].isModified = true
 
-        list[index].url = await callbackUploadPhotoHandler(
+        const {url} = await callbackUploadPhotoHandler(
           blob,
           callbackUploadPhoto,
           list[index].url
         )
+        list[index].url = url
+
         setFiles(list)
         setNotificationError(DEFAULT_NOTIFICATION_ERROR)
         _callbackPhotosUploaded(list, {

--- a/components/molecule/photoUploader/src/fileTools.js
+++ b/components/molecule/photoUploader/src/fileTools.js
@@ -101,7 +101,7 @@ export async function callbackUploadPhotoHandler(
   if (callbackUploadPhoto) {
     try {
       const response = await callbackUploadPhoto(blob, oldUrl)
-      return response.url
+      return response
     } catch (e) {}
   }
 }
@@ -150,7 +150,7 @@ export const prepareFiles = ({
             ])
             setCorruptedFileError(errorText)
           } else {
-            const url = await callbackUploadPhotoHandler(
+            const {url, ...restProps} = await callbackUploadPhotoHandler(
               blob,
               callbackUploadPhoto
             )
@@ -171,7 +171,8 @@ export const prepareFiles = ({
                 },
                 preview: croppedBase64,
                 rotation,
-                url
+                url,
+                ...restProps
               })
             }
           }


### PR DESCRIPTION
## MOLECULE/PHOTO_UPLOADER
#### `❓ Ask`

**TASK**:  NO JIRA

### Description, Motivation and Context

With this new feature, we allow passing extra props when a new photo is uploaded from outside to internal component. 
For example, we want to perform 2 calls when user add a new photo, one to analyse the photo and the other to store it. The first call can delay a little bit the UX and that's not an option. 

So, we will create a custom id and pass it to photoUploader component, in order to identify it when is updated or deleted.

### Types of changes

- [x] ✨ New feature (non-breaking change which adds functionality)