### PR TITLE
Feat/success progress bar

### DIFF
--- a/components/atom/progressBar/src/ProgressBarCircle/index.scss
+++ b/components/atom/progressBar/src/ProgressBarCircle/index.scss
@@ -116,6 +116,10 @@ $base-class-circle: '#{$base-class}Circle';
     &--loading {
       stroke: $c-atom-circle-progress-bar-trail--loading;
     }
+
+    &--success {
+      stroke: $c-atom-circle-progress-bar-trail--success;
+    }
   }
 
   &-path {

--- a/components/atom/progressBar/src/ProgressBarCircle/settings.scss
+++ b/components/atom/progressBar/src/ProgressBarCircle/settings.scss
@@ -15,6 +15,7 @@ $h-atom-circle-progress-bar-circle-small--error: $w-atom-circle-progress-bar-cir
 $c-atom-circle-progress-bar-trail: $c-gray-lightest !default;
 $c-atom-circle-progress-bar-trail--error: $c-alert !default;
 $c-atom-circle-progress-bar-trail--loading: $c-gray-lightest !default;
+$c-atom-circle-progress-bar-trail--success: $c-success !default;
 $c-atom-circle-progress-bar-path: $c-primary !default;
 $fz-atom-circle-progress-bar-text--extraLarge: $fz-l !default;
 $fz-atom-circle-progress-bar-text--inner: $fz-s !default;

--- a/components/atom/progressBar/src/ProgressBarLine/index.scss
+++ b/components/atom/progressBar/src/ProgressBarLine/index.scss
@@ -63,6 +63,9 @@ $base-class-line: '#{$base-class}Line';
       &-loading {
         background-color: $c-atom-line-progress-bar-status--loading;
       }
+      &-success {
+        background-color: $c-atom-line-progress-bar-status--success;
+      }
     }
   }
 }

--- a/components/atom/progressBar/src/ProgressBarLine/settings.scss
+++ b/components/atom/progressBar/src/ProgressBarLine/settings.scss
@@ -25,6 +25,7 @@ $trsdu-progress-exrta-bar: 500ms !default;
 $c-atom-line-progress-bar-status--progress: $c-primary !default;
 $c-atom-line-progress-bar-status--error: $c-alert !default;
 $c-atom-line-progress-bar-status--loading: $c-gray-lightest !default;
+$c-atom-line-progress-bar-status--success: $c-success !default;
 
 $size-atom-line-progress-bar: (
   small: $sz-base * 0.5,

--- a/components/atom/progressBar/src/settings.js
+++ b/components/atom/progressBar/src/settings.js
@@ -27,5 +27,6 @@ export const LINE_CAPS = {
 export const STATUS = {
   LOADING: 'loading',
   PROGRESS: 'progress',
-  ERROR: 'error'
+  ERROR: 'error',
+  SUCCESS: 'success'
 }

--- a/components/atom/progressBar/test/index.test.js
+++ b/components/atom/progressBar/test/index.test.js
@@ -262,12 +262,13 @@ describe(json.name, () => {
       const expected = {
         LOADING: 'loading',
         PROGRESS: 'progress',
-        ERROR: 'error'
+        ERROR: 'error',
+        SUCCESS: 'success'
       }
 
       // When
       const {atomProgressBarStatus: actual} = library
-      const {LOADING, PROGRESS, ERROR, ...others} = actual
+      const {LOADING, PROGRESS, ERROR, SUCCESS, ...others} = actual
 
       // Then
       expect(Object.keys(others).length).to.equal(0)


### PR DESCRIPTION
## atom/progressBar

#### `🔍 Show`

### Description, Motivation and Context

There is a status to render an in progress progress bar, a loading one, and an errored one.
However, there was not an status to reflect a progress bar that represents a successfully completed process.

This PR adds this new status to the component, taking advantage of the $c-success token, that already exists and is widely used across sui components.

### Types of changes

- [X] ✨ New feature (non-breaking change which adds functionality)

### Screenshots - Animations

<img width="1551" alt="Captura de pantalla 2023-09-14 a las 16 17 59" src="https://github.com/SUI-Components/sui-components/assets/16169223/a5f5d856-e387-42b8-8f63-78f4d040603e">

<img width="1168" alt="Captura de pantalla 2023-09-14 a las 16 18 37" src="https://github.com/SUI-Components/sui-components/assets/16169223/1a51a715-823e-4249-b194-40b93cd0a464">


