### PR TITLE
feat(components/atom/videoPlayer): Add playsInline prop to videoPlayer

### DIFF
--- a/components/atom/videoPlayer/src/components/HLSPlayer.js
+++ b/components/atom/videoPlayer/src/components/HLSPlayer.js
@@ -15,6 +15,7 @@ const HLSPlayer = forwardRef(
       controls,
       muted,
       onLoadVideo,
+      playsInline,
       hlsConfig,
       timeLimit,
       timeOffset,
@@ -55,6 +56,7 @@ const HLSPlayer = forwardRef(
         <video
           onPlaying={startTimeLimitInterval}
           onPause={stopTimeLimitInterval}
+          playsInline={playsInline}
           controls={controls}
           muted={muted}
           className={`${BASE_CLASS}-hlsPlayerVideo`}
@@ -73,6 +75,7 @@ HLSPlayer.propTypes = {
   controls: PropTypes.bool,
   muted: PropTypes.bool,
   onLoadVideo: PropTypes.func,
+  playsInline: PropTypes.bool,
   hlsConfig: PropTypes.object,
   timeLimit: PropTypes.number,
   timeOffset: PropTypes.number,

--- a/components/atom/videoPlayer/src/components/NativePlayer.js
+++ b/components/atom/videoPlayer/src/components/NativePlayer.js
@@ -15,6 +15,7 @@ const NativePlayer = forwardRef(
       controls,
       muted,
       onLoadVideo,
+      playsInline,
       timeLimit,
       timeOffset,
       src,
@@ -60,6 +61,7 @@ const NativePlayer = forwardRef(
           title={title}
           controls={controls}
           onLoadedMetadata={onLoadedMetadata}
+          playsInline={playsInline}
         >
           {videoSrc !== null && (
             <source data-testid="videosrc" src={videoSrc} />
@@ -76,6 +78,7 @@ NativePlayer.propTypes = {
   controls: PropTypes.bool,
   muted: PropTypes.bool,
   onLoadVideo: PropTypes.func,
+  playsInline: PropTypes.bool,
   timeLimit: PropTypes.number,
   timeOffset: PropTypes.number,
   src: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),

--- a/components/atom/videoPlayer/src/index.js
+++ b/components/atom/videoPlayer/src/index.js
@@ -37,6 +37,7 @@ const AtomVideoPlayer = forwardRef(
       controls,
       muted,
       onLoadVideo,
+      playsInline,
       src,
       timeLimit,
       title,

--- a/components/atom/videoPlayer/src/index.js
+++ b/components/atom/videoPlayer/src/index.js
@@ -24,10 +24,11 @@ const AtomVideoPlayer = forwardRef(
       intersectionObserverConfiguration = INTERSECTION_OBSERVER_DEFAULT_CONFIGURATION,
       muted = false,
       onLoadVideo = NO_OP,
+      playsInline = false,
       src = '',
       timeLimit,
-      title,
-      timeOffset
+      timeOffset,
+      title
     },
     forwardedRef = createRef()
   ) => {
@@ -79,6 +80,7 @@ AtomVideoPlayer.propTypes = {
   }),
   muted: PropTypes.bool,
   onLoadVideo: PropTypes.func,
+  playsInline: PropTypes.bool,
   src: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   timeLimit: PropTypes.number,
   title: PropTypes.string,


### PR DESCRIPTION
## atom/videoPlayer
#### `🔍 Show`

### Description, Motivation and Context

Add the `playsInline` prop to ensure video can be played inline on iOS mobile devices without automatically entering into fullscreen mode.

### Types of changes

- [X] ✨ New feature (non-breaking change which adds functionality)