### PR TITLE
Feat/xcomp 10406 phone input

### DIFF
--- a/components/molecule/phoneInput/demo/ArticleStates.js
+++ b/components/molecule/phoneInput/demo/ArticleStates.js
@@ -32,6 +32,7 @@ export default function ArticleStates({openIcon, closeIcon}) {
         type={phoneValidationType.DEFAULT}
         initialSelectedPrefix={PREFIXES[1]}
         prefixes={PREFIXES}
+        helpText="The format should be numbers"
       />
       <H3>Error</H3>
       <MoleculePhoneInput
@@ -44,6 +45,7 @@ export default function ArticleStates({openIcon, closeIcon}) {
         initialSelectedPrefix={PREFIXES[2]}
         prefixes={PREFIXES}
         hasError
+        errorText="Incorrect format"
       />
       <br />
       <MoleculePhoneInput

--- a/components/molecule/phoneInput/demo/ArticleStates.js
+++ b/components/molecule/phoneInput/demo/ArticleStates.js
@@ -34,6 +34,10 @@ export default function ArticleStates({openIcon, closeIcon}) {
         prefixes={PREFIXES}
         helpText="The format should be numbers"
       />
+
+      <br />
+      <br />
+
       <H3>Error</H3>
       <MoleculePhoneInput
         value={errorPhone}
@@ -48,6 +52,8 @@ export default function ArticleStates({openIcon, closeIcon}) {
         errorText="Incorrect format"
       />
       <br />
+      <br />
+
       <MoleculePhoneInput
         value={errorPhone}
         onChange={onErrorPhoneChange}
@@ -58,6 +64,7 @@ export default function ArticleStates({openIcon, closeIcon}) {
         initialSelectedPrefix={PREFIXES[1]}
         prefixes={PREFIXES}
         hasError
+        errorText="Incorrect format"
       />
     </Article>
   )

--- a/components/molecule/phoneInput/package.json
+++ b/components/molecule/phoneInput/package.json
@@ -9,12 +9,11 @@
     "build:styles": "cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/react-atom-input": "5",
-    "@s-ui/react-molecule-dropdown-option": "2",
-    "@s-ui/react-molecule-dropdown-list": "2",
-    "@s-ui/react-atom-icon": "1",
-    "@s-ui/react-atom-button": "1",
     "@s-ui/component-dependencies": "latest",
+    "@s-ui/react-atom-button": "1",
+    "@s-ui/react-molecule-dropdown-list": "2",
+    "@s-ui/react-molecule-dropdown-option": "2",
+    "@s-ui/react-molecule-input-field": "4",
     "rendered-country-flags": "1"
   },
   "peerDependencies": {

--- a/components/molecule/phoneInput/src/index.js
+++ b/components/molecule/phoneInput/src/index.js
@@ -4,32 +4,34 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import flagIcons from 'rendered-country-flags'
 
-import AtomIcon, {
-  ATOM_ICON_COLORS,
-  ATOM_ICON_SIZES
-} from '@s-ui/react-atom-icon'
-import AtomInput from '@s-ui/react-atom-input'
 import {TYPES} from '@s-ui/react-atom-input/lib/config.js'
 import MoleculeDropdownList, {
   moleculeDropdownListDesigns
 } from '@s-ui/react-molecule-dropdown-list'
 import MoleculeDropdownOption from '@s-ui/react-molecule-dropdown-option'
+import MoleculeInputField from '@s-ui/react-molecule-input-field'
 
 import {phoneValidationType} from './settings.js'
 
 const BASE_CLASS = 'sui-MoleculePhoneInput'
 
+export {PREFIXES} from './settings.js'
 export default function MoleculePhoneInput({
+  alertText,
+  autoHideHelpText = false,
   dropdownCloseIcon,
   dropdownIcon,
-  value = '',
-  setFormattedValue,
-  prefixes = [],
+  errorText,
+  hasError,
+  helpText,
   onChange,
   placeholder,
-  hasError,
+  prefixes = [],
   initialSelectedPrefix = prefixes[0],
+  setFormattedValue,
+  successText,
   type = phoneValidationType.DEFAULT,
+  value = '',
   visiblePrefixes = true
 }) {
   const [showDropdown, setShowDropdown] = useState(false)
@@ -102,14 +104,7 @@ export default function MoleculePhoneInput({
               src={flagIcons[selectedPrefix?.value]}
             />
           )}
-          {visiblePrefixes && (
-            <AtomIcon
-              size={ATOM_ICON_SIZES.medium}
-              color={ATOM_ICON_COLORS.currentColor}
-            >
-              {showDropdown ? dropdownCloseIcon : dropdownIcon}
-            </AtomIcon>
-          )}
+          {visiblePrefixes && (showDropdown ? dropdownCloseIcon : dropdownIcon)}
         </div>
         <div className={`${baseClass}-input-phoneContainer`}>
           {selectedPrefix && (
@@ -117,13 +112,20 @@ export default function MoleculePhoneInput({
               {selectedPrefix.countryCode}
             </p>
           )}
-          <AtomInput
-            value={value.toString()}
+          <MoleculeInputField
+            {...{
+              alertText,
+              autoHideHelpText,
+              errorText,
+              helpText,
+              placeholder,
+              successText
+            }}
             mask={inputMask}
-            placeholder={placeholder}
-            type={TYPES.MASK}
-            onChange={handlePhoneChange}
             noBorder
+            onChange={handlePhoneChange}
+            type={TYPES.MASK}
+            value={value.toString()}
           />
         </div>
       </div>
@@ -187,5 +189,18 @@ MoleculePhoneInput.propTypes = {
     mask: PropTypes.string
   }),
   hasError: PropTypes.bool,
-  visiblePrefixes: PropTypes.bool
+  visiblePrefixes: PropTypes.bool,
+  /** Boolean to decide if helptext should be auto hide */
+  autoHideHelpText: PropTypes.bool,
+  /** Success message to display when success state  */
+  successText: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+
+  /** Error message to display when error state  */
+  errorText: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+
+  /** Alert message to display when alert state  */
+  alertText: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+
+  /** Help Text to display */
+  helpText: PropTypes.oneOfType([PropTypes.string, PropTypes.bool])
 }

--- a/components/molecule/phoneInput/src/index.scss
+++ b/components/molecule/phoneInput/src/index.scss
@@ -37,6 +37,19 @@
 
         & > input {
           background: none;
+
+          &.sui-AtomInput-input--noBorder {
+            position: relative;
+          }
+        }
+
+        & span.sui-AtomValidationText {
+          position: absolute;
+          left: 0;
+        }
+        & span.sui-AtomHelpText {
+          position: absolute;
+          left: 0;
         }
 
         &.splitted {

--- a/components/molecule/phoneInput/src/index.scss
+++ b/components/molecule/phoneInput/src/index.scss
@@ -1,7 +1,7 @@
 @import '~@s-ui/theme/lib/index';
 @import '~@s-ui/react-molecule-dropdown-option/lib/index';
 @import '~@s-ui/react-molecule-dropdown-list/lib/index';
-@import '~@s-ui/react-atom-input/lib/index';
+@import '~@s-ui/react-molecule-input-field/lib/index';
 @import '~@s-ui/react-atom-button/lib/index';
 
 .sui-MoleculePhoneInput {
@@ -44,8 +44,20 @@
           border: 1px solid $c-gray-light;
           width: 100%;
 
+          & .sui-AtomInput-input--noBorder {
+            border-width: 1px 0;
+            border-style: solid;
+            border-color: $c-gray-light;
+          }
+
           &.sui-MoleculePhoneInput--error {
             border-color: $c-error;
+
+            & .sui-AtomInput-input--noBorder {
+              border-width: 1px 0;
+              border-style: solid;
+              border-color: $c-error;
+            }
           }
         }
       }

--- a/components/molecule/phoneInput/src/index.scss
+++ b/components/molecule/phoneInput/src/index.scss
@@ -12,7 +12,7 @@
 
   &-input {
     border-radius: $bdrs-l;
-    border: 1px solid $c-gray-light;
+    border: $bdw-s solid $c-gray-light;
     display: flex;
     height: 40px;
 
@@ -54,11 +54,11 @@
 
         &.splitted {
           border-radius: $bdrs-l;
-          border: 1px solid $c-gray-light;
+          border: $bdw-s solid $c-gray-light;
           width: 100%;
 
           & .sui-AtomInput-input--noBorder {
-            border-width: 1px 0;
+            border-width: $bdw-s 0;
             border-style: solid;
             border-color: $c-gray-light;
           }
@@ -67,7 +67,7 @@
             border-color: $c-error;
 
             & .sui-AtomInput-input--noBorder {
-              border-width: 1px 0;
+              border-width: $bdw-s 0;
               border-style: solid;
               border-color: $c-error;
             }
@@ -87,7 +87,7 @@
 
       &.splitted {
         background-color: transparent;
-        border: 1px solid $c-gray-light;
+        border: $bdw-s solid $c-gray-light;
 
         &.sui-MoleculePhoneInput--error {
           border-color: $c-error;
@@ -115,7 +115,7 @@
     top: 45px;
     width: 100%;
     z-index: 1;
-    border: 1px solid $c-gray-light;
+    border: $bdw-s solid $c-gray-light;
     border-radius: $bdrs-l;
 
     & > ul {


### PR DESCRIPTION
## Molecule/PhoneInput
 #### `🔍 Show`


<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
Make MoleculePhoneInput use MoleculeInputField instead of AtomInput. This way, we get more features like different types of help texts. Also, we remove the unnecessary wrapper of AtomIcon.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<img width="458" alt="Screenshot 2023-09-26 at 12 06 13" src="https://github.com/SUI-Components/sui-components/assets/5814411/a7e135f7-febe-4a80-90e9-7612e6d1c982">
