### PR TITLE
Add icons for the two dropdown states

### DIFF
--- a/components/molecule/phoneInput/src/index.js
+++ b/components/molecule/phoneInput/src/index.js
@@ -20,7 +20,8 @@ import {phoneValidationType} from './settings.js'
 const BASE_CLASS = 'sui-MoleculePhoneInput'
 
 export default function MoleculePhoneInput({
-  dropdownIcon,
+  hideDropdownIcon,
+  showDropdownIcon,
   value = '',
   prefixes = [],
   onChange,
@@ -101,7 +102,7 @@ export default function MoleculePhoneInput({
             size={ATOM_ICON_SIZES.medium}
             color={ATOM_ICON_COLORS.currentColor}
           >
-            {dropdownIcon}
+            {showDropdown ? hideDropdownIcon : showDropdownIcon}
           </AtomIcon>
         </div>
         <div className={`${baseClass}-input-phoneContainer`}>
@@ -165,7 +166,8 @@ export default function MoleculePhoneInput({
 MoleculePhoneInput.displayName = 'MoleculePhoneInput'
 
 MoleculePhoneInput.propTypes = {
-  dropdownIcon: PropTypes.node,
+  hideDropdownIcon: PropTypes.node,
+  showDropdownIcon: PropTypes.node,
   value: PropTypes.string,
   placeholder: PropTypes.string,
   prefixes: PropTypes.array,

--- a/components/molecule/phoneInput/src/index.js
+++ b/components/molecule/phoneInput/src/index.js
@@ -20,8 +20,8 @@ import {phoneValidationType} from './settings.js'
 const BASE_CLASS = 'sui-MoleculePhoneInput'
 
 export default function MoleculePhoneInput({
-  hideDropdownIcon,
-  showDropdownIcon,
+  dropdownCloseIcon,
+  dropdownIcon,
   value = '',
   prefixes = [],
   onChange,
@@ -102,7 +102,7 @@ export default function MoleculePhoneInput({
             size={ATOM_ICON_SIZES.medium}
             color={ATOM_ICON_COLORS.currentColor}
           >
-            {showDropdown ? hideDropdownIcon : showDropdownIcon}
+            {showDropdown ? dropdownCloseIcon : dropdownIcon}
           </AtomIcon>
         </div>
         <div className={`${baseClass}-input-phoneContainer`}>
@@ -166,8 +166,8 @@ export default function MoleculePhoneInput({
 MoleculePhoneInput.displayName = 'MoleculePhoneInput'
 
 MoleculePhoneInput.propTypes = {
-  hideDropdownIcon: PropTypes.node,
-  showDropdownIcon: PropTypes.node,
+  dropdownCloseIcon: PropTypes.node,
+  dropdownIcon: PropTypes.node,
   value: PropTypes.string,
   placeholder: PropTypes.string,
   prefixes: PropTypes.array,


### PR DESCRIPTION
## Molecule/PhoneInput
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
`🔍 Show` 
<!-- #### `❓ Ask` -->

### Description, Motivation and Context
Adding a new prop to allow to use different icons for the dropdown open and closed state.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool
