### PR TITLE
feat(components/atom/videoPlayer): Set video player width to 100% by …

### DIFF
--- a/components/atom/videoPlayer/src/index.scss
+++ b/components/atom/videoPlayer/src/index.scss
@@ -5,6 +5,7 @@ $fourByThreeAspectRatio: calc(100% / 4 * 3);
 
 @mixin atom-videoplayer-external-player {
   position: relative;
+  width: 100%;
 
   &Frame {
     height: 100%;


### PR DESCRIPTION
…default

## atom/videoPlayer
#### `🔍 Show`


### Description, Motivation and Context

Set width to 100% on external players to ensure they are properly displayed.

### Types of changes

- [X] 💄 Styles