### PR TITLE
feat(components/atom/videoPlayer): Add imperative handle to know the …

### DIFF
--- a/components/atom/videoPlayer/demo/DemoPlayer.js
+++ b/components/atom/videoPlayer/demo/DemoPlayer.js
@@ -20,7 +20,6 @@ const DemoPlayer = ({src}) => {
   const [muted, setMuted] = useState(false)
   const [timeLimit, setTimeLimit] = useState(0)
   const [timeOffset, setTimeOffset] = useState(0)
-
   return (
     <>
       <H2>Autoplay</H2>

--- a/components/atom/videoPlayer/src/components/VimeoPlayer.js
+++ b/components/atom/videoPlayer/src/components/VimeoPlayer.js
@@ -1,68 +1,83 @@
-import {useRef} from 'react'
+import {forwardRef, useRef} from 'react'
 
 import PropTypes from 'prop-types'
 
 import {toQueryString} from '@s-ui/js/lib/string'
 
+import useImperativeApi from '../hooks/useImperativeApi.js'
 import useTimeLimitCheck from '../hooks/vimeo/useTimeLimitCheck.js'
 import useVideoMetadata from '../hooks/vimeo/useVideoMetadata.js'
 import useVimeoApi from '../hooks/vimeo/useVimeoApi.js'
 import useVimeoProperties from '../hooks/vimeo/useVimeoProperties.js'
 import {BASE_CLASS, VIMEO_DEFAULT_TITLE} from '../settings/index.js'
 
-const VimeoPlayer = ({
-  autoPlay,
-  controls,
-  muted,
-  onLoadVideo,
-  timeLimit,
-  timeOffset,
-  src,
-  title = VIMEO_DEFAULT_TITLE
-}) => {
-  const {getEmbeddableUrl} = useVimeoProperties()
-  const params = toQueryString({
-    autoplay: autoPlay ? '1' : '0',
-    controls: controls ? '1' : '0',
-    muted: muted ? '1' : '0'
-  })
-  const time = `#t=${timeOffset}`
-  const videoSrc = `${getEmbeddableUrl(src)}?${params}${time}`
-  const playerRef = useRef(null)
+const VimeoPlayer = forwardRef(
+  (
+    {
+      autoPlay,
+      controls,
+      muted,
+      onLoadVideo,
+      timeLimit,
+      timeOffset,
+      src,
+      title = VIMEO_DEFAULT_TITLE
+    },
+    forwardedRef
+  ) => {
+    const {getEmbeddableUrl} = useVimeoProperties()
+    const params = toQueryString({
+      autoplay: autoPlay ? '1' : '0',
+      controls: controls ? '1' : '0',
+      muted: muted ? '1' : '0'
+    })
+    const time = `#t=${timeOffset}`
+    const videoSrc = `${getEmbeddableUrl(src)}?${params}${time}`
+    const playerRef = useRef(null)
+    const vimeoPlayer = useRef(null)
 
-  const {startTimeLimitInterval, stopTimeLimitInterval} = useTimeLimitCheck({
-    playerRef,
-    timeLimit,
-    timeOffset
-  })
+    const {startTimeLimitInterval, stopTimeLimitInterval} = useTimeLimitCheck({
+      playerRef,
+      timeLimit,
+      timeOffset
+    })
 
-  const {loadVideoMetadata} = useVideoMetadata({
-    src,
-    onLoadVideo
-  })
+    const {loadVideoMetadata} = useVideoMetadata({
+      src,
+      onLoadVideo
+    })
 
-  useVimeoApi({
-    playerRef,
-    onPlay: startTimeLimitInterval,
-    onPause: stopTimeLimitInterval,
-    onLoad: loadVideoMetadata,
-    onCleanEffect: stopTimeLimitInterval
-  })
+    useVimeoApi({
+      playerRef,
+      onPlay: startTimeLimitInterval,
+      onPause: stopTimeLimitInterval,
+      onLoad: player => {
+        vimeoPlayer.current = player.current
+        loadVideoMetadata(player)
+      },
+      onCleanEffect: stopTimeLimitInterval
+    })
 
-  return (
-    <div className={`${BASE_CLASS}-vimeoPlayer`}>
-      <iframe
-        className={`${BASE_CLASS}-vimeoPlayerFrame`}
-        title={title}
-        src={videoSrc}
-        frameBorder="0"
-        allow="autoplay; fullscreen; picture-in-picture"
-        allowFullScreen
-        ref={playerRef}
-      />
-    </div>
-  )
-}
+    useImperativeApi({
+      ref: forwardedRef,
+      getCurrentTime: () => vimeoPlayer.current.getCurrentTime()
+    })
+
+    return (
+      <div className={`${BASE_CLASS}-vimeoPlayer`}>
+        <iframe
+          className={`${BASE_CLASS}-vimeoPlayerFrame`}
+          title={title}
+          src={videoSrc}
+          frameBorder="0"
+          allow="autoplay; fullscreen; picture-in-picture"
+          allowFullScreen
+          ref={playerRef}
+        />
+      </div>
+    )
+  }
+)
 
 VimeoPlayer.propTypes = {
   autoPlay: PropTypes.bool,

--- a/components/atom/videoPlayer/src/components/YouTubePlayer.js
+++ b/components/atom/videoPlayer/src/components/YouTubePlayer.js
@@ -1,57 +1,68 @@
-import {useEffect} from 'react'
+import {forwardRef, useEffect} from 'react'
 
 import PropTypes from 'prop-types'
 
 import {toQueryString} from '@s-ui/js/lib/string'
 
+import useImperativeApi from '../hooks/useImperativeApi.js'
 import useYouTubeProperties from '../hooks/youtube/useYouTubeProperties.js'
 import {BASE_CLASS, YOUTUBE_DEFAULT_TITLE} from '../settings/index.js'
 import {YOUTUBE} from '../settings/players.js'
 
-const YouTubePlayer = ({
-  autoPlay,
-  controls,
-  muted,
-  onLoadVideo,
-  src,
-  timeLimit,
-  timeOffset,
-  title = YOUTUBE_DEFAULT_TITLE
-}) => {
-  const {getEmbeddableUrl} = useYouTubeProperties()
-
-  useEffect(() => {
-    onLoadVideo({
+const YouTubePlayer = forwardRef(
+  (
+    {
+      autoPlay,
+      controls,
+      muted,
+      onLoadVideo,
       src,
-      type: YOUTUBE.VIDEO_TYPE,
-      duration: null,
-      videoWidth: null,
-      videoHeight: null
+      timeLimit,
+      timeOffset,
+      title = YOUTUBE_DEFAULT_TITLE
+    },
+    forwardedRef
+  ) => {
+    const {getEmbeddableUrl} = useYouTubeProperties()
+
+    useEffect(() => {
+      onLoadVideo({
+        src,
+        type: YOUTUBE.VIDEO_TYPE,
+        duration: null,
+        videoWidth: null,
+        videoHeight: null
+      })
+    }, [])
+
+    useImperativeApi({
+      ref: forwardedRef,
+      getCurrentTime: () => Promise.resolve(null)
     })
-  }, [])
 
-  const params = toQueryString({
-    autoplay: autoPlay ? '1' : '0',
-    controls: controls ? '1' : '0',
-    start: timeOffset || '0',
-    end: timeLimit,
-    mute: muted ? '1' : '0'
-  })
+    const params = toQueryString({
+      autoplay: autoPlay ? '1' : '0',
+      controls: controls ? '1' : '0',
+      start: timeOffset || '0',
+      end: timeLimit,
+      mute: muted ? '1' : '0'
+    })
 
-  const videoSrc = `${getEmbeddableUrl(src)}?${params}`
-  return (
-    <div className={`${BASE_CLASS}-youtubePlayer`}>
-      <iframe
-        className={`${BASE_CLASS}-youtubePlayerFrame`}
-        src={videoSrc}
-        title={title}
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        allowFullScreen
-      />
-    </div>
-  )
-}
+    const videoSrc = `${getEmbeddableUrl(src)}?${params}`
+    return (
+      <div className={`${BASE_CLASS}-youtubePlayer`}>
+        <iframe
+          className={`${BASE_CLASS}-youtubePlayerFrame`}
+          src={videoSrc}
+          title={title}
+          frameBorder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowFullScreen
+        />
+      </div>
+    )
+  }
+)
 
 YouTubePlayer.propTypes = {
   autoPlay: PropTypes.bool,

--- a/components/atom/videoPlayer/src/hooks/native/useGetBlobAsVideoSrcEffect.js
+++ b/components/atom/videoPlayer/src/hooks/native/useGetBlobAsVideoSrcEffect.js
@@ -1,7 +1,7 @@
 import {useEffect, useState} from 'react'
 
 const isNotBlobType = src => typeof src === 'string'
-const useGetBlobAsVideoSrcEffect = ({src, videoNode}) => {
+const useGetBlobAsVideoSrcEffect = ({src, playerRef}) => {
   const [videoSrc, setVideoSrc] = useState(isNotBlobType(src) ? src : null)
 
   useEffect(() => {
@@ -9,13 +9,13 @@ const useGetBlobAsVideoSrcEffect = ({src, videoNode}) => {
 
     const objectUrl = URL.createObjectURL(src)
     setVideoSrc(objectUrl)
-    videoNode.current?.load()
+    playerRef.current?.load()
 
     return () => {
       window.URL.revokeObjectURL(objectUrl)
       setVideoSrc(null)
     }
-  }, [src, videoNode])
+  }, [src, playerRef])
 
   return videoSrc
 }

--- a/components/atom/videoPlayer/src/hooks/useImperativeApi.js
+++ b/components/atom/videoPlayer/src/hooks/useImperativeApi.js
@@ -1,0 +1,15 @@
+import {useImperativeHandle} from 'react'
+
+const useImperativeApi = ({ref, getCurrentTime}) => {
+  useImperativeHandle(
+    ref,
+    () => {
+      return {
+        getCurrentTime
+      }
+    },
+    []
+  )
+}
+
+export default useImperativeApi

--- a/components/atom/videoPlayer/src/index.js
+++ b/components/atom/videoPlayer/src/index.js
@@ -42,7 +42,6 @@ const AtomVideoPlayer = forwardRef(
 
     const componentRef = useRef(null)
     const ref = forwardedRef || componentRef
-
     const autoPlayState = useScrollAutoplayEffect({
       autoPlay,
       intersectionObserverConfiguration,
@@ -51,12 +50,13 @@ const AtomVideoPlayer = forwardRef(
     })
 
     return (
-      <div ref={ref} className={BASE_CLASS}>
+      <div className={BASE_CLASS}>
         <Suspense fallback={fallbackComponent}>
           <Component
             {...{
               ...props,
-              autoPlay: autoPlayState
+              autoPlay: autoPlayState,
+              ref
             }}
           />
         </Suspense>


### PR DESCRIPTION
…current video position

## atom/videoPlayer

#### `🔍 Show`

### Description, Motivation and Context

Expose an imperative basic API to know current video time on an specific moment. In a similar way that an standard html5 video node exposes the `currentTime` property.

Compatible with native, HLS and VIMEO. YouTube always returns  null as result.

### Types of changes

- [X] ✨ New feature (non-breaking change which adds functionality)

### Screenshots - Animations

<img width="993" alt="Captura de pantalla 2023-08-02 a las 10 54 51" src="https://github.com/SUI-Components/sui-components/assets/16169223/13371e37-0ceb-4d3b-bb5e-b5f836530967">

