### PR TITLE
feat(components/molecule/selectPopover): force close popover behavior

### DIFF
--- a/components/molecule/selectPopover/demo/index.js
+++ b/components/molecule/selectPopover/demo/index.js
@@ -52,6 +52,8 @@ const Demo = () => {
   const [renderSelect, setRenderSelect] = useState(false)
   const [overlayType, setOverlayType] = useState(selectPopoverOverlayTypes.NONE)
   const [hasCustomRenderActions, setCustomRenderActions] = useState(false)
+  const [hasForceClosePopover, setHasForceClosePopover] = useState(false)
+  const [forceClosePopover, setForceClosePopover] = useState(false)
 
   const overlayContentRef = useRef()
 
@@ -63,6 +65,11 @@ const Demo = () => {
       checked: item.id === target.id ? !item.checked : item.checked
     }))
     setUnconfirmedItems(newItems)
+
+    if (hasForceClosePopover) {
+      setItems(newItems)
+      setForceClosePopover(true)
+    }
   }
 
   const handleClose = () => {
@@ -71,6 +78,8 @@ const Demo = () => {
 
   const handleOpen = () => {
     hasEvents && window.alert('Popover opened!')
+
+    hasForceClosePopover && setForceClosePopover(false)
   }
 
   const renderContentWrapper = ({actions, content, isOpen, setIsOpen}) => {
@@ -234,6 +243,16 @@ const Demo = () => {
             customRenderActions
           </label>
         </div>
+        <div>
+          <label>
+            <input
+              type="checkbox"
+              checked={hasForceClosePopover}
+              onChange={ev => setHasForceClosePopover(ev.target.checked)}
+            />
+            Force close popover
+          </label>
+        </div>
 
         <h3>Component</h3>
         <MoleculeSelectPopover
@@ -247,6 +266,7 @@ const Demo = () => {
           }}
           renderContentWrapper={customContentWrapper && renderContentWrapper}
           renderSelect={renderSelect && <button>Now I'm a button!</button>}
+          forceClosePopover={forceClosePopover}
           fullWidth={isFullWidth}
           hideActions={actionsAreHidden}
           iconArrowDown={IconArrowDown}

--- a/components/molecule/selectPopover/src/index.js
+++ b/components/molecule/selectPopover/src/index.js
@@ -39,6 +39,7 @@ const MoleculeSelectPopover = ({
   customButtonText,
   customButtonOptions,
   children,
+  forceClosePopover = false,
   fullWidth,
   hideActions,
   iconArrowDown: IconArrowDown,
@@ -72,6 +73,8 @@ const MoleculeSelectPopover = ({
 
   const hasOverlay =
     Boolean(overlayContentRef.current) && overlayType !== OVERLAY_TYPES.NONE
+
+  useEffect(() => forceClosePopover && setIsOpen(false), [forceClosePopover])
 
   useEffect(() => {
     /**
@@ -298,6 +301,7 @@ MoleculeSelectPopover.propTypes = {
     negative: PropTypes.bool
   }),
   children: PropTypes.node.isRequired,
+  forceClosePopover: PropTypes.bool,
   fullWidth: PropTypes.bool,
   hideActions: PropTypes.bool,
   iconArrowDown: PropTypes.elementType.isRequired,


### PR DESCRIPTION
## Molecule/SelectPopover
 #### `🔍 Show`

### Description, Motivation and Context
From Motor we have the need to force the popover to close in a controlled way when a user makes a selection within one of the popover elements.
With this proposal we solve this problem by means of a `forceClosePopover` prop that will allow us to close the popover from outside when necessary.

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)

