### PR TITLE
feat(components/atom/spinner): Add sizing to the atom/spinner component

### DIFF
--- a/components/atom/spinner/src/SUILoader/index.scss
+++ b/components/atom/spinner/src/SUILoader/index.scss
@@ -3,13 +3,10 @@
 #{$base-class} {
   &-loader {
     border-radius: $bdrs-rounded;
-    height: $sz-atom-spinner-oval;
     left: 0;
     margin: 0 auto;
     position: absolute;
     right: 0;
-    top: calc(50% - #{$sz-atom-spinner});
-    width: $sz-atom-spinner-oval;
     z-index: $z-atom-spinner-loader;
   }
 }
@@ -18,11 +15,27 @@
   $loaderColorOne: map-get($type, loaderColorOne);
   $loaderColorTwo: map-get($type, loaderColorTwo);
 
-  @include animation-atom-spinner($name, $loaderColorOne, $loaderColorTwo);
+  @each $sizeName, $sizes in $atom-spinner-sizes {
+    $size: map-get($sizes, size);
 
-  .sui-AtomSpinner--#{'' + $name} {
-    & .sui-AtomSpinner-loader {
-      animation: atom-spinner-#{$name} 1.5s ease-in-out infinite;
+    @include animation-atom-spinner(
+      $name,
+      $loaderColorOne,
+      $loaderColorTwo,
+      $sizeName,
+      $size
+    );
+
+    .sui-AtomSpinner--#{'' + $name}-#{'' + $sizeName} {
+      $size: map-get($sizes, size);
+      $totalSize: $size * 2;
+
+      & .sui-AtomSpinner-loader {
+        animation: atom-spinner-#{$name}-#{$sizeName} 1.5s ease-in-out infinite;
+        height: $size;
+        top: calc(50% - #{$totalSize});
+        width: $size;
+      }
     }
   }
 }

--- a/components/atom/spinner/src/SUILoader/settings.scss
+++ b/components/atom/spinner/src/SUILoader/settings.scss
@@ -1,32 +1,27 @@
-$sz-atom-spinner-oval: $sz-icon-s !default;
-$sz-atom-spinner: $sz-atom-spinner-oval * 2 !default;
 $z-atom-spinner-loader: 999 !default;
 
-@mixin animation-atom-spinner($name, $color1, $color2) {
-  @keyframes atom-spinner-#{'' + $name} {
+@mixin animation-atom-spinner($name, $color1, $color2, $sizeName, $size) {
+  $totalSize: $size * 2;
+
+  @keyframes atom-spinner-#{'' + $name}-#{'' + $sizeName} {
     0% {
-      box-shadow: -$sz-atom-spinner-oval * 0.5 $sz-atom-spinner-oval $color1,
-        $sz-atom-spinner-oval * 0.5 $sz-atom-spinner $color2;
+      box-shadow: -$size * 0.5 $size $color1, $size * 0.5 $totalSize $color2;
     }
 
     25% {
-      box-shadow: $sz-atom-spinner-oval * 0.5 $sz-atom-spinner-oval $color1,
-        -$sz-atom-spinner-oval * 0.5 $sz-atom-spinner $color2;
+      box-shadow: $size * 0.5 $size $color1, -$size * 0.5 $totalSize $color2;
     }
 
     50% {
-      box-shadow: $sz-atom-spinner-oval * 0.5 $sz-atom-spinner $color1,
-        -$sz-atom-spinner-oval * 0.5 $sz-atom-spinner-oval $color2;
+      box-shadow: $size * 0.5 $totalSize $color1, -$size * 0.5 $size $color2;
     }
 
     75% {
-      box-shadow: -$sz-atom-spinner-oval * 0.5 $sz-atom-spinner $color1,
-        $sz-atom-spinner-oval * 0.5 $sz-atom-spinner-oval $color2;
+      box-shadow: -$size * 0.5 $totalSize $color1, $size * 0.5 $size $color2;
     }
 
     100% {
-      box-shadow: -$sz-atom-spinner-oval * 0.5 $sz-atom-spinner-oval $color1,
-        $sz-atom-spinner-oval * 0.5 $sz-atom-spinner $color2;
+      box-shadow: -$size * 0.5 $size $color1, $size * 0.5 $totalSize $color2;
     }
   }
 }

--- a/components/atom/spinner/src/index.js
+++ b/components/atom/spinner/src/index.js
@@ -12,6 +12,7 @@ import {
   getParentClassName,
   OVERLAY_TYPES,
   removeParentClass,
+  SIZES,
   TYPES
 } from './settings.js'
 
@@ -22,6 +23,7 @@ const AtomSpinner = forwardRef(
       isDelayed: isDelayedFromProps = false,
       loader = <SUILoader />,
       overlayType = OVERLAY_TYPES.LIGHT,
+      size = SIZES.MEDIUM,
       type = TYPES.SECTION
     },
     forwardedRef
@@ -32,6 +34,7 @@ const AtomSpinner = forwardRef(
     useEffect(() => {
       const parentClassName = getParentClassName({
         overlayType,
+        size,
         type
       })
       const parentNodeClassList = refSpinner.current.parentNode.classList
@@ -47,7 +50,7 @@ const AtomSpinner = forwardRef(
         clearTimeout(timer)
         removeParentClass(parentNodeClassList)(parentClassName)
       }
-    }, [isDelayed, overlayType, type])
+    }, [isDelayed, overlayType, size, type])
 
     return (
       <div ref={refSpinner} className="sui-AtomSpinner-content">
@@ -56,6 +59,7 @@ const AtomSpinner = forwardRef(
           loader={loader}
           overlayType={overlayType}
           ref={forwardedRef}
+          size={size}
           type={type}
         >
           {children}
@@ -86,6 +90,12 @@ AtomSpinner.propTypes = {
    * 'TRANSPARENT'
    */
   overlayType: PropTypes.oneOf(Object.values(OVERLAY_TYPES)),
+
+  /**
+   * Possible options:
+   * 'SMALL' and 'MEDIUM'
+   */
+  size: PropTypes.oneOf(Object.values(SIZES)),
 
   /**
    * Possible options:

--- a/components/atom/spinner/src/settings.js
+++ b/components/atom/spinner/src/settings.js
@@ -1,5 +1,10 @@
 import cx from 'classnames'
 
+export const SIZES = {
+  SMALL: 'small',
+  MEDIUM: 'medium'
+}
+
 export const TYPES = {
   FULL: 'full',
   SECTION: 'section'
@@ -17,8 +22,8 @@ export const DELAY = 500 // ms
 export const BASE_CLASS = 'sui-AtomSpinner'
 export const CLASS_FULL = `${BASE_CLASS}--fullPage`
 
-export const getParentClassName = ({overlayType, type}) =>
-  cx(`${BASE_CLASS}--${overlayType}`, {
+export const getParentClassName = ({overlayType, size, type}) =>
+  cx(`${BASE_CLASS}--${overlayType}-${size}`, `${BASE_CLASS}--${size}`, {
     [BASE_CLASS]: type === TYPES.SECTION,
     [CLASS_FULL]: type === TYPES.FULL
   })

--- a/components/atom/spinner/src/styles/index.scss
+++ b/components/atom/spinner/src/styles/index.scss
@@ -43,4 +43,15 @@ $base-class: '.sui-AtomSpinner';
       background-color: $bgc;
     }
   }
+
+  @each $name, $sizes in $atom-spinner-sizes {
+    $size: map-get($sizes, size);
+
+    &--#{'' + $name} {
+      .sui-AtomSpinner-loader {
+        height: $size;
+        width: $size;
+      }
+    }
+  }
 }

--- a/components/atom/spinner/src/styles/settings.scss
+++ b/components/atom/spinner/src/styles/settings.scss
@@ -50,6 +50,18 @@ $atom-spinner-overlay-types: (
   )
 ) !default;
 
+$sz-atom-spinner-oval: $sz-icon-s !default;
+$sz-atom-spinner-small: $sz-icon-xs !default;
+
+$atom-spinner-sizes: (
+  small: (
+    size: $sz-atom-spinner-small
+  ),
+  medium: (
+    size: $sz-atom-spinner-oval
+  )
+) !default;
+
 %spinner-layer {
   bottom: 0;
   content: '';


### PR DESCRIPTION
## atom/spinner
#### `🔍 Show` 

### Description, Motivation and Context

Co-author with @davidmartin84 

This PR modifies the `atom/spinner` component to add the possibility of defining sizes.
It adds a new size to render small spinners too.

We think this should be backwards compatible.

### Types of changes

- [X] ✨ New feature (non-breaking change which adds functionality)

### Screenshots - Animations

Now with small size:

<img width="133" alt="Captura de pantalla 2023-09-18 a las 16 34 35" src="https://github.com/SUI-Components/sui-components/assets/16169223/5f657101-fea8-478d-ac08-206753eb5a2a">

Before with medium size (this is the default size if prop is not received):

<img width="93" alt="Captura de pantalla 2023-09-18 a las 16 39 57" src="https://github.com/SUI-Components/sui-components/assets/16169223/980709e4-bf1f-4aba-9d8a-2ff5f1c13497">

