### PR TITLE
feat(components/atom/progressBar): Allow customizing the progress bar…

### DIFF
--- a/components/atom/progressBar/src/ProgressBarLine/index.js
+++ b/components/atom/progressBar/src/ProgressBarLine/index.js
@@ -41,7 +41,10 @@ const ProgressBarLine = ({
       {!hideIndicator && !indicatorBottom && indicatorTopElement}
       <div
         className={cx(CLASS_CONTAINER_BAR, {
-          [`${CLASS_CONTAINER_BAR}--size-${size}`]: size
+          [`${CLASS_CONTAINER_BAR}--size-${size}`]: size,
+          [`${CLASS_CONTAINER_BAR}--success`]: status === STATUS.SUCCESS,
+          [`${CLASS_CONTAINER_BAR}--error`]: status === STATUS.ERROR,
+          [`${CLASS_CONTAINER_BAR}--loading`]: status === STATUS.LOADING
         })}
       >
         {percentageArray.map((percentageValue, currentIndex, array) => {

--- a/components/atom/progressBar/src/ProgressBarLine/index.scss
+++ b/components/atom/progressBar/src/ProgressBarLine/index.scss
@@ -15,6 +15,19 @@ $base-class-line: '#{$base-class}Line';
     }
   }
   &-container {
+    &--error {
+      background: $bg-progress-bar--error;
+      border: $bd-line-progress-container--error;
+    }
+    &--loading {
+      background: $bg-progress-bar--loading;
+      border: $bd-line-progress-container--loading;
+    }
+    &--success {
+      background: $bg-progress-bar--success;
+      border: $bd-line-progress-container--success;
+    }
+
     background: $bg-progress-bar;
     border: $bd-line-progress-container;
     border-radius: $bdrs-progress-container;

--- a/components/atom/progressBar/src/ProgressBarLine/settings.scss
+++ b/components/atom/progressBar/src/ProgressBarLine/settings.scss
@@ -1,4 +1,7 @@
 $bg-progress-bar: $c-gray-lightest !default;
+$bg-progress-bar--success: $bg-progress-bar !default;
+$bg-progress-bar--loading: $bg-progress-bar !default;
+$bg-progress-bar--error: $bg-progress-bar !default;
 $bc-progress-bar: $c-gray-light !default;
 $c-progress-bar-fill: $c-primary !default;
 
@@ -6,6 +9,9 @@ $trsdu-progress-bar: 500ms !default;
 $trstf-progress-bar: linear !default;
 
 $bd-line-progress-container: $bdw-s solid $bc-progress-bar !default;
+$bd-line-progress-container--success: $bd-line-progress-container !default;
+$bd-line-progress-container--loading: $bd-line-progress-container !default;
+$bd-line-progress-container--error: $bd-line-progress-container !default;
 $bd-line-double-progress-container: $bdw-s solid $bc-progress-bar !default;
 
 $br-progress-container: $bdrs-l !default;


### PR DESCRIPTION
… depending on its status

## atom/progressBar
#### `🔍 Show` 

### Description, Motivation and Context

Due to UX requirements, we need to customize the container look of a specific progressBar status.

### Types of changes

- [X] ✨ New feature (non-breaking change which adds functionality)

### Screenshots - Animations

How our success bar looks: (no border, and a kind of green background on the container)

<img width="191" alt="Captura de pantalla 2023-09-15 a las 13 49 43" src="https://github.com/SUI-Components/sui-components/assets/16169223/c848d668-34b2-4d7c-846b-5c03f043cbc0">

How a standard bar looks: (White background, and 1px solid border)

<img width="197" alt="Captura de pantalla 2023-09-15 a las 13 51 21" src="https://github.com/SUI-Components/sui-components/assets/16169223/7d28f677-f7c8-42d8-b323-96aecefea31a">
