### PR TITLE
fix(components/molecule/select): Use onChange callback instead of onK…

### DIFF
--- a/components/molecule/select/src/components/Search.js
+++ b/components/molecule/select/src/components/Search.js
@@ -1,36 +1,21 @@
-import {useState} from 'react'
-
 import AtomInput, {inputTypes} from '@s-ui/react-atom-input'
 
 import {useDropdown} from '../config.js'
 import {getClassSearch} from './config.js'
 
 export default function Search(props) {
-  const [value, setValue] = useState('')
-
-  const {
-    setInputRef,
-    isOpen,
-    focusFirstOption,
-    onSearch,
-    searchPlaceholder,
-    searchIcon
-  } = useDropdown()
-
-  const handleKeyDown = ev => {
-    setTimeout(() => focusFirstOption(ev))
-  }
+  const {setInputRef, isOpen, onSearch, searchPlaceholder, searchIcon} =
+    useDropdown()
 
   const onChange = (_ev, {value}) => {
-    setValue(value)
     typeof onSearch === 'function' && setTimeout(() => onSearch({value}))
   }
 
   return (
-    <div className={getClassSearch(isOpen)} onKeyDown={handleKeyDown}>
+    <div className={getClassSearch(isOpen)}>
       <AtomInput
         type={inputTypes.TEXT}
-        value={value}
+        value={setInputRef?.current?.value}
         reference={setInputRef}
         onChange={onChange}
         placeholder={searchPlaceholder}

--- a/components/molecule/select/src/index.js
+++ b/components/molecule/select/src/index.js
@@ -196,7 +196,6 @@ const MoleculeSelect = forwardRef((props, forwardedRef) => {
     hasSearch,
     setInputRef,
     isOpen: isOpenState,
-    focusFirstOption,
     inputSearch,
     onSearch,
     isFirstOptionFocused,


### PR DESCRIPTION
…eyDown for input changes

## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
`🚢 Ship`
<!-- #### `🔍 Show` -->
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

Since input search was setting an onKeyDown handler it caused a bug when trying to introduce the character á and ended up adding ´a instead.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

