### PR TITLE
feat(components/atom/videoPlayer): Modify video player to allow playi…

### DIFF
--- a/components/atom/videoPlayer/src/hooks/native/useGetBlobAsVideoSrcEffect.js
+++ b/components/atom/videoPlayer/src/hooks/native/useGetBlobAsVideoSrcEffect.js
@@ -6,15 +6,15 @@ const useGetBlobAsVideoSrcEffect = ({src, videoNode}) => {
   useEffect(() => {
     if (videoSrc !== null) return
 
-    const reader = new FileReader()
+    const objectUrl = URL.createObjectURL(src)
+    setVideoSrc(objectUrl)
+    videoNode.current?.load()
 
-    reader.onload = function (e) {
-      setVideoSrc(e.target.result)
-      videoNode.current?.load()
+    return () => {
+      window.URL.revokeObjectURL(objectUrl)
+      setVideoSrc(null)
     }
-
-    reader.readAsDataURL(src)
-  }, [src, videoNode, videoSrc])
+  }, [src, videoNode])
 
   return videoSrc
 }

--- a/components/atom/videoPlayer/src/hooks/native/useGetBlobAsVideoSrcEffect.js
+++ b/components/atom/videoPlayer/src/hooks/native/useGetBlobAsVideoSrcEffect.js
@@ -4,7 +4,7 @@ const useGetBlobAsVideoSrcEffect = ({src, videoNode}) => {
   const [videoSrc, setVideoSrc] = useState(typeof src === 'string' ? src : null)
 
   useEffect(() => {
-    if (videoSrc !== null) return
+    if (typeof src === 'string') return
 
     const objectUrl = URL.createObjectURL(src)
     setVideoSrc(objectUrl)

--- a/components/atom/videoPlayer/test/index.test.js
+++ b/components/atom/videoPlayer/test/index.test.js
@@ -368,7 +368,7 @@ describe('AtomVideoPlayer', () => {
 
       // Then
       const {src} = await component.findByTestId('videosrc')
-      expect(src).to.include('data:video/mp4;base64,ZmFrZVZpZGVv')
+      expect(src).to.include('blob:')
     })
 
     it('should display controls by default', async () => {


### PR DESCRIPTION
…ng large videos by referencing

## atom/VideoPlayer
#### `🔍 Show`

### Description, Motivation and Context

With this changes, the video player is now capable of loading the preview of large local videos (blobs/files).

By creating an object url we are able to reference to a local existing file, which is much more efficient and faster than reading all the file and trying to codify it in base64 (yeah, it was a horrible choice but we didn't notice that this was a better choice until now).

### Types of changes

- [X] ✨ New feature (non-breaking change which adds functionality)
