### PR TITLE
refactor(components/molecule/phoneInput): remove errorText from phone input

### DIFF
--- a/components/molecule/phoneInput/demo/ArticleStates.js
+++ b/components/molecule/phoneInput/demo/ArticleStates.js
@@ -49,7 +49,7 @@ export default function ArticleStates({openIcon, closeIcon}) {
         initialSelectedPrefix={PREFIXES[2]}
         prefixes={PREFIXES}
         hasError
-        errorText="Incorrect format"
+        helpText="Incorrect format"
       />
       <br />
       <br />
@@ -64,7 +64,7 @@ export default function ArticleStates({openIcon, closeIcon}) {
         initialSelectedPrefix={PREFIXES[1]}
         prefixes={PREFIXES}
         hasError
-        errorText="Incorrect format"
+        helpText="Incorrect format"
       />
     </Article>
   )

--- a/components/molecule/phoneInput/src/index.js
+++ b/components/molecule/phoneInput/src/index.js
@@ -21,7 +21,6 @@ export default function MoleculePhoneInput({
   autoHideHelpText = false,
   dropdownCloseIcon,
   dropdownIcon,
-  errorText,
   hasError,
   helpText,
   id,
@@ -54,7 +53,7 @@ export default function MoleculePhoneInput({
   const baseClass = cx(
     {
       splitted: type === phoneValidationType.SPLITTED,
-      [`${BASE_CLASS}--error`]: hasError || !!errorText,
+      [`${BASE_CLASS}--error`]: hasError,
       withLabel: !!label
     },
     BASE_CLASS
@@ -126,14 +125,13 @@ export default function MoleculePhoneInput({
               ...props,
               alertText,
               autoHideHelpText,
-              errorText,
-              helpText,
               id,
               label,
               name,
               placeholder,
               successText
             }}
+            {...(hasError ? {errorText: helpText} : {helpText})}
             mask={inputMask}
             noBorder
             onChange={handlePhoneChange}
@@ -202,10 +200,12 @@ MoleculePhoneInput.propTypes = {
     countryCode: PropTypes.string,
     mask: PropTypes.string
   }),
+
+  /** Boolean to decide if the helptext should be displayed as an error or as explanatory text */
   hasError: PropTypes.bool,
   visiblePrefixes: PropTypes.bool,
 
-  /** Boolean to decide if helptext should be auto hide */
+  /** Boolean to decide if the helptext should be auto hide */
   autoHideHelpText: PropTypes.bool,
   /** Success message to display when success state  */
   successText: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),

--- a/components/molecule/phoneInput/test/index.test.js
+++ b/components/molecule/phoneInput/test/index.test.js
@@ -170,28 +170,6 @@ describe('MoleculePhoneInput', () => {
     expect(selectedPrefixLabel.textContent).to.be.equal(PREFIXES[0].countryCode)
   })
 
-  it('should add selected class to the selected option', () => {
-    // Given
-    const props = {
-      value: '666666666',
-      prefixes: PREFIXES,
-      initialSelectedPrefix: PREFIXES[0],
-      onChange: () => {}
-    }
-
-    const {container} = setup(props)
-    const prefix = container.querySelector(
-      'div.sui-MoleculePhoneInput-input-prefix'
-    )
-    // When
-    prefix.click()
-    const options = container.querySelectorAll('.sui-MoleculeDropdownOption')
-    const firstOption = options[0]
-    firstOption.click()
-    // Then
-    expect(firstOption.classList.contains('is-selected')).to.be.true
-  })
-
   it('should close options when clicked outside', () => {
     // Given
     const props = {
@@ -267,20 +245,50 @@ describe('MoleculePhoneInput', () => {
     expect(phonePrefix).to.be.equal(PREFIXES[1])
   })
 
-  it('should add error class when error', () => {
+  it('should add help text class when help text exists', () => {
     // Given
+    const HELP_TEXT = 'Error Text'
     const props = {
       value: '',
       prefixes: PREFIXES,
       initialSelectedPrefix: PREFIXES[0],
       onChange: () => {},
-      hasError: true
+      hasError: false,
+      helpText: HELP_TEXT
     }
 
     const {container} = setup(props)
-    const input = container.querySelector('.sui-MoleculePhoneInput--error')
+    const helpText = container.querySelector('.sui-AtomHelpText')
+    const errorText = container.querySelector(
+      '.sui-AtomValidationText.sui-AtomValidationText--error'
+    )
 
-    expect(input).to.not.be.null
+    expect(helpText).to.exist
+    expect(helpText.textContent).to.equal(HELP_TEXT)
+    expect(errorText).not.to.exist
+  })
+
+  it('should add error class when error exists', () => {
+    // Given
+    const ERROR_TEXT = 'Error Text'
+    const props = {
+      value: '',
+      prefixes: PREFIXES,
+      initialSelectedPrefix: PREFIXES[0],
+      onChange: () => {},
+      hasError: true,
+      helpText: ERROR_TEXT
+    }
+
+    const {container} = setup(props)
+    const errorText = container.querySelector(
+      '.sui-AtomValidationText.sui-AtomValidationText--error'
+    )
+    const helpText = container.querySelector('.sui-AtomHelpText')
+
+    expect(errorText).to.exist
+    expect(errorText.textContent).to.equal(ERROR_TEXT)
+    expect(helpText).not.to.exist
   })
 
   it('Should apply different mask given a land line value', () => {


### PR DESCRIPTION
## Molecule/PhoneInput
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
 #### `🔍 Show`
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
Remove `errorText` from `PhoneInput`
Use `hasError` with `helpText` instead of `errorText`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [x] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool
