### PR TITLE
fix(components/molecule/accordion): fix header content overflow

### DIFF
--- a/components/molecule/accordion/src/styles/index.scss
+++ b/components/molecule/accordion/src/styles/index.scss
@@ -131,6 +131,7 @@ $base-class-item-panel: '#{$base-class-item}Panel';
   align-items: center;
   background-color: $bgc-accordion-item-header;
   padding: $p-accordion-item-header;
+  max-width: calc(100% - ($p-accordion-title * 2));
 }
 
 #{$base-class-item-header-icon}Default {

--- a/components/molecule/accordion/src/styles/index.scss
+++ b/components/molecule/accordion/src/styles/index.scss
@@ -125,13 +125,12 @@ $base-class-item-panel: '#{$base-class-item}Panel';
   }
 }
 #{$base-class-item-header}ButtonContainer {
-  width: 100%;
+  width: calc(100% - ($p-accordion-title * 2));
   height: 100%;
   display: flex;
   align-items: center;
   background-color: $bgc-accordion-item-header;
   padding: $p-accordion-item-header;
-  max-width: calc(100% - ($p-accordion-title * 2));
 }
 
 #{$base-class-item-header-icon}Default {


### PR DESCRIPTION
## Molecule/Accordion
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
#### `🔍 Show`
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: [MTR-76371](https://jira.ets.mpi-internal.com/browse/MTR-76371) & [MTR-76164](https://jira.ets.mpi-internal.com/browse/MTR-76164)

### Description, Motivation and Context
We have identified a problem with the accordion header container when the text is long and a line break is not defined, since it displaces the content overflowing the container.

To solve this, we have to modify the width of the container that will be defined by subtracting 100% of the available width minus the two paddings applied to the sides.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
#### BEFORE
![image](https://github.com/SUI-Components/sui-components/assets/31726966/82242573-327a-4103-92a8-59f51eea5963)

#### AFTER
![image](https://github.com/SUI-Components/sui-components/assets/31726966/89c0902e-fdaf-412b-882a-e5a6ed6d6f55)


