### PR TITLE
feat(components/atom/videoPlayer): Avoid directly checking window value

### DIFF
--- a/components/atom/videoPlayer/src/settings/index.js
+++ b/components/atom/videoPlayer/src/settings/index.js
@@ -17,5 +17,5 @@ export const INTERSECTION_OBSERVER_DEFAULT_CONFIGURATION = {
   threshold: 1
 }
 export const NO_OP = () => null
-export const IS_NODE = window === undefined
+export const IS_NODE = typeof window === 'undefined'
 export const BLOB_TYPE = IS_NODE ? null : Blob


### PR DESCRIPTION
## atom/videoPlayer

#### `🔍 Show`

### Description, Motivation and Context

Do not directly check the window variable to avoid crashes when running in SSR mode.

### Types of changes

- [X] ✨ New feature (non-breaking change which adds functionality)