### PR TITLE
feat(components/molecule/inputTags): add tagSize prop to MoleculeInpu…

### DIFF
--- a/components/molecule/inputTags/demo/articles/ArticleSize.js
+++ b/components/molecule/inputTags/demo/articles/ArticleSize.js
@@ -21,9 +21,9 @@ import {closeIcon} from '../settings.js'
 const ArticleSize = ({className}) => {
   return (
     <Article className={className}>
-      <H2>Sizes</H2>
+      <H2>Input's Sizes</H2>
       <Paragraph>
-        Use the prop <Code>size</Code> (enum) to define the InputTag size. The
+        Use the prop <Code>size</Code> (enum) to define the input's size. The
         values are under the <Code>moleculeInputTagsInputSizes</Code> exported
         enum
       </Paragraph>

--- a/components/molecule/inputTags/demo/articles/ArticleTagsSize.js
+++ b/components/molecule/inputTags/demo/articles/ArticleTagsSize.js
@@ -1,0 +1,60 @@
+import {Fragment} from 'react'
+
+import PropTypes from 'prop-types'
+
+import {
+  Article,
+  Cell,
+  Code,
+  Grid,
+  H2,
+  Label,
+  Paragraph
+} from '@s-ui/documentation-library'
+
+import MoleculeInputTags, {moleculeInputTagsSizes} from '../../src/index.js'
+import Data from '../Data.js'
+import {closeIcon} from '../settings.js'
+
+const ArticleTagsSize = ({className}) => {
+  return (
+    <Article className={className}>
+      <H2>Tag's Sizes</H2>
+      <Paragraph>
+        Use the prop <Code>tagSize</Code> (enum) to define the tags' size. The
+        values are under the <Code>moleculeInputTagsSizes</Code> exported enum
+      </Paragraph>
+      <Grid cols={6} gutter={[8, 8]}>
+        {Object.values(moleculeInputTagsSizes).map(moleculeInputTagsSize => (
+          <Fragment key={moleculeInputTagsSize}>
+            <Cell>
+              <Label>{moleculeInputTagsSize}</Label>
+            </Cell>
+            <Cell span={5}>
+              <MoleculeInputTags
+                defaultTags={Data.beattles}
+                defaultValue="George Martin"
+                name={`ArticleTagsSize-${moleculeInputTagsSize}`}
+                tagSize={moleculeInputTagsSize}
+                tagsCloseIcon={closeIcon}
+                onChange={(event, {name, tags, value, ...other}) => {
+                  console.log('onChange', {value, name, tags, ...other}) // eslint-disable-line no-console
+                }}
+                onChangeTags={(event, {tags, name, value, ...other}) => {
+                  console.log('onChange', {value, name, tags, ...other}) // eslint-disable-line no-console
+                }}
+              />
+            </Cell>
+          </Fragment>
+        ))}
+      </Grid>
+    </Article>
+  )
+}
+
+ArticleTagsSize.displayName = 'ArticleTagsSize'
+ArticleTagsSize.propTypes = {
+  className: PropTypes.string
+}
+
+export default ArticleTagsSize

--- a/components/molecule/inputTags/demo/index.js
+++ b/components/molecule/inputTags/demo/index.js
@@ -6,6 +6,7 @@ import ArticleHandlers from './articles/ArticleHandlers.js'
 import ArticleMaxTagsAndAllowDuplicates from './articles/ArticleMaxTagsAndAllowDuplicates.js'
 import ArticleSemantic from './articles/ArticleSemantic.js'
 import ArticleSize from './articles/ArticleSize.js'
+import ArticleTagsSize from './articles/ArticleTagsSize.js'
 import {CLASS_DEMO_SECTION} from './settings.js'
 
 import './index.scss'
@@ -23,6 +24,8 @@ const Demo = () => {
       <ArticleDisableReadOnly className={CLASS_DEMO_SECTION} />
       <br />
       <ArticleSize className={CLASS_DEMO_SECTION} />
+      <br />
+      <ArticleTagsSize className={CLASS_DEMO_SECTION} />
       <br />
       <ArticleHandlers className={CLASS_DEMO_SECTION} />
       <br />

--- a/components/molecule/inputTags/src/index.js
+++ b/components/molecule/inputTags/src/index.js
@@ -27,6 +27,7 @@ const MoleculeInputTags = forwardRef(
       onChangeTags,
       optionsData,
       size = inputSizes.MEDIUM,
+      tagSize = atomTagSizes.SMALL,
       defaultTags = [],
       tags: tagsFromProps,
       tagsCloseIcon,
@@ -137,7 +138,7 @@ const MoleculeInputTags = forwardRef(
                 label
               })}
               label={label}
-              size={atomTagSizes.SMALL}
+              size={tagSize}
               responsive={responsive}
               readOnly={readOnly}
               disabled={disabled}
@@ -172,7 +173,10 @@ MoleculeInputTags.propTypes = {
   errorState: PropTypes.bool,
 
   /** Tag size */
-  size: PropTypes.oneOf(Object.values(atomTagSizes)),
+  tagSize: PropTypes.oneOf(Object.values(atomTagSizes)),
+
+  /** Input size */
+  size: PropTypes.oneOf(Object.values(inputSizes)),
 
   /* close icon to be displayed on tags */
   tagsCloseIcon: PropTypes.node.isRequired,
@@ -224,4 +228,8 @@ MoleculeInputTags.propTypes = {
 }
 
 export default MoleculeInputTags
-export {inputSizes, inputSizes as moleculeInputTagsInputSizes}
+export {
+  inputSizes,
+  inputSizes as moleculeInputTagsInputSizes,
+  atomTagSizes as moleculeInputTagsSizes
+}

--- a/components/molecule/inputTags/test/index.test.js
+++ b/components/molecule/inputTags/test/index.test.js
@@ -24,6 +24,7 @@ describe(json.name, () => {
     const libraryExportedMembers = [
       'inputSizes',
       'moleculeInputTagsInputSizes',
+      'moleculeInputTagsSizes',
       'default'
     ]
 
@@ -31,6 +32,7 @@ describe(json.name, () => {
     const {
       inputSizes,
       moleculeInputTagsInputSizes,
+      moleculeInputTagsSizes,
       default: MoleculeInputTags,
       ...others
     } = library


### PR DESCRIPTION
…tTags

## molecule/inputTags
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
#### `🔍 Show`
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**:  PI-63497

### Description, Motivation and Context
Add tagSize prop to MoleculeInputTags to have the possibility to change the tags' size.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
**Before:** 
<img width="1104" alt="Captura de pantalla 2023-07-11 a las 12 40 00" src="https://github.com/SUI-Components/sui-components/assets/71508330/324d0aef-8585-4717-a4bc-3415edcbafe4">

**After:**
<img width="1061" alt="Captura de pantalla 2023-07-11 a las 12 39 08" src="https://github.com/SUI-Components/sui-components/assets/71508330/0fae3ac3-cb24-43d9-9691-45afac1394d8">

