### PR TITLE
feat(components/molecule/buttonGroup): add unset  in groupPositions

### DIFF
--- a/components/molecule/buttonGroup/src/index.js
+++ b/components/molecule/buttonGroup/src/index.js
@@ -11,11 +11,15 @@ import {SPACED} from './config.js'
 import {BASE_CLASS} from './settings.js'
 
 const getGroupPosition =
-  ({groupPositions, numChildren}) =>
+  ({groupPositions, numChildren, spaced}) =>
   index => {
-    if (index === 0) return groupPositions.FIRST
-    if (index === numChildren - 1) return groupPositions.LAST
-    return groupPositions.MIDDLE
+    if (spaced) {
+      return groupPositions.UNSET
+    } else {
+      if (index === 0) return groupPositions.FIRST
+      if (index === numChildren - 1) return groupPositions.LAST
+      return groupPositions.MIDDLE
+    }
   }
 
 const MoleculeButtonGroup = ({
@@ -25,7 +29,12 @@ const MoleculeButtonGroup = ({
   size,
   design,
   negative,
-  groupPositions,
+  groupPositions = {
+    FIRST: 'first',
+    MIDDLE: 'middle',
+    LAST: 'last',
+    UNSET: 'unset'
+  },
   onClick,
   spaced,
   isVertical,
@@ -34,6 +43,7 @@ const MoleculeButtonGroup = ({
   const numChildren = children.length
 
   const getGroupPositionByIndex = getGroupPosition({
+    spaced,
     groupPositions,
     numChildren
   })
@@ -127,14 +137,6 @@ MoleculeButtonGroup.propTypes = {
 
   /** buttons should have a vertical layout */
   isVertical: PropTypes.bool
-}
-
-MoleculeButtonGroup.defaultProps = {
-  groupPositions: {
-    FIRST: 'first',
-    MIDDLE: 'middle',
-    LAST: 'last'
-  }
 }
 
 export default MoleculeButtonGroup


### PR DESCRIPTION


🔍


<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
Adding 'unset' in default props in order to use when buttonGroup has prop spaced as true. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [x] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
