### PR TITLE
feat(components/atom/videoPlayer): Expose useDetectVideoType hook and UNKNOWN constant

### DIFF
--- a/components/atom/videoPlayer/src/index.js
+++ b/components/atom/videoPlayer/src/index.js
@@ -2,6 +2,7 @@ import {forwardRef, Suspense, useRef} from 'react'
 
 import PropTypes from 'prop-types'
 
+import useDetectVideoType from './hooks/useDetectVideoType.js'
 import useScrollAutoplayEffect from './hooks/useScrollAutoplayEffect.js'
 import useVideoPlayer from './hooks/useVideoPlayer.js'
 import {
@@ -9,7 +10,8 @@ import {
   AUTOPLAY_DEFAULT_VALUE,
   AUTOPLAY_OPTIONS,
   BASE_CLASS,
-  INTERSECTION_OBSERVER_DEFAULT_CONFIGURATION
+  INTERSECTION_OBSERVER_DEFAULT_CONFIGURATION,
+  UNKNOWN
 } from './settings/index.js'
 
 const AtomVideoPlayer = forwardRef(
@@ -78,4 +80,4 @@ AtomVideoPlayer.propTypes = {
 }
 
 export default AtomVideoPlayer
-export {AUTOPLAY}
+export {AUTOPLAY, UNKNOWN, useDetectVideoType}


### PR DESCRIPTION
## atom/videoPlayer

#### `🔍 Show`

### Description, Motivation and Context

As the `atom/videoPlayer` component contains logic to identify a specific video type, and in order to avoid duplicating that logic to other places, we are modifying the component to expose the hook that currently wraps that functionality.

### Types of changes

- [X] ✨ New feature (non-breaking change which adds functionality)