### PR TITLE
Fix/fix spinner overlay

### DIFF
--- a/components/atom/spinner/src/settings.js
+++ b/components/atom/spinner/src/settings.js
@@ -23,7 +23,7 @@ export const BASE_CLASS = 'sui-AtomSpinner'
 export const CLASS_FULL = `${BASE_CLASS}--fullPage`
 
 export const getParentClassName = ({overlayType, size, type}) =>
-  cx(`${BASE_CLASS}--${overlayType}-${size}`, `${BASE_CLASS}--${size}`, {
+  cx(`${BASE_CLASS}--${overlayType}`, `${BASE_CLASS}--${overlayType}-${size}`, `${BASE_CLASS}--${size}`, {
     [BASE_CLASS]: type === TYPES.SECTION,
     [CLASS_FULL]: type === TYPES.FULL
   })

--- a/components/atom/spinner/src/settings.js
+++ b/components/atom/spinner/src/settings.js
@@ -23,10 +23,15 @@ export const BASE_CLASS = 'sui-AtomSpinner'
 export const CLASS_FULL = `${BASE_CLASS}--fullPage`
 
 export const getParentClassName = ({overlayType, size, type}) =>
-  cx(`${BASE_CLASS}--${overlayType}`, `${BASE_CLASS}--${overlayType}-${size}`, `${BASE_CLASS}--${size}`, {
-    [BASE_CLASS]: type === TYPES.SECTION,
-    [CLASS_FULL]: type === TYPES.FULL
-  })
+  cx(
+    `${BASE_CLASS}--${overlayType}`,
+    `${BASE_CLASS}--${overlayType}-${size}`,
+    `${BASE_CLASS}--${size}`,
+    {
+      [BASE_CLASS]: type === TYPES.SECTION,
+      [CLASS_FULL]: type === TYPES.FULL
+    }
+  )
 
 export const addParentClass = parentNodeClassList => parentClassName =>
   parentNodeClassList.add(...parentClassName.split(' '))


### PR DESCRIPTION
## atom/Spinner
#### `🔍 Show`

### Description, Motivation and Context

atom/Spinner was not displaying the overlay background. This PR fixs it by adding a missing class name.

### Types of changes

- [X] 🪲 Bug fix (non-breaking change which fixes an issue)