### PR TITLE
Feature/create default tooltip component sui coachmark

### DIFF
--- a/components/molecule/coachmark/README.md
+++ b/components/molecule/coachmark/README.md
@@ -30,4 +30,8 @@ return <MoleculeCoachmark {...props} />
 @import '~@s-ui/react-molecule-coachmark/lib/index';
 ```
 
+### Overwriting styles
+
+Overwriting styles is possible thanks to the `styles` prop. [Here you can find a list](https://github.com/gilbarbara/react-joyride/blob/3e08384415a831b20ce21c8423b6c271ad419fbf/src/styles.js) of possible properties to be overwritten
+
 > **Find full description and more examples in the [demo page](#).**

--- a/components/molecule/coachmark/package.json
+++ b/components/molecule/coachmark/package.json
@@ -19,6 +19,10 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@s-ui/react-atom-badge": "1",
+    "@s-ui/react-atom-button": "1",
+    "@s-ui/react-atom-icon": "1",
+    "@s-ui/react-atom-image": "2",
     "react-joyride": "2"
   }
 }

--- a/components/molecule/coachmark/src/Tooltip/index.js
+++ b/components/molecule/coachmark/src/Tooltip/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import AtomButton, {
   atomButtonColors,
   atomButtonDesigns,
+  atomButtonShapes,
   atomButtonSizes
 } from '@s-ui/react-atom-button'
 import AtomImage from '@s-ui/react-atom-image'
@@ -125,7 +126,21 @@ const Tooltip = ({
 
 Tooltip.propTypes = {
   defaultTooltipOptions: PropTypes.shape({
-    badge: PropTypes.node
+    badge: PropTypes.node,
+    image: PropTypes.shape({url: PropTypes.string, alt: PropTypes.string}),
+    closeIcon: PropTypes.node,
+    actionButtons: PropTypes.arrayOf([
+      PropTypes.shape({
+        id: PropTypes.oneOf([
+          DEFAULT_TOOLTIP_ACTION_BUTTONS_IDS.BACK,
+          DEFAULT_TOOLTIP_ACTION_BUTTONS_IDS.NEXT
+        ]),
+        color: PropTypes.oneOf([Object.values(atomButtonColors)]),
+        design: PropTypes.oneOf([Object.values(atomButtonDesigns)]),
+        size: PropTypes.oneOf([Object.values(atomButtonSizes)]),
+        shape: PropTypes.oneOf([Object.values(atomButtonShapes)])
+      })
+    ])
   }),
   hideBackButton: PropTypes.bool,
   index: PropTypes.number,

--- a/components/molecule/coachmark/src/Tooltip/index.js
+++ b/components/molecule/coachmark/src/Tooltip/index.js
@@ -1,0 +1,143 @@
+import PropTypes from 'prop-types'
+
+import AtomButton, {
+  atomButtonColors,
+  atomButtonDesigns,
+  atomButtonSizes
+} from '@s-ui/react-atom-button'
+import AtomImage from '@s-ui/react-atom-image'
+
+import {
+  BASE_CLASS,
+  DEFAULT_TOOLTIP_ACTION_BUTTONS_IDS,
+  MINIMUM_COACHMARK_STEPS
+} from '../settings.js'
+
+const Tooltip = ({
+  defaultTooltipOptions = {},
+  index,
+  isLastStep,
+  primaryProps,
+  size: totalSteps,
+  skipProps,
+  step,
+  tooltipProps,
+  backProps,
+  hideBackButton,
+  showProgress
+}) => {
+  return (
+    <div className={`${BASE_CLASS}-tooltip`} {...tooltipProps}>
+      <header className={`${BASE_CLASS}-tooltipHeader`}>
+        {defaultTooltipOptions.badge ? (
+          <div className={`${BASE_CLASS}-tooltipBadge`}>
+            {defaultTooltipOptions.badge}
+          </div>
+        ) : null}
+
+        {defaultTooltipOptions.closeIcon ? (
+          <div className={`${BASE_CLASS}-tooltipCloseButton`}>
+            <AtomButton
+              color={atomButtonColors.NEUTRAL}
+              design={atomButtonDesigns.LINK}
+              size={atomButtonSizes.SMALL}
+              leftIcon={defaultTooltipOptions.closeIcon}
+              {...skipProps}
+            />
+          </div>
+        ) : null}
+      </header>
+
+      <div className={`${BASE_CLASS}-tooltipContent`}>
+        {defaultTooltipOptions.image ? (
+          <div className={`${BASE_CLASS}-tooltipImageContainer`}>
+            <div className={`${BASE_CLASS}-tooltipImage`}>
+              <AtomImage
+                src={defaultTooltipOptions.image.url}
+                alt={defaultTooltipOptions.image.alt}
+              />
+            </div>
+          </div>
+        ) : null}
+
+        <div className={`${BASE_CLASS}-tooltipTexts`}>
+          {step.heading && (
+            <h1 className={`${BASE_CLASS}-tooltipHeadingText`}>
+              {step.heading}
+            </h1>
+          )}
+          <p className={`${BASE_CLASS}-tooltipBodyText`}>{step.content}</p>
+        </div>
+      </div>
+
+      <div className={`${BASE_CLASS}-tooltipFooter`}>
+        {showProgress && totalSteps > MINIMUM_COACHMARK_STEPS && (
+          <p className={`${BASE_CLASS}-tooltipStepCounter`}>{`${
+            index + 1
+          }/${totalSteps}`}</p>
+        )}
+
+        <div className={`${BASE_CLASS}-tooltipButtons`}>
+          {defaultTooltipOptions?.actionButtons
+            ? defaultTooltipOptions.actionButtons.map(
+                ({id, color, size, design, shape}) => {
+                  const isBackButton =
+                    DEFAULT_TOOLTIP_ACTION_BUTTONS_IDS.BACK === id
+                  const isNextButton =
+                    DEFAULT_TOOLTIP_ACTION_BUTTONS_IDS.NEXT === id
+
+                  const isBackButtonHidden =
+                    (isBackButton && index === 0) ||
+                    (isBackButton && hideBackButton)
+
+                  const getButtonText = () => {
+                    if (isNextButton) {
+                      return isLastStep ? step.locale.last : step.locale.next
+                    }
+
+                    return step.locale.back
+                  }
+
+                  const buttonProps =
+                    isBackButton && !isBackButtonHidden
+                      ? backProps
+                      : primaryProps
+
+                  return isBackButtonHidden ? null : (
+                    <AtomButton
+                      color={color}
+                      design={design}
+                      size={size}
+                      shape={shape}
+                      {...buttonProps}
+                    >
+                      {getButtonText()}
+                    </AtomButton>
+                  )
+                }
+              )
+            : null}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+Tooltip.propTypes = {
+  defaultTooltipOptions: PropTypes.shape({
+    badge: PropTypes.node
+  }),
+  hideBackButton: PropTypes.bool,
+  index: PropTypes.number,
+  isLastStep: PropTypes.bool,
+  primaryProps: PropTypes.object,
+  backProps: PropTypes.object,
+  showBadge: PropTypes.bool,
+  showProgress: PropTypes.bool,
+  size: PropTypes.number,
+  skipProps: PropTypes.object,
+  step: PropTypes.object,
+  tooltipProps: PropTypes.object
+}
+
+export default Tooltip

--- a/components/molecule/coachmark/src/index.js
+++ b/components/molecule/coachmark/src/index.js
@@ -9,6 +9,7 @@ import {
   atomButtonSizes
 } from '@s-ui/react-atom-button'
 
+import Tooltip from './Tooltip/index.js'
 import {
   DEFAULT_SCROLL_DURATION,
   DEFAULT_SCROLL_OFFSET,
@@ -20,11 +21,11 @@ import {
 } from './settings.js'
 
 const MoleculeCoachmark = ({
-  steps,
   beaconComponent,
   callback,
   continuous = true,
   debug = false,
+  defaultTooltipOptions,
   disableCloseOnEsc = false,
   disableOverlay = false,
   disableOverlayClose = false,
@@ -34,20 +35,21 @@ const MoleculeCoachmark = ({
   getHelpers = null,
   hideBackButton = false,
   hideCloseButton = false,
+  locale,
   run = true,
-  scrollOffset = DEFAULT_SCROLL_OFFSET,
   scrollDuration = DEFAULT_SCROLL_DURATION,
+  scrollOffset = DEFAULT_SCROLL_OFFSET,
   scrollToFirstStep = false,
-  showProgress = false,
   shopSkipButton = false,
+  showProgress = false,
   spotlightClicks = false,
   spotlightPadding = DEFAULT_SPOTLIGHT_PADDING,
   stepIndex,
+  steps,
   styles
 }) => {
   return (
     <Joyride
-      steps={steps}
       beaconComponent={beaconComponent}
       callback={callback}
       continuous={continuous}
@@ -59,23 +61,34 @@ const MoleculeCoachmark = ({
       disableScrollParentFix={disableScrollParentFix}
       floaterProps={floaterProps}
       {...(getHelpers && {getHelpers})}
-      styles={{
-        options: {
-          zIndex: 9999,
-          ...styles
-        }
-      }}
       hideBackButton={hideBackButton}
       hideCloseButton={hideCloseButton}
+      locale={locale}
       run={run}
-      scrollOffset={scrollOffset}
       scrollDuration={scrollDuration}
+      scrollOffset={scrollOffset}
       scrollToFirstStep={scrollToFirstStep}
-      showProgress={showProgress}
       shopSkipButton={shopSkipButton}
+      showProgress={showProgress}
       spotlightClicks={spotlightClicks}
       spotlightPadding={spotlightPadding}
       stepIndex={stepIndex}
+      steps={steps}
+      styles={{
+        options: {
+          zIndex: DEFAULT_Z_INDEX,
+          ...styles.options
+        },
+        ...styles.components
+      }}
+      tooltipComponent={props => (
+        <Tooltip
+          {...props}
+          defaultTooltipOptions={defaultTooltipOptions}
+          showProgress={showProgress}
+          hideBackButton={hideBackButton}
+        />
+      )}
     />
   )
 }

--- a/components/molecule/coachmark/src/index.js
+++ b/components/molecule/coachmark/src/index.js
@@ -3,9 +3,18 @@ import Joyride, {ACTIONS, EVENTS, LIFECYCLE, STATUS} from 'react-joyride'
 import PropTypes from 'prop-types'
 
 import {
+  atomButtonColors,
+  atomButtonDesigns,
+  atomButtonShapes,
+  atomButtonSizes
+} from '@s-ui/react-atom-button'
+
+import {
   DEFAULT_SCROLL_DURATION,
   DEFAULT_SCROLL_OFFSET,
   DEFAULT_SPOTLIGHT_PADDING,
+  DEFAULT_TOOLTIP_ACTION_BUTTONS_IDS,
+  DEFAULT_Z_INDEX,
   STEP_BEACON_PLACEMENT_TYPES,
   STEP_PLACEMENT_TYPES
 } from './settings.js'
@@ -77,6 +86,26 @@ MoleculeCoachmark.propTypes = {
   callback: PropTypes.fn,
   continuous: PropTypes.bool,
   debug: PropTypes.bool,
+
+  /* When a tooltip component is not passed as a props, 
+    the default tooltip should be set up to see the coachmark */
+  defaultTooltipOptions: PropTypes.shape({
+    badge: PropTypes.node,
+    image: PropTypes.shape({url: PropTypes.string, alt: PropTypes.string}),
+    closeIcon: PropTypes.node,
+    actionButtons: PropTypes.arrayOf([
+      PropTypes.shape({
+        id: PropTypes.oneOf([
+          DEFAULT_TOOLTIP_ACTION_BUTTONS_IDS.BACK,
+          DEFAULT_TOOLTIP_ACTION_BUTTONS_IDS.NEXT
+        ]),
+        color: PropTypes.oneOf([Object.values(atomButtonColors)]),
+        design: PropTypes.oneOf([Object.values(atomButtonDesigns)]),
+        size: PropTypes.oneOf([Object.values(atomButtonSizes)]),
+        shape: PropTypes.oneOf([atomButtonShapes])
+      })
+    ])
+  }),
   disableCloseOnEsc: PropTypes.bool,
   disableOverlay: PropTypes.bool,
   disableOverlayClose: PropTypes.bool,
@@ -86,6 +115,14 @@ MoleculeCoachmark.propTypes = {
   getHelpers: PropTypes.func,
   hideBackButton: PropTypes.bool,
   hideCloseButton: PropTypes.bool,
+  locale: PropTypes.shape({
+    back: PropTypes.string,
+    close: PropTypes.string,
+    last: PropTypes.string,
+    next: PropTypes.string,
+    open: PropTypes.string,
+    skip: PropTypes.string
+  }),
   run: PropTypes.bool,
   scrollOffset: PropTypes.number,
   scrollDuration: PropTypes.number,
@@ -94,12 +131,16 @@ MoleculeCoachmark.propTypes = {
   shopSkipButton: PropTypes.bool,
   spotlightClicks: PropTypes.bool,
   spotlightPadding: PropTypes.number,
+
+  /* When using stepIndex, the controlled mode is activated,
+   should be controlled with the callback prop */
   stepIndex: PropTypes.number,
   steps: PropTypes.arrayOf(
     PropTypes.shape({
-      target: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+      target: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
+        .isRequired,
       heading: PropTypes.node,
-      content: PropTypes.node,
+      content: PropTypes.node.isRequired,
       disableBeacon: PropTypes.bool,
       event: PropTypes.func,
       isFixed: PropTypes.bool,
@@ -119,5 +160,6 @@ export {ACTIONS as moleculeCoachmarkActions}
 export {EVENTS as moleculeCoachmarkEvents}
 export {STATUS as moleculeCoachmarkStatus}
 export {LIFECYCLE as moleculeCoachmarkLifeCycle}
+export {DEFAULT_TOOLTIP_ACTION_BUTTONS_IDS as moleculeCoachmarkActionButtonIds}
 
 export default MoleculeCoachmark

--- a/components/molecule/coachmark/src/index.js
+++ b/components/molecule/coachmark/src/index.js
@@ -8,8 +8,9 @@ import {
   atomButtonShapes,
   atomButtonSizes
 } from '@s-ui/react-atom-button'
+import Injector from '@s-ui/react-primitive-injector'
 
-import Tooltip from './Tooltip/index.js'
+import DefaultTooltip from './Tooltip/index.js'
 import {
   DEFAULT_SCROLL_DURATION,
   DEFAULT_SCROLL_OFFSET,
@@ -46,7 +47,8 @@ const MoleculeCoachmark = ({
   spotlightPadding = DEFAULT_SPOTLIGHT_PADDING,
   stepIndex,
   steps,
-  styles
+  styles,
+  tooltipComponent: CustomTooltipComponent
 }) => {
   return (
     <Joyride
@@ -81,13 +83,20 @@ const MoleculeCoachmark = ({
         },
         ...styles.components
       }}
+      // eslint-disable-next-line react/no-unstable-nested-components
       tooltipComponent={props => (
-        <Tooltip
+        <Injector
           {...props}
           defaultTooltipOptions={defaultTooltipOptions}
           showProgress={showProgress}
           hideBackButton={hideBackButton}
-        />
+        >
+          {CustomTooltipComponent ? (
+            <CustomTooltipComponent />
+          ) : (
+            <DefaultTooltip />
+          )}
+        </Injector>
       )}
     />
   )
@@ -166,7 +175,8 @@ MoleculeCoachmark.propTypes = {
       title: PropTypes.node
     })
   ),
-  styles: PropTypes.object
+  styles: PropTypes.object,
+  tooltipComponent: PropTypes.node
 }
 
 export {ACTIONS as moleculeCoachmarkActions}

--- a/components/molecule/coachmark/src/index.js
+++ b/components/molecule/coachmark/src/index.js
@@ -29,7 +29,7 @@ const MoleculeCoachmark = ({
   defaultTooltipOptions,
   disableCloseOnEsc = false,
   disableOverlay = false,
-  disableOverlayClose = false,
+  disableOverlayClose = true,
   disableScrolling = false,
   disableScrollParentFix = false,
   floaterProps,
@@ -79,9 +79,9 @@ const MoleculeCoachmark = ({
       styles={{
         options: {
           zIndex: DEFAULT_Z_INDEX,
-          ...styles.options
+          ...styles?.options
         },
-        ...styles.components
+        ...styles?.components
       }}
       // eslint-disable-next-line react/no-unstable-nested-components
       tooltipComponent={props => (

--- a/components/molecule/coachmark/src/index.js
+++ b/components/molecule/coachmark/src/index.js
@@ -124,7 +124,7 @@ MoleculeCoachmark.propTypes = {
         color: PropTypes.oneOf([Object.values(atomButtonColors)]),
         design: PropTypes.oneOf([Object.values(atomButtonDesigns)]),
         size: PropTypes.oneOf([Object.values(atomButtonSizes)]),
-        shape: PropTypes.oneOf([atomButtonShapes])
+        shape: PropTypes.oneOf([Object.values(atomButtonShapes)])
       })
     ])
   }),

--- a/components/molecule/coachmark/src/index.scss
+++ b/components/molecule/coachmark/src/index.scss
@@ -1,5 +1,8 @@
 @import '~@s-ui/theme/lib/index';
+@import '~@s-ui/react-atom-icon/lib/index.scss';
+@import '~@s-ui/react-atom-button/lib/index.scss';
+@import '~@s-ui/react-atom-badge/lib/index.scss';
+@import '~@s-ui/react-atom-image/lib/index.scss';
 
-.react-MoleculeCoachmark {
-  // Do your magic
-}
+@import './styles/settings.scss';
+@import './styles/index.scss';

--- a/components/molecule/coachmark/src/settings.js
+++ b/components/molecule/coachmark/src/settings.js
@@ -1,3 +1,4 @@
+export const BASE_CLASS = 'sui-MoleculeCoachmark'
 export const STEP_PLACEMENT_TYPES = {
   'bottom-end': 'bottom-end',
   'bottom-start': 'bottom-start',
@@ -25,3 +26,9 @@ export const STEP_BEACON_PLACEMENT_TYPES = {
 export const DEFAULT_SCROLL_OFFSET = 20
 export const DEFAULT_SCROLL_DURATION = 300
 export const DEFAULT_SPOTLIGHT_PADDING = 10
+export const DEFAULT_Z_INDEX = 9999
+export const MINIMUM_COACHMARK_STEPS = 1
+export const DEFAULT_TOOLTIP_ACTION_BUTTONS_IDS = {
+  BACK: 'back',
+  NEXT: 'next'
+}

--- a/components/molecule/coachmark/src/styles/index.scss
+++ b/components/molecule/coachmark/src/styles/index.scss
@@ -1,0 +1,66 @@
+$base-class: '.sui-MoleculeCoachmark';
+
+#{$base-class} {
+  &-tooltip {
+    background-color: $bgc-molecule-coachmark-tooltip;
+    border-radius: $brds-molecule-coachmark-tooltip;
+    padding: $p-molecule-coachmark-tooltip;
+    max-width: $maw-molecule-coachmark-tooltip;
+    min-width: $mih-molecule-coachmark-tooltip;
+
+    &Buttons {
+      margin-left: auto;
+    }
+
+    &Content {
+      display: flex;
+      gap: $g-molecule-coachmark-tooltip-content;
+    }
+
+    &Image {
+      align-self: center;
+      height: 100%;
+      width: 100%;
+
+      &Container {
+        align-self: center;
+        display: flex;
+        flex: $fx-molecule-coachmark-tooltip-image-container;
+      }
+    }
+
+    &Header {
+      align-items: center;
+      display: flex;
+      margin: $m-molecule-coachmark-tooltip-header;
+    }
+
+    &HeadingText {
+      color: $c-primary;
+      font-size: $fz-molecule-coachmark-tooltip-heading-text;
+      font-weight: $fw-molecule-coachmark-tooltip-heading-text;
+      margin: $m-molecule-coachmark-tooltip-heading-text;
+    }
+
+    &BodyText {
+      color: $c-primary;
+      font-size: $fz-molecule-coachmark-tooltip-body-text;
+      margin: $m-molecule-coachmark-tooltip-body-text;
+    }
+
+    &CloseButton {
+      margin-left: auto;
+    }
+
+    &Footer {
+      align-items: center;
+      display: flex;
+      justify-content: space-between;
+    }
+
+    &StepCounter {
+      font-size: $fz-molecule-coachmark-tooltip-step-counter;
+      font-weight: $fw-molecule-coachmark-tooltip-step-counter;
+    }
+  }
+}

--- a/components/molecule/coachmark/src/styles/settings.scss
+++ b/components/molecule/coachmark/src/styles/settings.scss
@@ -1,0 +1,17 @@
+$bgc-molecule-coachmark-tooltip: $c-white !default;
+$brds-molecule-coachmark-tooltip: 8px !default;
+$p-molecule-coachmark-tooltip: $p-l !default;
+$mih-molecule-coachmark-tooltip: 320px !default;
+$maw-molecule-coachmark-tooltip: 350px !default;
+$g-molecule-coachmark-tooltip-content: $g-l !default;
+$fx-molecule-coachmark-tooltip-image-container: 0 0 64px;
+$fz-molecule-coachmark-tooltip-heading-text: $fz-m !default;
+$fw-molecule-coachmark-tooltip-heading-text: $fw-semi-bold !default;
+$c-molecule-coachmark-tooltip-heading-text: $c-primary !default;
+$c-molecule-coachmark-tooltip-body-text: $c-primary !default;
+$fz-molecule-coachmark-tooltip-body-text: $fz-m !default;
+$fw-molecule-coachmark-tooltip-step-counter: $fw-semi-bold !default;
+$fz-molecule-coachmark-tooltip-step-counter: $fz-m !default;
+$m-molecule-coachmark-tooltip-body-text: 0 0 $m-l 0 !default;
+$m-molecule-coachmark-tooltip-heading-text: 0 0 $m-m 0 !default;
+$m-molecule-coachmark-tooltip-header: 0 0 $m-s 0 !default;

--- a/components/molecule/coachmark/test/index.test.js
+++ b/components/molecule/coachmark/test/index.test.js
@@ -9,6 +9,7 @@ import ReactDOM from 'react-dom'
 
 import chai, {expect} from 'chai'
 import chaiDOM from 'chai-dom'
+
 import Component from '../src/index.js'
 
 chai.use(chaiDOM)


### PR DESCRIPTION
## Molecule/Coachmark
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: https://jira.ets.mpi-internal.com/browse/MTR-69959

### Description, Motivation and Context
<!--- Describe your changes in detail -->
Create default tooltip component to be shown when no custom tooltip is passed as prop
with optional badge, close icon, buttons, image and progress counter.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
This is still WIP in version 0. We should still create the test suite and the proper demo page.

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
![image](https://github.com/SUI-Components/sui-components/assets/17437586/26c1e9ea-cf54-467d-89dc-2b3759cf97ed)

