### PR TITLE
Feature/progress bar circle add size caps and outer stroke

### DIFF
--- a/components/atom/progressBar/demo/articles/ArticleCircleDefault.js
+++ b/components/atom/progressBar/demo/articles/ArticleCircleDefault.js
@@ -18,6 +18,7 @@ import AtomProgressBar, {
   atomProgressBarLineCaps,
   atomProgressBarSizes,
   atomProgressBarStatus,
+  atomProgressBarStrokeSizes,
   atomProgressBarTypes
 } from '../../src/index.js'
 import {getShuffledValue} from '../settings.js'
@@ -28,7 +29,8 @@ const ArticleCircleDefault = ({className}) => {
   const [hideIndicator, setHideIndicator] = useState()
   const [indicatorBottom, setIndicatorBottom] = useState()
   const [strokeLineCap, setStrokeLineCap] = useState('square')
-  const [outerStrokeWidth, setOuterStrokeWidth] = useState()
+  const [mainStrokeSize, setMainStrokeSize] = useState()
+  const [progressStrokeSize, setProgressStrokeSize] = useState()
   const [indicatorTotal, setIndicatorTotal] = useState()
   const [status, setStatus] = useState()
   const [size, setSize] = useState()
@@ -105,36 +107,49 @@ const ArticleCircleDefault = ({className}) => {
             checked={indicatorTotal}
           />
         </Cell>
+
         <Cell>
-          <Label>strokeLineCap</Label>
+          <Label>mainStrokeSize</Label>
         </Cell>
         <Cell>
-          <Label>outerStrokeWidth</Label>
+          <Label>progressStrokeSize</Label>
         </Cell>
+
         <Cell>
           <RadioButtonGroup
-            value={strokeLineCap}
-            onChange={(event, value) => setStrokeLineCap(value)}
+            value={mainStrokeSize}
+            onChange={(event, value) => setMainStrokeSize(value)}
           >
             {[
               ['undefined', undefined],
-              ...Object.entries(atomProgressBarLineCaps)
-            ].map(([, atomProgressBarLineCapsValue]) => (
+              ...Object.entries(atomProgressBarStrokeSizes)
+            ].map(([, atomProgressBarStrokeSizesValue]) => (
               <RadioButton
-                key={`${atomProgressBarLineCapsValue}`}
-                label={`${atomProgressBarLineCapsValue}`}
-                value={atomProgressBarLineCapsValue}
-                checked={strokeLineCap === atomProgressBarLineCapsValue}
+                key={`${atomProgressBarStrokeSizesValue}`}
+                label={`${atomProgressBarStrokeSizesValue}`}
+                value={atomProgressBarStrokeSizesValue}
+                checked={mainStrokeSize === atomProgressBarStrokeSizesValue}
               />
             ))}
           </RadioButtonGroup>
         </Cell>
         <Cell>
-          <RadioButton
-            onClick={() => setOuterStrokeWidth(!outerStrokeWidth)}
-            label={outerStrokeWidth ? 'true' : 'false'}
-            checked={outerStrokeWidth}
-          />
+          <RadioButtonGroup
+            value={progressStrokeSize}
+            onChange={(event, value) => setProgressStrokeSize(value)}
+          >
+            {[
+              ['undefined', undefined],
+              ...Object.entries(atomProgressBarStrokeSizes)
+            ].map(([, atomProgressBarStrokeSizesValue]) => (
+              <RadioButton
+                key={`${atomProgressBarStrokeSizesValue}`}
+                label={`${atomProgressBarStrokeSizesValue}`}
+                value={atomProgressBarStrokeSizesValue}
+                checked={progressStrokeSize === atomProgressBarStrokeSizesValue}
+              />
+            ))}
+          </RadioButtonGroup>
         </Cell>
 
         <Cell>
@@ -179,6 +194,27 @@ const ArticleCircleDefault = ({className}) => {
             ))}
           </RadioButtonGroup>
         </Cell>
+        <Cell>
+          <Label>strokeLineCap</Label>
+        </Cell>
+        <Cell>
+          <RadioButtonGroup
+            value={strokeLineCap}
+            onChange={(event, value) => setStrokeLineCap(value)}
+          >
+            {[
+              ['undefined', undefined],
+              ...Object.entries(atomProgressBarLineCaps)
+            ].map(([, atomProgressBarLineCapsValue]) => (
+              <RadioButton
+                key={`${atomProgressBarLineCapsValue}`}
+                label={`${atomProgressBarLineCapsValue}`}
+                value={atomProgressBarLineCapsValue}
+                checked={strokeLineCap === atomProgressBarLineCapsValue}
+              />
+            ))}
+          </RadioButtonGroup>
+        </Cell>
         <Cell span={2}>
           <Label>result</Label>
         </Cell>
@@ -193,7 +229,8 @@ const ArticleCircleDefault = ({className}) => {
             indicatorBottom={indicatorBottom}
             indicatorTotal={indicatorTotal}
             strokeLineCap={strokeLineCap}
-            outerStrokeWidth={outerStrokeWidth}
+            mainStrokeSize={mainStrokeSize}
+            progressStrokeSize={progressStrokeSize}
           />
         </Cell>
       </Grid>

--- a/components/atom/progressBar/demo/articles/ArticleCircleDefault.js
+++ b/components/atom/progressBar/demo/articles/ArticleCircleDefault.js
@@ -15,6 +15,7 @@ import {
 } from '@s-ui/documentation-library'
 
 import AtomProgressBar, {
+  atomProgressBarLineCaps,
   atomProgressBarSizes,
   atomProgressBarStatus,
   atomProgressBarTypes
@@ -26,9 +27,12 @@ const ArticleCircleDefault = ({className}) => {
   const [isAnimated, setIsAnimated] = useState(true)
   const [hideIndicator, setHideIndicator] = useState()
   const [indicatorBottom, setIndicatorBottom] = useState()
+  const [strokeLineCaps, setStrokeLineCaps] = useState('square')
+  const [outerStrokeWidth, setOuterStrokeWidth] = useState()
   const [indicatorTotal, setIndicatorTotal] = useState()
   const [status, setStatus] = useState()
   const [size, setSize] = useState()
+
   return (
     <Article className={className}>
       <H2 id="circle-progress-bar">Circle Progress Bar</H2>
@@ -102,6 +106,38 @@ const ArticleCircleDefault = ({className}) => {
           />
         </Cell>
         <Cell>
+          <Label>strokeLineCaps</Label>
+        </Cell>
+        <Cell>
+          <Label>outerStrokeWidth</Label>
+        </Cell>
+        <Cell>
+          <RadioButtonGroup
+            value={strokeLineCaps}
+            onChange={(event, value) => setStrokeLineCaps(value)}
+          >
+            {[
+              ['undefined', undefined],
+              ...Object.entries(atomProgressBarLineCaps)
+            ].map(([, atomProgressBarLineCapsValue]) => (
+              <RadioButton
+                key={`${atomProgressBarLineCapsValue}`}
+                label={`${atomProgressBarLineCapsValue}`}
+                value={atomProgressBarLineCapsValue}
+                checked={strokeLineCaps === atomProgressBarLineCapsValue}
+              />
+            ))}
+          </RadioButtonGroup>
+        </Cell>
+        <Cell>
+          <RadioButton
+            onClick={() => setOuterStrokeWidth(!outerStrokeWidth)}
+            label={outerStrokeWidth ? 'true' : 'false'}
+            checked={outerStrokeWidth}
+          />
+        </Cell>
+
+        <Cell>
           <Label>status</Label>
         </Cell>
         <Cell>
@@ -156,6 +192,8 @@ const ArticleCircleDefault = ({className}) => {
             hideIndicator={hideIndicator}
             indicatorBottom={indicatorBottom}
             indicatorTotal={indicatorTotal}
+            strokeLineCaps={strokeLineCaps}
+            outerStrokeWidth={outerStrokeWidth}
           />
         </Cell>
       </Grid>

--- a/components/atom/progressBar/demo/articles/ArticleCircleDefault.js
+++ b/components/atom/progressBar/demo/articles/ArticleCircleDefault.js
@@ -27,7 +27,7 @@ const ArticleCircleDefault = ({className}) => {
   const [isAnimated, setIsAnimated] = useState(true)
   const [hideIndicator, setHideIndicator] = useState()
   const [indicatorBottom, setIndicatorBottom] = useState()
-  const [strokeLineCaps, setStrokeLineCaps] = useState('square')
+  const [strokeLineCap, setStrokeLineCap] = useState('square')
   const [outerStrokeWidth, setOuterStrokeWidth] = useState()
   const [indicatorTotal, setIndicatorTotal] = useState()
   const [status, setStatus] = useState()
@@ -106,15 +106,15 @@ const ArticleCircleDefault = ({className}) => {
           />
         </Cell>
         <Cell>
-          <Label>strokeLineCaps</Label>
+          <Label>strokeLineCap</Label>
         </Cell>
         <Cell>
           <Label>outerStrokeWidth</Label>
         </Cell>
         <Cell>
           <RadioButtonGroup
-            value={strokeLineCaps}
-            onChange={(event, value) => setStrokeLineCaps(value)}
+            value={strokeLineCap}
+            onChange={(event, value) => setStrokeLineCap(value)}
           >
             {[
               ['undefined', undefined],
@@ -124,7 +124,7 @@ const ArticleCircleDefault = ({className}) => {
                 key={`${atomProgressBarLineCapsValue}`}
                 label={`${atomProgressBarLineCapsValue}`}
                 value={atomProgressBarLineCapsValue}
-                checked={strokeLineCaps === atomProgressBarLineCapsValue}
+                checked={strokeLineCap === atomProgressBarLineCapsValue}
               />
             ))}
           </RadioButtonGroup>
@@ -192,7 +192,7 @@ const ArticleCircleDefault = ({className}) => {
             hideIndicator={hideIndicator}
             indicatorBottom={indicatorBottom}
             indicatorTotal={indicatorTotal}
-            strokeLineCaps={strokeLineCaps}
+            strokeLineCap={strokeLineCap}
             outerStrokeWidth={outerStrokeWidth}
           />
         </Cell>

--- a/components/atom/progressBar/src/ProgressBarCircle/Circle/index.js
+++ b/components/atom/progressBar/src/ProgressBarCircle/Circle/index.js
@@ -93,7 +93,7 @@ Circle.propTypes = {
   /** When progress stroke is bigger than main one, it would be double in width  */
   outerStrokeWidth: PropTypes.bool,
   /** The shape of the end of line, it can be "round" or "square" */
-  strokeLineCap: PropTypes.string.isRequired,
+  strokeLineCap: PropTypes.string,
   /** size of the circle [small, large]  */
   size: PropTypes.oneOf(Object.values(SIZES)).isRequired
 }

--- a/components/atom/progressBar/src/ProgressBarCircle/Circle/index.js
+++ b/components/atom/progressBar/src/ProgressBarCircle/Circle/index.js
@@ -11,7 +11,8 @@ const Circle = ({
   percentage,
   strokeWidth,
   size,
-  withAnimation
+  withAnimation,
+  outerStrokeWidth,
 }) => {
   const [currentPercentage, setCurrentPercentage] = useState(percentage)
   const [transitionTime, setTransitionTime] = useState(0)
@@ -30,7 +31,7 @@ const Circle = ({
   )
 
   const getPathStyles = ({percentage, strokeWidth}) => {
-    const radius = 50 - strokeWidth / 2
+    const radius = 50 - (outerStrokeWidth ? strokeWidth : strokeWidth / 2)
     const d = `M 50,50 m 0,-${radius}
      a ${radius},${radius} 0 1 1 0,${2 * radius}
      a ${radius},${radius} 0 1 1 0,-${2 * radius}`
@@ -70,7 +71,7 @@ const Circle = ({
         })}
         {...getPathStyles({percentage, strokeWidth})}
         strokeLinecap="square"
-        strokeWidth={strokeWidth}
+        strokeWidth={outerStrokeWidth ? strokeWidth * 2 : strokeWidth}
         fillOpacity="0"
       />
     </svg>
@@ -88,6 +89,8 @@ Circle.propTypes = {
   strokeWidth: PropTypes.node.isRequired,
   /** boolean to activate/desactivate animations */
   withAnimation: PropTypes.bool,
+  /** When progress stroke is bigger than main one, it would be double in width  */
+  outerStrokeWidth: PropTypes.bool,
   /** size of the circle [small, large]  */
   size: PropTypes.oneOf(Object.values(SIZES)).isRequired
 }

--- a/components/atom/progressBar/src/ProgressBarCircle/Circle/index.js
+++ b/components/atom/progressBar/src/ProgressBarCircle/Circle/index.js
@@ -13,6 +13,7 @@ const Circle = ({
   size,
   withAnimation,
   outerStrokeWidth,
+  strokeLineCaps
 }) => {
   const [currentPercentage, setCurrentPercentage] = useState(percentage)
   const [transitionTime, setTransitionTime] = useState(0)
@@ -70,7 +71,7 @@ const Circle = ({
           [`${baseClassName}-path--${modifier}`]: !!modifier
         })}
         {...getPathStyles({percentage, strokeWidth})}
-        strokeLinecap="square"
+        strokeLinecap={strokeLineCaps}
         strokeWidth={outerStrokeWidth ? strokeWidth * 2 : strokeWidth}
         fillOpacity="0"
       />
@@ -91,6 +92,8 @@ Circle.propTypes = {
   withAnimation: PropTypes.bool,
   /** When progress stroke is bigger than main one, it would be double in width  */
   outerStrokeWidth: PropTypes.bool,
+  /** The shape of the end of line, it can be "round" or "square" */
+  strokeLineCaps: PropTypes.string.isRequired,
   /** size of the circle [small, large]  */
   size: PropTypes.oneOf(Object.values(SIZES)).isRequired
 }

--- a/components/atom/progressBar/src/ProgressBarCircle/Circle/index.js
+++ b/components/atom/progressBar/src/ProgressBarCircle/Circle/index.js
@@ -13,7 +13,7 @@ const Circle = ({
   size,
   withAnimation,
   outerStrokeWidth,
-  strokeLineCaps
+  strokeLineCap
 }) => {
   const [currentPercentage, setCurrentPercentage] = useState(percentage)
   const [transitionTime, setTransitionTime] = useState(0)
@@ -71,7 +71,7 @@ const Circle = ({
           [`${baseClassName}-path--${modifier}`]: !!modifier
         })}
         {...getPathStyles({percentage, strokeWidth})}
-        strokeLinecap={strokeLineCaps}
+        strokeLinecap={strokeLineCap}
         strokeWidth={outerStrokeWidth ? strokeWidth * 2 : strokeWidth}
         fillOpacity="0"
       />
@@ -93,7 +93,7 @@ Circle.propTypes = {
   /** When progress stroke is bigger than main one, it would be double in width  */
   outerStrokeWidth: PropTypes.bool,
   /** The shape of the end of line, it can be "round" or "square" */
-  strokeLineCaps: PropTypes.string.isRequired,
+  strokeLineCap: PropTypes.string.isRequired,
   /** size of the circle [small, large]  */
   size: PropTypes.oneOf(Object.values(SIZES)).isRequired
 }

--- a/components/atom/progressBar/src/ProgressBarCircle/Circle/index.js
+++ b/components/atom/progressBar/src/ProgressBarCircle/Circle/index.js
@@ -9,10 +9,10 @@ const Circle = ({
   baseClassName,
   modifier,
   percentage,
-  strokeWidth,
   size,
   withAnimation,
-  outerStrokeWidth,
+  mainStrokeWidth,
+  progressStrokeWidth,
   strokeLineCap
 }) => {
   const [currentPercentage, setCurrentPercentage] = useState(percentage)
@@ -31,8 +31,14 @@ const Circle = ({
     [currentPercentage, percentage]
   )
 
+  const getRadius = () => {
+    return mainStrokeWidth === progressStrokeWidth
+      ? 50 - mainStrokeWidth / 2
+      : 50 - Math.max(...[progressStrokeWidth, mainStrokeWidth]) / 2
+  }
+
   const getPathStyles = ({percentage, strokeWidth}) => {
-    const radius = 50 - (outerStrokeWidth ? strokeWidth : strokeWidth / 2)
+    const radius = getRadius()
     const d = `M 50,50 m 0,-${radius}
      a ${radius},${radius} 0 1 1 0,${2 * radius}
      a ${radius},${radius} 0 1 1 0,-${2 * radius}`
@@ -62,17 +68,17 @@ const Circle = ({
         className={cx(`${baseClassName}-trail`, {
           [`${baseClassName}-trail--${modifier}`]: !!modifier
         })}
-        {...getPathStyles({percentage: 100, strokeWidth})}
-        strokeWidth={strokeWidth}
+        {...getPathStyles({percentage: 100, strokeWidth: mainStrokeWidth})}
+        strokeWidth={mainStrokeWidth}
         fillOpacity="0"
       />
       <path
         className={cx(`${baseClassName}-path`, {
           [`${baseClassName}-path--${modifier}`]: !!modifier
         })}
-        {...getPathStyles({percentage, strokeWidth})}
+        {...getPathStyles({percentage, strokeWidth: progressStrokeWidth})}
         strokeLinecap={strokeLineCap}
-        strokeWidth={outerStrokeWidth ? strokeWidth * 2 : strokeWidth}
+        strokeWidth={progressStrokeWidth}
         fillOpacity="0"
       />
     </svg>
@@ -90,8 +96,10 @@ Circle.propTypes = {
   strokeWidth: PropTypes.node.isRequired,
   /** boolean to activate/desactivate animations */
   withAnimation: PropTypes.bool,
-  /** When progress stroke is bigger than main one, it would be double in width  */
-  outerStrokeWidth: PropTypes.bool,
+  /** The size of the progress stroke, by default it is undefined, it can be "small", "medium" or "large" */
+  progressStrokeWidth: PropTypes.literal,
+  /** The size of the main stroke, by default it is undefined, it can be "small", "medium" or "large" */
+  mainStrokeWidth: PropTypes.literal,
   /** The shape of the end of line, it can be "round" or "square" */
   strokeLineCap: PropTypes.string,
   /** size of the circle [small, large]  */

--- a/components/atom/progressBar/src/ProgressBarCircle/index.js
+++ b/components/atom/progressBar/src/ProgressBarCircle/index.js
@@ -1,7 +1,7 @@
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 
-import {SIZES, STATUS} from '../settings.js'
+import {LINE_CAPS, SIZES, STATUS} from '../settings.js'
 import Circle from './Circle/index.js'
 import Indicator from './Indicator.js'
 import {BASE_CLASS_NAME, SIZE_TO_WIDTH_LINE_MAP} from './settings.js'
@@ -15,6 +15,7 @@ const ProgressBarCircle = ({
   hideIndicator,
   children,
   outerStrokeWidth,
+  strokeLineCaps
 }) => {
   const circleWidth = SIZE_TO_WIDTH_LINE_MAP[size]
 
@@ -34,6 +35,7 @@ const ProgressBarCircle = ({
         strokeWidth={circleWidth}
         size={size}
         outerStrokeWidth={outerStrokeWidth}
+        strokeLineCaps={strokeLineCaps}
       />
       {!hideIndicator && (
         <Indicator
@@ -69,6 +71,10 @@ ProgressBarCircle.propTypes = {
 
   /** Hide the indicator */
   hideIndicator: PropTypes.bool,
+
+  /** The shape of the end of line, it can be "round" or "square" */
+  strokeLineCaps: PropTypes.oneOf(Object.values(LINE_CAPS)),
+
   /** When progress stroke is bigger than main one, it would be double in width  */
   outerStrokeWidth: PropTypes.bool,
 
@@ -79,6 +85,7 @@ ProgressBarCircle.propTypes = {
 ProgressBarCircle.defaultProps = {
   isAnimatedOnChange: false,
   outerStrokeWidth: false,
+  strokeLineCaps: LINE_CAPS.SQUARE,
   status: STATUS.PROGRESS,
   hideIndicator: false,
   size: SIZES.LARGE

--- a/components/atom/progressBar/src/ProgressBarCircle/index.js
+++ b/components/atom/progressBar/src/ProgressBarCircle/index.js
@@ -15,7 +15,7 @@ const ProgressBarCircle = ({
   hideIndicator,
   children,
   outerStrokeWidth,
-  strokeLineCaps
+  strokeLineCap
 }) => {
   const circleWidth = SIZE_TO_WIDTH_LINE_MAP[size]
 
@@ -35,7 +35,7 @@ const ProgressBarCircle = ({
         strokeWidth={circleWidth}
         size={size}
         outerStrokeWidth={outerStrokeWidth}
-        strokeLineCaps={strokeLineCaps}
+        strokeLineCap={strokeLineCap}
       />
       {!hideIndicator && (
         <Indicator
@@ -73,7 +73,7 @@ ProgressBarCircle.propTypes = {
   hideIndicator: PropTypes.bool,
 
   /** The shape of the end of line, it can be "round" or "square" */
-  strokeLineCaps: PropTypes.oneOf(Object.values(LINE_CAPS)),
+  strokeLineCap: PropTypes.oneOf(Object.values(LINE_CAPS)),
 
   /** When progress stroke is bigger than main one, it would be double in width  */
   outerStrokeWidth: PropTypes.bool,
@@ -85,7 +85,7 @@ ProgressBarCircle.propTypes = {
 ProgressBarCircle.defaultProps = {
   isAnimatedOnChange: false,
   outerStrokeWidth: false,
-  strokeLineCaps: LINE_CAPS.SQUARE,
+  strokeLineCap: LINE_CAPS.SQUARE,
   status: STATUS.PROGRESS,
   hideIndicator: false,
   size: SIZES.LARGE

--- a/components/atom/progressBar/src/ProgressBarCircle/index.js
+++ b/components/atom/progressBar/src/ProgressBarCircle/index.js
@@ -4,7 +4,11 @@ import PropTypes from 'prop-types'
 import {LINE_CAPS, SIZES, STATUS} from '../settings.js'
 import Circle from './Circle/index.js'
 import Indicator from './Indicator.js'
-import {BASE_CLASS_NAME, SIZE_TO_WIDTH_LINE_MAP} from './settings.js'
+import {
+  BASE_CLASS_NAME,
+  SIZE_TO_WIDTH_LINE_MAP,
+  STROKE_SIZE_MAP
+} from './settings.js'
 
 const ProgressBarCircle = ({
   percentage,
@@ -14,10 +18,14 @@ const ProgressBarCircle = ({
   isAnimatedOnChange,
   hideIndicator,
   children,
-  outerStrokeWidth,
+  mainStrokeSize,
+  progressStrokeSize,
   strokeLineCap
 }) => {
-  const circleWidth = SIZE_TO_WIDTH_LINE_MAP[size]
+  const mainStrokeWidth =
+    STROKE_SIZE_MAP[mainStrokeSize] || SIZE_TO_WIDTH_LINE_MAP[size]
+  const progressStrokeWidth =
+    STROKE_SIZE_MAP[progressStrokeSize] || SIZE_TO_WIDTH_LINE_MAP[size]
 
   return (
     <div
@@ -29,13 +37,13 @@ const ProgressBarCircle = ({
     >
       <Circle
         baseClassName={BASE_CLASS_NAME}
+        mainStrokeWidth={mainStrokeWidth}
         modifier={status}
         percentage={status === STATUS.PROGRESS ? percentage : 0}
-        withAnimation={isAnimatedOnChange}
-        strokeWidth={circleWidth}
+        progressStrokeWidth={progressStrokeWidth}
         size={size}
-        outerStrokeWidth={outerStrokeWidth}
         strokeLineCap={strokeLineCap}
+        withAnimation={isAnimatedOnChange}
       />
       {!hideIndicator && (
         <Indicator
@@ -75,8 +83,11 @@ ProgressBarCircle.propTypes = {
   /** The shape of the end of line, it can be "round" or "square" */
   strokeLineCap: PropTypes.oneOf(Object.values(LINE_CAPS)),
 
-  /** When progress stroke is bigger than main one, it would be double in width  */
-  outerStrokeWidth: PropTypes.bool,
+  /** The size of the progress stroke, by default it is undefined, it can be "small", "medium" or "large" */
+  progressStrokeSize: PropTypes.literal,
+
+  /** The size of the main stroke, by default it is undefined, it can be "small", "medium" or "large" */
+  mainStrokeSize: PropTypes.literal,
 
   /** Component to render inside the circle instead of the current progress */
   children: PropTypes.node
@@ -84,7 +95,6 @@ ProgressBarCircle.propTypes = {
 
 ProgressBarCircle.defaultProps = {
   isAnimatedOnChange: false,
-  outerStrokeWidth: false,
   strokeLineCap: LINE_CAPS.SQUARE,
   status: STATUS.PROGRESS,
   hideIndicator: false,

--- a/components/atom/progressBar/src/ProgressBarCircle/index.js
+++ b/components/atom/progressBar/src/ProgressBarCircle/index.js
@@ -13,7 +13,8 @@ const ProgressBarCircle = ({
   size,
   isAnimatedOnChange,
   hideIndicator,
-  children
+  children,
+  outerStrokeWidth,
 }) => {
   const circleWidth = SIZE_TO_WIDTH_LINE_MAP[size]
 
@@ -32,6 +33,7 @@ const ProgressBarCircle = ({
         withAnimation={isAnimatedOnChange}
         strokeWidth={circleWidth}
         size={size}
+        outerStrokeWidth={outerStrokeWidth}
       />
       {!hideIndicator && (
         <Indicator
@@ -67,12 +69,16 @@ ProgressBarCircle.propTypes = {
 
   /** Hide the indicator */
   hideIndicator: PropTypes.bool,
+  /** When progress stroke is bigger than main one, it would be double in width  */
+  outerStrokeWidth: PropTypes.bool,
+
   /** Component to render inside the circle instead of the current progress */
   children: PropTypes.node
 }
 
 ProgressBarCircle.defaultProps = {
   isAnimatedOnChange: false,
+  outerStrokeWidth: false,
   status: STATUS.PROGRESS,
   hideIndicator: false,
   size: SIZES.LARGE

--- a/components/atom/progressBar/src/ProgressBarCircle/index.scss
+++ b/components/atom/progressBar/src/ProgressBarCircle/index.scss
@@ -27,13 +27,13 @@ $base-class-circle: '#{$base-class}Circle';
     height: $h-atom-circle-progress-bar-circle-large;
     width: $w-atom-circle-progress-bar-circle-large;
   }
-  &--xl {
+  &--extraLarge {
     align-items: center;
     display: flex;
     justify-content: center;
-    font-size: $fz-atom-circle-progress-bar-text-xl--inner;
-    height: $h-atom-circle-progress-bar-circle-xl;
-    width: $w-atom-circle-progress-bar-circle-xl;
+    font-size: $fz-atom-circle-progress-bar-text--extraLarge;
+    height: $h-atom-circle-progress-bar-circle-extraLarge;
+    width: $w-atom-circle-progress-bar-circle-extraLarge;
   }
 
   &--error {
@@ -67,12 +67,12 @@ $base-class-circle: '#{$base-class}Circle';
       height: $h-atom-circle-progress-bar-circle-large;
       width: $w-atom-circle-progress-bar-circle-large;
     }
-    &--xl {
+    &--extraLarge {
       display: flex;
       justify-content: center;
       align-items: center;
-      height: $h-atom-circle-progress-bar-circle-xl;
-      width: $w-atom-circle-progress-bar-circle-xl;
+      height: $h-atom-circle-progress-bar-circle-extraLarge;
+      width: $w-atom-circle-progress-bar-circle-extraLarge;
     }
 
     &--error {
@@ -100,9 +100,9 @@ $base-class-circle: '#{$base-class}Circle';
       height: $h-atom-circle-progress-bar-circle-large;
       width: $w-atom-circle-progress-bar-circle-large;
     }
-    &--xl {
-      height: $h-atom-circle-progress-bar-circle-xl;
-      width: $w-atom-circle-progress-bar-circle-xl;
+    &--extraLarge {
+      height: $h-atom-circle-progress-bar-circle-extraLarge;
+      width: $w-atom-circle-progress-bar-circle-extraLarge;
     }
   }
 

--- a/components/atom/progressBar/src/ProgressBarCircle/index.scss
+++ b/components/atom/progressBar/src/ProgressBarCircle/index.scss
@@ -27,6 +27,14 @@ $base-class-circle: '#{$base-class}Circle';
     height: $h-atom-circle-progress-bar-circle-large;
     width: $w-atom-circle-progress-bar-circle-large;
   }
+  &--xl {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    font-size: $fz-atom-circle-progress-bar-text-xl--inner;
+    height: $h-atom-circle-progress-bar-circle-xl;
+    width: $w-atom-circle-progress-bar-circle-xl;
+  }
 
   &--error {
     align-items: center;
@@ -59,6 +67,13 @@ $base-class-circle: '#{$base-class}Circle';
       height: $h-atom-circle-progress-bar-circle-large;
       width: $w-atom-circle-progress-bar-circle-large;
     }
+    &--xl {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: $h-atom-circle-progress-bar-circle-xl;
+      width: $w-atom-circle-progress-bar-circle-xl;
+    }
 
     &--error {
       display: flex;
@@ -84,6 +99,10 @@ $base-class-circle: '#{$base-class}Circle';
     &--large {
       height: $h-atom-circle-progress-bar-circle-large;
       width: $w-atom-circle-progress-bar-circle-large;
+    }
+    &--xl {
+      height: $h-atom-circle-progress-bar-circle-xl;
+      width: $w-atom-circle-progress-bar-circle-xl;
     }
   }
 

--- a/components/atom/progressBar/src/ProgressBarCircle/settings.js
+++ b/components/atom/progressBar/src/ProgressBarCircle/settings.js
@@ -5,7 +5,7 @@ export const BASE_CLASS_NAME = `${BASE_CLASS}Circle`
 export const INDICATOR_CLASS_NAME = `${BASE_CLASS_NAME}-indicator`
 
 export const SIZE_TO_WIDTH_LINE_MAP = {
-  [SIZES.XL]: 6,
+  [SIZES.EXTRA_LARGE]: 6,
   [SIZES.LARGE]: 4,
   [SIZES.MEDIUM]: 8,
   [SIZES.SMALL]: 8

--- a/components/atom/progressBar/src/ProgressBarCircle/settings.js
+++ b/components/atom/progressBar/src/ProgressBarCircle/settings.js
@@ -5,6 +5,7 @@ export const BASE_CLASS_NAME = `${BASE_CLASS}Circle`
 export const INDICATOR_CLASS_NAME = `${BASE_CLASS_NAME}-indicator`
 
 export const SIZE_TO_WIDTH_LINE_MAP = {
+  [SIZES.XL]: 6,
   [SIZES.LARGE]: 4,
   [SIZES.MEDIUM]: 8,
   [SIZES.SMALL]: 8

--- a/components/atom/progressBar/src/ProgressBarCircle/settings.js
+++ b/components/atom/progressBar/src/ProgressBarCircle/settings.js
@@ -10,3 +10,9 @@ export const SIZE_TO_WIDTH_LINE_MAP = {
   [SIZES.MEDIUM]: 8,
   [SIZES.SMALL]: 8
 }
+
+export const STROKE_SIZE_MAP = {
+  [SIZES.LARGE]: 18,
+  [SIZES.MEDIUM]: 12,
+  [SIZES.SMALL]: 6
+}

--- a/components/atom/progressBar/src/ProgressBarCircle/settings.scss
+++ b/components/atom/progressBar/src/ProgressBarCircle/settings.scss
@@ -1,4 +1,6 @@
+$w-atom-circle-progress-bar-circle-xl: 64px !default;
 $w-atom-circle-progress-bar-circle-large: 48px !default;
+$h-atom-circle-progress-bar-circle-xl: $w-atom-circle-progress-bar-circle-xl !default;
 $h-atom-circle-progress-bar-circle-large: $w-atom-circle-progress-bar-circle-large !default;
 $w-atom-circle-progress-bar-circle-medium: 24px !default;
 $h-atom-circle-progress-bar-circle-medium: $w-atom-circle-progress-bar-circle-medium !default;
@@ -14,6 +16,7 @@ $c-atom-circle-progress-bar-trail: $c-gray-lightest !default;
 $c-atom-circle-progress-bar-trail--error: $c-alert !default;
 $c-atom-circle-progress-bar-trail--loading: $c-gray-lightest !default;
 $c-atom-circle-progress-bar-path: $c-primary !default;
+$fz-atom-circle-progress-bar-text-xl--inner: $fz-l !default;
 $fz-atom-circle-progress-bar-text--inner: $fz-s !default;
 $fz-atom-circle-progress-bar-text--outer: $fz-xs !default;
 $ml-atom-circle-progress-bar-text--outer: $m-s !default;

--- a/components/atom/progressBar/src/ProgressBarCircle/settings.scss
+++ b/components/atom/progressBar/src/ProgressBarCircle/settings.scss
@@ -1,6 +1,6 @@
-$w-atom-circle-progress-bar-circle-xl: 64px !default;
+$w-atom-circle-progress-bar-circle-extraLarge: 64px !default;
 $w-atom-circle-progress-bar-circle-large: 48px !default;
-$h-atom-circle-progress-bar-circle-xl: $w-atom-circle-progress-bar-circle-xl !default;
+$h-atom-circle-progress-bar-circle-extraLarge: $w-atom-circle-progress-bar-circle-extraLarge !default;
 $h-atom-circle-progress-bar-circle-large: $w-atom-circle-progress-bar-circle-large !default;
 $w-atom-circle-progress-bar-circle-medium: 24px !default;
 $h-atom-circle-progress-bar-circle-medium: $w-atom-circle-progress-bar-circle-medium !default;
@@ -16,7 +16,7 @@ $c-atom-circle-progress-bar-trail: $c-gray-lightest !default;
 $c-atom-circle-progress-bar-trail--error: $c-alert !default;
 $c-atom-circle-progress-bar-trail--loading: $c-gray-lightest !default;
 $c-atom-circle-progress-bar-path: $c-primary !default;
-$fz-atom-circle-progress-bar-text-xl--inner: $fz-l !default;
+$fz-atom-circle-progress-bar-text--extraLarge: $fz-l !default;
 $fz-atom-circle-progress-bar-text--inner: $fz-s !default;
 $fz-atom-circle-progress-bar-text--outer: $fz-xs !default;
 $ml-atom-circle-progress-bar-text--outer: $m-s !default;

--- a/components/atom/progressBar/src/ProgressBarLine/settings.scss
+++ b/components/atom/progressBar/src/ProgressBarLine/settings.scss
@@ -30,5 +30,5 @@ $size-atom-line-progress-bar: (
   small: $sz-base * 0.5,
   medium: $sz-base,
   large: $sz-base * 2,
-  xl: $sz-base * 4
+  extraLarge: $sz-base * 4
 );

--- a/components/atom/progressBar/src/ProgressBarLine/settings.scss
+++ b/components/atom/progressBar/src/ProgressBarLine/settings.scss
@@ -29,5 +29,6 @@ $c-atom-line-progress-bar-status--loading: $c-gray-lightest !default;
 $size-atom-line-progress-bar: (
   small: $sz-base * 0.5,
   medium: $sz-base,
-  large: $sz-base * 2
+  large: $sz-base * 2,
+  xl: $sz-base * 4
 );

--- a/components/atom/progressBar/src/index.js
+++ b/components/atom/progressBar/src/index.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 
 import ProgressBarCircle from './ProgressBarCircle/index.js'
 import ProgressBarLine from './ProgressBarLine/index.js'
-import {SIZES, STATUS, TYPES} from './settings.js'
+import {LINE_CAPS, SIZES, STATUS, TYPES} from './settings.js'
 
 const AtomProgressBar = ({type, size, ...props}) => {
   switch (type) {
@@ -30,7 +30,8 @@ AtomProgressBar.defaultProps = {
 
 export default AtomProgressBar
 export {
-  TYPES as atomProgressBarTypes,
+  LINE_CAPS as atomProgressBarLineCaps,
   SIZES as atomProgressBarSizes,
-  STATUS as atomProgressBarStatus
+  STATUS as atomProgressBarStatus,
+  TYPES as atomProgressBarTypes
 }

--- a/components/atom/progressBar/src/index.js
+++ b/components/atom/progressBar/src/index.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 
 import ProgressBarCircle from './ProgressBarCircle/index.js'
 import ProgressBarLine from './ProgressBarLine/index.js'
-import {LINE_CAPS, SIZES, STATUS, TYPES} from './settings.js'
+import {LINE_CAPS, SIZES, STATUS, STROKE_SIZES, TYPES} from './settings.js'
 
 const AtomProgressBar = ({type, size, ...props}) => {
   switch (type) {
@@ -31,6 +31,7 @@ AtomProgressBar.defaultProps = {
 export default AtomProgressBar
 export {
   LINE_CAPS as atomProgressBarLineCaps,
+  STROKE_SIZES as atomProgressBarStrokeSizes,
   SIZES as atomProgressBarSizes,
   STATUS as atomProgressBarStatus,
   TYPES as atomProgressBarTypes

--- a/components/atom/progressBar/src/settings.js
+++ b/components/atom/progressBar/src/settings.js
@@ -7,6 +7,7 @@ export const TYPES = {
 }
 
 export const SIZES = {
+  XL: 'xl',
   SMALL: 'small',
   MEDIUM: 'medium',
   LARGE: 'large'

--- a/components/atom/progressBar/src/settings.js
+++ b/components/atom/progressBar/src/settings.js
@@ -7,7 +7,7 @@ export const TYPES = {
 }
 
 export const SIZES = {
-  XL: 'xl',
+  EXTRA_LARGE: 'extraLarge',
   SMALL: 'small',
   MEDIUM: 'medium',
   LARGE: 'large'

--- a/components/atom/progressBar/src/settings.js
+++ b/components/atom/progressBar/src/settings.js
@@ -13,6 +13,11 @@ export const SIZES = {
   LARGE: 'large'
 }
 
+export const LINE_CAPS = {
+  ROUND: 'round',
+  SQUARE: 'square'
+}
+
 export const STATUS = {
   LOADING: 'loading',
   PROGRESS: 'progress',

--- a/components/atom/progressBar/src/settings.js
+++ b/components/atom/progressBar/src/settings.js
@@ -13,6 +13,12 @@ export const SIZES = {
   LARGE: 'large'
 }
 
+export const STROKE_SIZES = {
+  SMALL: 'small',
+  MEDIUM: 'medium',
+  LARGE: 'large'
+}
+
 export const LINE_CAPS = {
   ROUND: 'round',
   SQUARE: 'square'

--- a/components/atom/progressBar/test/index.test.js
+++ b/components/atom/progressBar/test/index.test.js
@@ -26,6 +26,7 @@ describe(json.name, () => {
       'atomProgressBarTypes',
       'atomProgressBarSizes',
       'atomProgressBarStatus',
+      'atomProgressBarLineCaps',
       'default'
     ]
 
@@ -34,6 +35,7 @@ describe(json.name, () => {
       atomProgressBarTypes,
       atomProgressBarSizes,
       atomProgressBarStatus,
+      atomProgressBarLineCaps,
       default: AtomProgressBar,
       ...others
     } = library
@@ -220,6 +222,7 @@ describe(json.name, () => {
       // Given
       const library = pkg
       const expected = {
+        XL: 'xl',
         LARGE: 'large',
         MEDIUM: 'medium',
         SMALL: 'small'
@@ -227,7 +230,7 @@ describe(json.name, () => {
 
       // When
       const {atomProgressBarSizes: actual} = library
-      const {LARGE, MEDIUM, SMALL, ...others} = actual
+      const {XL, LARGE, MEDIUM, SMALL, ...others} = actual
 
       // Then
       expect(Object.keys(others).length).to.equal(0)

--- a/components/atom/progressBar/test/index.test.js
+++ b/components/atom/progressBar/test/index.test.js
@@ -213,6 +213,7 @@ describe(json.name, () => {
 
       // When
       const {atomProgressBarSizes: actual} = library
+      console.log('🚀 ~ file: index.test.js:216 ~ it ~ actual:', actual)
 
       // Then
       expect(actual).to.be.an('object')
@@ -230,7 +231,7 @@ describe(json.name, () => {
 
       // When
       const {atomProgressBarSizes: actual} = library
-      const {XL, LARGE, MEDIUM, SMALL, ...others} = actual
+      const {EXTRA_LARGE, LARGE, MEDIUM, SMALL, ...others} = actual
 
       // Then
       expect(Object.keys(others).length).to.equal(0)

--- a/components/atom/progressBar/test/index.test.js
+++ b/components/atom/progressBar/test/index.test.js
@@ -222,7 +222,7 @@ describe(json.name, () => {
       // Given
       const library = pkg
       const expected = {
-        XL: 'xl',
+        EXTRA_LARGE: 'extraLarge',
         LARGE: 'large',
         MEDIUM: 'medium',
         SMALL: 'small'

--- a/components/atom/progressBar/test/index.test.js
+++ b/components/atom/progressBar/test/index.test.js
@@ -27,6 +27,7 @@ describe(json.name, () => {
       'atomProgressBarSizes',
       'atomProgressBarStatus',
       'atomProgressBarLineCaps',
+      'atomProgressBarStrokeSizes',
       'default'
     ]
 
@@ -36,6 +37,7 @@ describe(json.name, () => {
       atomProgressBarSizes,
       atomProgressBarStatus,
       atomProgressBarLineCaps,
+      atomProgressBarStrokeSizes,
       default: AtomProgressBar,
       ...others
     } = library
@@ -213,7 +215,6 @@ describe(json.name, () => {
 
       // When
       const {atomProgressBarSizes: actual} = library
-      console.log('🚀 ~ file: index.test.js:216 ~ it ~ actual:', actual)
 
       // Then
       expect(actual).to.be.an('object')


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
`❓ Ask`

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: [MTR-71274](https://jira.ets.mpi-internal.com/browse/MTR-71274)

### Description, Motivation and Context
- Add props to Progress Bar component.
- New XL size.
- OuterStroke to have a progress line bigger than the main one.
- Add the possibility to change the line caps to Round type.
- Update tests and classes

### Types of changes

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [X] 🧪 Test
- [ ] 🧠 Refactor
- [X] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
![image](https://github.com/SUI-Components/sui-components/assets/73495169/ceb31c0a-f7c2-4ea2-8338-50e40ffbf510)
