### PR TITLE
feat(components/atom/videoPlayer): Add a callback to retrieve video m…

### DIFF
--- a/components/atom/videoPlayer/README.md
+++ b/components/atom/videoPlayer/README.md
@@ -55,7 +55,7 @@ The behaviour of the player can be customized by setting the following propertie
 | timeOffset | number | Second on which the video will start to be played. This is intended to skip a number of seconds from a video and start playing it from a specific position | No | undefined |
 | src | string or Blob | Video to be played. It can be a remote URL or a Blob instance (it works with a File instance too, as it is an extension from Blobs) | No | `''` |
 | fallbackComponent | Node | A component to be shown while the player and required libraries are being loaded using React lazy | No | `null` |
-
+| onLoadVideo | function | Returns a basic object containing the video duration, video width and video height. NOT SUPPORTED for YouTube videos. | No | `() => null` |
 
 ## Other exported objects
 

--- a/components/atom/videoPlayer/src/components/HLSPlayer.js
+++ b/components/atom/videoPlayer/src/components/HLSPlayer.js
@@ -11,6 +11,7 @@ const HLSPlayer = ({
   autoPlay,
   controls,
   muted,
+  onLoadVideo,
   hlsConfig,
   timeLimit,
   timeOffset,
@@ -22,6 +23,7 @@ const HLSPlayer = ({
   useInitHlsEffect({
     autoPlay,
     hlsConfig,
+    onLoadVideo,
     playerRef,
     src,
     timeOffset
@@ -59,6 +61,7 @@ HLSPlayer.propTypes = {
   autoPlay: PropTypes.bool,
   controls: PropTypes.bool,
   muted: PropTypes.bool,
+  onLoadVideo: PropTypes.func,
   hlsConfig: PropTypes.object,
   timeLimit: PropTypes.number,
   timeOffset: PropTypes.number,

--- a/components/atom/videoPlayer/src/components/NativePlayer.js
+++ b/components/atom/videoPlayer/src/components/NativePlayer.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types'
 import useGetBlobAsVideoSrcEffect from '../hooks/native/useGetBlobAsVideoSrcEffect.js'
 import useGetSrcWithMediaFragments from '../hooks/native/useGetSrcWithMediaFragments.js'
 import {BASE_CLASS, NATIVE_DEFAULT_TITLE} from '../settings/index.js'
+import {NATIVE} from '../settings/players.js'
 
 const NativePlayer = ({
   autoPlay,
@@ -30,7 +31,13 @@ const NativePlayer = ({
 
   const onLoadedMetadata = () => {
     const {duration, videoHeight, videoWidth} = videoNode.current
-    onLoadVideo({duration, videoHeight, videoWidth})
+    onLoadVideo({
+      src,
+      type: NATIVE.VIDEO_TYPE,
+      duration,
+      videoHeight,
+      videoWidth
+    })
   }
 
   return (

--- a/components/atom/videoPlayer/src/components/NativePlayer.js
+++ b/components/atom/videoPlayer/src/components/NativePlayer.js
@@ -10,6 +10,7 @@ const NativePlayer = ({
   autoPlay,
   controls,
   muted,
+  onLoadVideo,
   timeLimit,
   timeOffset,
   src,
@@ -27,6 +28,11 @@ const NativePlayer = ({
     }
   }, [autoPlay])
 
+  const onLoadedMetadata = () => {
+    const {duration, videoHeight, videoWidth} = videoNode.current
+    onLoadVideo({duration, videoHeight, videoWidth})
+  }
+
   return (
     <div className={`${BASE_CLASS}-nativePlayer`}>
       <video
@@ -36,6 +42,7 @@ const NativePlayer = ({
         ref={videoNode}
         title={title}
         controls={controls}
+        onLoadedMetadata={onLoadedMetadata}
       >
         {videoSrc !== null && <source data-testid="videosrc" src={videoSrc} />}
         Your browser does not support the video tag.
@@ -48,6 +55,7 @@ NativePlayer.propTypes = {
   autoPlay: PropTypes.bool,
   controls: PropTypes.bool,
   muted: PropTypes.bool,
+  onLoadVideo: PropTypes.func,
   timeLimit: PropTypes.number,
   timeOffset: PropTypes.number,
   src: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Blob)]),

--- a/components/atom/videoPlayer/src/components/VimeoPlayer.js
+++ b/components/atom/videoPlayer/src/components/VimeoPlayer.js
@@ -5,6 +5,8 @@ import PropTypes from 'prop-types'
 import {toQueryString} from '@s-ui/js/lib/string'
 
 import useTimeLimitCheck from '../hooks/vimeo/useTimeLimitCheck.js'
+import useVideoMetadata from '../hooks/vimeo/useVideoMetadata.js'
+import useVimeoApi from '../hooks/vimeo/useVimeoApi.js'
 import useVimeoProperties from '../hooks/vimeo/useVimeoProperties.js'
 import {BASE_CLASS, VIMEO_DEFAULT_TITLE} from '../settings/index.js'
 
@@ -12,6 +14,7 @@ const VimeoPlayer = ({
   autoPlay,
   controls,
   muted,
+  onLoadVideo,
   timeLimit,
   timeOffset,
   src,
@@ -26,10 +29,23 @@ const VimeoPlayer = ({
   const time = `#t=${timeOffset}`
   const videoSrc = `${getEmbeddableUrl(src)}?${params}${time}`
   const playerRef = useRef(null)
-  useTimeLimitCheck({
+
+  const {startTimeLimitInterval, stopTimeLimitInterval} = useTimeLimitCheck({
     playerRef,
     timeLimit,
     timeOffset
+  })
+
+  const {loadVideoMetadata} = useVideoMetadata({
+    onLoadVideo
+  })
+
+  useVimeoApi({
+    playerRef,
+    onPlay: startTimeLimitInterval,
+    onPause: stopTimeLimitInterval,
+    onLoad: loadVideoMetadata,
+    onCleanEffect: stopTimeLimitInterval
   })
 
   return (
@@ -51,6 +67,7 @@ VimeoPlayer.propTypes = {
   autoPlay: PropTypes.bool,
   controls: PropTypes.bool,
   muted: PropTypes.bool,
+  onLoadVideo: PropTypes.func,
   timeLimit: PropTypes.number,
   timeOffset: PropTypes.number,
   src: PropTypes.string,

--- a/components/atom/videoPlayer/src/components/VimeoPlayer.js
+++ b/components/atom/videoPlayer/src/components/VimeoPlayer.js
@@ -37,6 +37,7 @@ const VimeoPlayer = ({
   })
 
   const {loadVideoMetadata} = useVideoMetadata({
+    src,
     onLoadVideo
   })
 

--- a/components/atom/videoPlayer/src/components/YouTubePlayer.js
+++ b/components/atom/videoPlayer/src/components/YouTubePlayer.js
@@ -1,20 +1,34 @@
+import {useEffect} from 'react'
+
 import PropTypes from 'prop-types'
 
 import {toQueryString} from '@s-ui/js/lib/string'
 
 import useYouTubeProperties from '../hooks/youtube/useYouTubeProperties.js'
 import {BASE_CLASS, YOUTUBE_DEFAULT_TITLE} from '../settings/index.js'
+import {YOUTUBE} from '../settings/players.js'
 
 const YouTubePlayer = ({
   autoPlay,
   controls,
   muted,
+  onLoadVideo,
+  src,
   timeLimit,
   timeOffset,
-  src,
   title = YOUTUBE_DEFAULT_TITLE
 }) => {
   const {getEmbeddableUrl} = useYouTubeProperties()
+
+  useEffect(() => {
+    onLoadVideo({
+      src,
+      type: YOUTUBE.VIDEO_TYPE,
+      duration: null,
+      videoWidth: null,
+      videoHeight: null
+    })
+  }, [])
 
   const params = toQueryString({
     autoplay: autoPlay ? '1' : '0',
@@ -43,6 +57,7 @@ YouTubePlayer.propTypes = {
   autoPlay: PropTypes.bool,
   controls: PropTypes.bool,
   muted: PropTypes.bool,
+  onLoadVideo: PropTypes.func,
   timeLimit: PropTypes.number,
   timeOffset: PropTypes.number,
   src: PropTypes.string,

--- a/components/atom/videoPlayer/src/hooks/hls/useInitHlsEffect.js
+++ b/components/atom/videoPlayer/src/hooks/hls/useInitHlsEffect.js
@@ -2,6 +2,8 @@ import {useEffect} from 'react'
 
 import Hls from 'hls.js'
 
+import {HLS} from '../../settings/players.js'
+
 const useInitHlsEffect = ({
   autoPlay,
   hlsConfig,
@@ -33,7 +35,13 @@ const useInitHlsEffect = ({
         newHls.on(Hls.Events.MANIFEST_PARSED, () => {
           playerRef.current.onloadedmetadata = () => {
             const {duration, videoHeight, videoWidth} = playerRef.current
-            onLoadVideo({duration, videoHeight, videoWidth})
+            onLoadVideo({
+              src,
+              type: HLS.VIDEO_TYPE,
+              duration,
+              videoHeight,
+              videoWidth
+            })
           }
 
           if (timeOffset) playerRef.current.currentTime = timeOffset

--- a/components/atom/videoPlayer/src/hooks/hls/useInitHlsEffect.js
+++ b/components/atom/videoPlayer/src/hooks/hls/useInitHlsEffect.js
@@ -5,6 +5,7 @@ import Hls from 'hls.js'
 const useInitHlsEffect = ({
   autoPlay,
   hlsConfig,
+  onLoadVideo,
   playerRef,
   src,
   timeOffset
@@ -30,6 +31,11 @@ const useInitHlsEffect = ({
         newHls.loadSource(`${src}`)
 
         newHls.on(Hls.Events.MANIFEST_PARSED, () => {
+          playerRef.current.onloadedmetadata = () => {
+            const {duration, videoHeight, videoWidth} = playerRef.current
+            onLoadVideo({duration, videoHeight, videoWidth})
+          }
+
           if (timeOffset) playerRef.current.currentTime = timeOffset
 
           if (autoPlay) {

--- a/components/atom/videoPlayer/src/hooks/vimeo/useTimeLimitCheck.js
+++ b/components/atom/videoPlayer/src/hooks/vimeo/useTimeLimitCheck.js
@@ -1,52 +1,40 @@
-import {useCallback, useEffect, useRef} from 'react'
-
-import Player from '@vimeo/player'
+import {useCallback, useRef} from 'react'
 
 const ONE_SECOND = 1000
 
-const useTimeLimitCheck = ({playerRef, timeLimit, timeOffset}) => {
+const useTimeLimitCheck = ({timeLimit, timeOffset}) => {
   const checkTimeLimitInterval = useRef(null)
-  const player = useRef(null)
 
-  const stopTimeLimitInterval = useCallback(() => {
-    if (checkTimeLimitInterval.current === null) return
-    clearInterval(checkTimeLimitInterval.current)
-    checkTimeLimitInterval.current = null
-  }, [checkTimeLimitInterval])
+  const stopTimeLimitInterval = useCallback(
+    player => {
+      if (checkTimeLimitInterval.current === null) return
+      clearInterval(checkTimeLimitInterval.current)
+      checkTimeLimitInterval.current = null
+    },
+    [checkTimeLimitInterval]
+  )
 
-  const startTimeLimitInterval = useCallback(() => {
-    stopTimeLimitInterval()
-    if (timeLimit === undefined) return
-
-    checkTimeLimitInterval.current = setInterval(() => {
-      player.current.getCurrentTime().then(currentTime => {
-        const isTimeLimitReached =
-          currentTime >= timeLimit && timeLimit !== undefined
-
-        if (isTimeLimitReached) {
-          player.current.pause()
-          player.current.setCurrentTime(timeOffset || 0)
-        }
-      })
-    }, ONE_SECOND)
-  }, [
-    checkTimeLimitInterval,
-    player,
-    stopTimeLimitInterval,
-    timeLimit,
-    timeOffset
-  ])
-
-  useEffect(() => {
-    player.current = new Player(playerRef.current)
-    player.current.on('play', () => startTimeLimitInterval())
-    player.current.on('pause', () => stopTimeLimitInterval())
-
-    return () => {
+  const startTimeLimitInterval = useCallback(
+    player => {
       stopTimeLimitInterval()
-      player.current.destroy()
-    }
-  }, [playerRef, startTimeLimitInterval, stopTimeLimitInterval])
+      if (timeLimit === undefined) return
+
+      checkTimeLimitInterval.current = setInterval(() => {
+        player.current.getCurrentTime().then(currentTime => {
+          const isTimeLimitReached =
+            currentTime >= timeLimit && timeLimit !== undefined
+
+          if (isTimeLimitReached) {
+            player.current.pause()
+            player.current.setCurrentTime(timeOffset || 0)
+          }
+        })
+      }, ONE_SECOND)
+    },
+    [checkTimeLimitInterval, stopTimeLimitInterval, timeLimit, timeOffset]
+  )
+
+  return {startTimeLimitInterval, stopTimeLimitInterval}
 }
 
 export default useTimeLimitCheck

--- a/components/atom/videoPlayer/src/hooks/vimeo/useVideoMetadata.js
+++ b/components/atom/videoPlayer/src/hooks/vimeo/useVideoMetadata.js
@@ -1,9 +1,17 @@
-const useVideoMetadata = ({onLoadVideo}) => {
+import {VIMEO} from '../../settings/players.js'
+
+const useVideoMetadata = ({src, onLoadVideo}) => {
   const loadVideoMetadata = async player => {
     const duration = await player.current.getDuration()
     const videoWidth = await player.current.getVideoWidth()
     const videoHeight = await player.current.getVideoHeight()
-    onLoadVideo({duration, videoWidth, videoHeight})
+    onLoadVideo({
+      src,
+      type: VIMEO.VIDEO_TYPE,
+      duration,
+      videoWidth,
+      videoHeight
+    })
   }
 
   return {loadVideoMetadata}

--- a/components/atom/videoPlayer/src/hooks/vimeo/useVideoMetadata.js
+++ b/components/atom/videoPlayer/src/hooks/vimeo/useVideoMetadata.js
@@ -1,0 +1,12 @@
+const useVideoMetadata = ({onLoadVideo}) => {
+  const loadVideoMetadata = async player => {
+    const duration = await player.current.getDuration()
+    const videoWidth = await player.current.getVideoWidth()
+    const videoHeight = await player.current.getVideoHeight()
+    onLoadVideo({duration, videoWidth, videoHeight})
+  }
+
+  return {loadVideoMetadata}
+}
+
+export default useVideoMetadata

--- a/components/atom/videoPlayer/src/hooks/vimeo/useVimeoApi.js
+++ b/components/atom/videoPlayer/src/hooks/vimeo/useVimeoApi.js
@@ -1,0 +1,22 @@
+import {useEffect, useRef} from 'react'
+
+import Player from '@vimeo/player'
+
+const useVimeoApi = ({onPlay, onPause, onLoad, onCleanEffect, playerRef}) => {
+  const player = useRef(null)
+
+  useEffect(() => {
+    player.current = new Player(playerRef.current)
+    player.current.on('play', () => onPlay(player))
+    player.current.on('pause', () => onPause(player))
+    player.current.on('loaded', () => onLoad(player))
+
+    return () => {
+      onCleanEffect(player)
+      player.current.destroy()
+      player.current = null
+    }
+  }, [playerRef, onPlay, onPause, onLoad, onCleanEffect])
+}
+
+export default useVimeoApi

--- a/components/atom/videoPlayer/src/index.js
+++ b/components/atom/videoPlayer/src/index.js
@@ -11,6 +11,7 @@ import {
   AUTOPLAY_OPTIONS,
   BASE_CLASS,
   INTERSECTION_OBSERVER_DEFAULT_CONFIGURATION,
+  NO_OP,
   UNKNOWN
 } from './settings/index.js'
 
@@ -22,6 +23,7 @@ const AtomVideoPlayer = forwardRef(
       fallbackComponent = null,
       intersectionObserverConfiguration = INTERSECTION_OBSERVER_DEFAULT_CONFIGURATION,
       muted = false,
+      onLoadVideo = NO_OP,
       src = '',
       timeLimit,
       timeOffset
@@ -32,6 +34,7 @@ const AtomVideoPlayer = forwardRef(
       autoPlay,
       controls,
       muted,
+      onLoadVideo,
       src,
       timeLimit,
       timeOffset
@@ -74,6 +77,7 @@ AtomVideoPlayer.propTypes = {
     threshold: PropTypes.number
   }),
   muted: PropTypes.bool,
+  onLoadVideo: PropTypes.func,
   src: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Blob)]),
   timeLimit: PropTypes.number,
   timeOffset: PropTypes.number

--- a/components/atom/videoPlayer/src/settings/index.js
+++ b/components/atom/videoPlayer/src/settings/index.js
@@ -16,3 +16,4 @@ export const INTERSECTION_OBSERVER_DEFAULT_CONFIGURATION = {
   rootMargin: '0% 0% -25% 0%',
   threshold: 1
 }
+export const NO_OP = () => null


### PR DESCRIPTION
…etadata

## atom/videoPlayer
 #### `🔍 Show`


### Description, Motivation and Context

Add `onVideoLoad` parameter to the atom/videoPlayer component, to receive basic video metadata once the video is fully loaded.

So far, this is compatible with all video sources but YouTube.

### Types of changes

- [X] ✨ New feature (non-breaking change which adds functionality)