### PR TITLE
feat(components/atom/videoPlayer): Add new kind of youtube video urls

### DIFF
--- a/components/atom/videoPlayer/src/hooks/youtube/useYouTubeProperties.js
+++ b/components/atom/videoPlayer/src/hooks/youtube/useYouTubeProperties.js
@@ -1,18 +1,28 @@
 import {
   YOUTUBE,
-  YOUTUBE_SHORT_URL,
-  YOUTUBE_STANDARD_URL
+  YOUTUBE_EMBEDDABLE_URL_PATTERN,
+  YOUTUBE_READABLE_URL_PATTERN,
+  YOUTUBE_SHORT_URL_PATTERN,
+  YOUTUBE_STANDARD_URL_PATTERN
 } from '../../settings/players.js'
 
 const useYouTubeProperties = () => {
   const getEmbeddableUrl = src => {
     let videoSrc = _replaceNonEmbeddableUrl({
       src,
-      nonEmbeddableUrl: YOUTUBE_STANDARD_URL
+      nonEmbeddableUrl: YOUTUBE_EMBEDDABLE_URL_PATTERN
     })
     videoSrc = _replaceNonEmbeddableUrl({
       src: videoSrc,
-      nonEmbeddableUrl: YOUTUBE_SHORT_URL
+      nonEmbeddableUrl: YOUTUBE_STANDARD_URL_PATTERN
+    })
+    videoSrc = _replaceNonEmbeddableUrl({
+      src: videoSrc,
+      nonEmbeddableUrl: YOUTUBE_SHORT_URL_PATTERN
+    })
+    videoSrc = _replaceNonEmbeddableUrl({
+      src: videoSrc,
+      nonEmbeddableUrl: YOUTUBE_READABLE_URL_PATTERN
     })
     return videoSrc
   }

--- a/components/atom/videoPlayer/src/settings/players.js
+++ b/components/atom/videoPlayer/src/settings/players.js
@@ -1,8 +1,10 @@
 import {BLOB_TYPE} from './index.js'
 
 export const YOUTUBE_EMBEDDABLE_URL = 'https://www.youtube.com/embed/'
-export const YOUTUBE_STANDARD_URL = 'youtube.com/watch?v='
-export const YOUTUBE_SHORT_URL = 'youtu.be/'
+export const YOUTUBE_EMBEDDABLE_URL_PATTERN = 'youtube.com/embed/'
+export const YOUTUBE_STANDARD_URL_PATTERN = 'youtube.com/watch?v='
+export const YOUTUBE_SHORT_URL_PATTERN = 'youtu.be/'
+export const YOUTUBE_READABLE_URL_PATTERN = 'youtube.com/v/'
 
 export const HLS = {
   FILE_FORMATS: ['m3u8'],
@@ -28,9 +30,10 @@ export const VIMEO = {
 export const YOUTUBE = {
   EMBEDDABLE_URL: YOUTUBE_EMBEDDABLE_URL,
   SRC_PATTERNS: [
-    YOUTUBE_EMBEDDABLE_URL,
-    YOUTUBE_STANDARD_URL,
-    YOUTUBE_SHORT_URL
+    YOUTUBE_EMBEDDABLE_URL_PATTERN,
+    YOUTUBE_STANDARD_URL_PATTERN,
+    YOUTUBE_SHORT_URL_PATTERN,
+    YOUTUBE_READABLE_URL_PATTERN
   ],
   VIDEO_TYPE: 'youtube',
   PLAYER_COMPONENT: 'YouTubePlayer'

--- a/components/atom/videoPlayer/test/index.test.js
+++ b/components/atom/videoPlayer/test/index.test.js
@@ -76,6 +76,23 @@ describe('AtomVideoPlayer', () => {
       await component.findByTitle(YOUTUBE_DEFAULT_TITLE)
     })
 
+    it('should embed the youtube video player even if embeddable url does not have protocol or www', async () => {
+      // Given
+      const props = {
+        src: 'youtube.com/embed/1gI_HGDgG7c'
+      }
+
+      // When
+      const component = setup(props)
+
+      // Then
+      const iframeNode = await component.findByTitle(YOUTUBE_DEFAULT_TITLE)
+      // check that the iframe src is the embedable url
+      expect(iframeNode.src).to.include(
+        'https://www.youtube.com/embed/1gI_HGDgG7c'
+      )
+    })
+
     it('should convert standard youtube urls to embedable urls', async () => {
       // Given
       const props = {
@@ -97,6 +114,23 @@ describe('AtomVideoPlayer', () => {
       // Given
       const props = {
         src: 'https://youtu.be/1gI_HGDgG7c'
+      }
+
+      // When
+      const component = setup(props)
+
+      // Then
+      const iframeNode = await component.findByTitle(YOUTUBE_DEFAULT_TITLE)
+      // check that the iframe src is the embedable url
+      expect(iframeNode.src).to.include(
+        'https://www.youtube.com/embed/1gI_HGDgG7c'
+      )
+    })
+
+    it('should convert readable-kind youtube urls to embeddable urls', async () => {
+      // Given
+      const props = {
+        src: 'http://www.youtube.com/v/1gI_HGDgG7c'
       }
 
       // When


### PR DESCRIPTION
## atom/videoPlayer
#### `🔍 Show`

### Description, Motivation and Context

There were two kind of youtube urls that were not properly processed by the video player:

1. The youtube kind of "readable" urls (youtube.com/v/:id)
2. The youtube embeddable urls. This last one was not properly recognized when it was inserted without including www or the https protocol.

This PR adds support for both of these url types.

### Types of changes

- [X] ✨ New feature (non-breaking change which adds functionality)
