### PR TITLE
feat(components/atom/card): Add xl & xxl border radious atom card config

### DIFF
--- a/components/atom/card/src/config.js
+++ b/components/atom/card/src/config.js
@@ -10,7 +10,9 @@ export const CLASS_LINK = `${BASE_CLASS}-link`
 export const BORDER_RADIUS = {
   S: 's',
   M: 'm',
-  L: 'l'
+  L: 'l',
+  XL: 'xl',
+  XXL: 'xxl'
 }
 
 export const ELEVATION = {

--- a/components/atom/card/src/styles/settings.scss
+++ b/components/atom/card/src/styles/settings.scss
@@ -15,7 +15,9 @@ $p-atom-card-info: $p-l !default;
 $bdrs-atom-card-rounded: (
   's': $bdrs-s,
   'm': $bdrs-m,
-  'l': $bdrs-l
+  'l': $bdrs-l,
+  'xl': $bdrs-xl,
+  'xxl': $bdrs-xxl
 ) !default;
 $bxsh-atom-card-elevation: (
   's': $bxsh-s,

--- a/components/atom/card/test/index.test.js
+++ b/components/atom/card/test/index.test.js
@@ -181,12 +181,14 @@ describe(json.name, () => {
       const expected = {
         S: 's',
         M: 'm',
-        L: 'l'
+        L: 'l',
+        XL: 'xl',
+        XXL: 'xxl'
       }
 
       // When
       const {atomCardRounded: actual} = library
-      const {S, M, L, ...others} = actual
+      const {S, M, L, XL, XXL, ...others} = actual
 
       // Then
       expect(Object.keys(others).length).to.equal(0)


### PR DESCRIPTION
## atom/card
#### `🔍 Show` 

### Description, Motivation and Context

Add XL and XXL border radius variant to atom card

### Types of changes

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

