### PR TITLE
fix(components/molecule/selectPopover): Prepare component to work with React 18

### DIFF
--- a/components/molecule/selectPopover/src/index.js
+++ b/components/molecule/selectPopover/src/index.js
@@ -74,7 +74,9 @@ const MoleculeSelectPopover = ({
   const hasOverlay =
     Boolean(overlayContentRef.current) && overlayType !== OVERLAY_TYPES.NONE
 
-  useEffect(() => forceClosePopover && setIsOpen(false), [forceClosePopover])
+  useEffect(() => {
+    forceClosePopover && setIsOpen(false)
+  }, [forceClosePopover])
 
   useEffect(() => {
     /**


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` (should never be used for PR)
#### `🔍 Show`
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
- By migrating to React 18, we've seen there's an issue with this component. Due to the useEffect return is not a function it breaks, so changing the function expression is enough to keep the behaviour and working fine with React 18.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
![image](https://github.com/SUI-Components/sui-components/assets/16606947/f886c7a1-9c2a-43c6-a0af-232fc00aae9b)
