### PR TITLE
feat(components/atom/tag): Change the default tap highlight color for…

### DIFF
--- a/components/atom/tag/src/_settings.scss
+++ b/components/atom/tag/src/_settings.scss
@@ -1,7 +1,6 @@
 $bd-atom-tag: none !default;
 $bgc-atom-tag: color-variation($c-gray, 3) !default;
 $mw-label: 240px !default;
-$thc-atom-tag: inherit !default;
 
 // sizes
 $h-atom-tag-l: 40px !default;
@@ -28,6 +27,7 @@ $bgc-atom-tag-actionable: $c-primary !default;
 $bgc-atom-tag-actionable--hover: $c-primary-dark !default;
 $c-atom-tag-actionable: $c-white !default;
 $bd-atom-tag-actionable: none !default;
+$thc-atom-tag-actionable: inherit !default;
 $bgc-atom-tag-actionable-invert: $c-white !default;
 $bgc-atom-tag-actionable-invert--hover: $c-primary !default;
 $c-atom-tag-actionable-invert: $c-primary !default;

--- a/components/atom/tag/src/_settings.scss
+++ b/components/atom/tag/src/_settings.scss
@@ -1,6 +1,7 @@
 $bd-atom-tag: none !default;
 $bgc-atom-tag: color-variation($c-gray, 3) !default;
 $mw-label: 240px !default;
+$thc-atom-tag: inherit !default;
 
 // sizes
 $h-atom-tag-l: 40px !default;

--- a/components/atom/tag/src/styles/index.scss
+++ b/components/atom/tag/src/styles/index.scss
@@ -17,6 +17,7 @@ $base-class: '.sui-AtomTag';
   padding: $p-atom-tag-m;
   position: relative;
   white-space: nowrap;
+  -webkit-tap-highlight-color: $thc-atom-tag;
 
   &--isFitted {
     margin: 0;
@@ -95,7 +96,6 @@ $base-class: '.sui-AtomTag';
 
     &:not([aria-disabled='true']) {
       &:hover {
-        -webkit-tap-highlight-color: transparent;
         @media (hover: hover) and (pointer: fine) {
           background-color: $bgc-atom-tag-actionable--hover;
           color: $c-atom-tag-actionable;
@@ -118,7 +118,6 @@ $base-class: '.sui-AtomTag';
 
       &:not([aria-disabled='true']) {
         &:hover {
-          -webkit-tap-highlight-color: transparent;
           @media (hover: hover) and (pointer: fine) {
             background-color: $bgc-atom-tag-actionable-invert--hover;
             color: $c-atom-tag-actionable-invert--hover;

--- a/components/atom/tag/src/styles/index.scss
+++ b/components/atom/tag/src/styles/index.scss
@@ -17,7 +17,6 @@ $base-class: '.sui-AtomTag';
   padding: $p-atom-tag-m;
   position: relative;
   white-space: nowrap;
-  -webkit-tap-highlight-color: $thc-atom-tag;
 
   &--isFitted {
     margin: 0;
@@ -88,6 +87,7 @@ $base-class: '.sui-AtomTag';
     cursor: pointer;
     fill: $c-atom-tag-actionable;
     text-decoration: none;
+    -webkit-tap-highlight-color: $thc-atom-tag-actionable;
 
     &[aria-disabled='true'] {
       cursor: default;

--- a/components/atom/tag/src/styles/index.scss
+++ b/components/atom/tag/src/styles/index.scss
@@ -95,6 +95,7 @@ $base-class: '.sui-AtomTag';
 
     &:not([aria-disabled='true']) {
       &:hover {
+        -webkit-tap-highlight-color: transparent;
         @media (hover: hover) and (pointer: fine) {
           background-color: $bgc-atom-tag-actionable--hover;
           color: $c-atom-tag-actionable;
@@ -117,6 +118,7 @@ $base-class: '.sui-AtomTag';
 
       &:not([aria-disabled='true']) {
         &:hover {
+          -webkit-tap-highlight-color: transparent;
           @media (hover: hover) and (pointer: fine) {
             background-color: $bgc-atom-tag-actionable-invert--hover;
             color: $c-atom-tag-actionable-invert--hover;


### PR DESCRIPTION
… Chrome mobile

## /atom/tag
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
#### `🔍 Show`
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
Add the possibility to change the default tap highlight color for Chrome mobile (only for actionable tags)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
Chrome mobile default tap highlight color
<img width="688" alt="Captura de pantalla 2023-07-24 a las 17 41 27" src="https://github.com/SUI-Components/sui-components/assets/71508330/b1f517de-c08b-4b6a-89f6-49ff7e770704">

