### PR TITLE
feat(components/molecule/accordion): add text-wrap balance property t…

### DIFF
--- a/components/molecule/accordion/demo/articles/ArticleLabelWrap.js
+++ b/components/molecule/accordion/demo/articles/ArticleLabelWrap.js
@@ -1,0 +1,92 @@
+import {useState} from 'react'
+
+import PropTypes from 'prop-types'
+
+import {
+  Article,
+  Cell,
+  Code,
+  Grid,
+  H2,
+  Label,
+  Paragraph,
+  RadioButton,
+  RadioButtonGroup
+} from '@s-ui/documentation-library'
+
+import Accordion, {
+  moleculeAccordionHeaderLabelWraps,
+  MoleculeAccordionItem as AccordionItem
+} from '../../src/index.js'
+import LoremIpsum from '../LoremIpsum.js'
+
+const ArticleLabelWrap = ({className}) => {
+  const [currentLabelWrap, setCurrentLabelWrap] = useState()
+
+  return (
+    <Article className={className}>
+      <H2>Label wrap</H2>
+      <Paragraph>
+        You can customize your header title label wrap style under the{' '}
+        <Code>headerLabelWraps</Code> prop.
+      </Paragraph>
+      <Grid cols={1} gutter={[8, 8]}>
+        <Label>headerLabelWrap</Label>
+        <Cell>
+          <RadioButtonGroup
+            value={currentLabelWrap}
+            onChange={(_, value) => setCurrentLabelWrap(value)}
+          >
+            {[
+              undefined,
+              ...Object.values(moleculeAccordionHeaderLabelWraps)
+            ].map(labelWrap => (
+              <RadioButton
+                key={`${labelWrap}`}
+                value={labelWrap}
+                checked={labelWrap === currentLabelWrap}
+                label={`${labelWrap}`}
+              />
+            ))}
+          </RadioButtonGroup>
+        </Cell>
+        <div style={{maxWidth: '350px'}}>
+          <Accordion behavior="single" headerLabelWrap={currentLabelWrap}>
+            <AccordionItem
+              value="value-1"
+              label="Accordion Item Header 1 with a long text that overflows the container"
+              content={
+                <>
+                  <p>Accordion Item Content 1</p>
+                  <p>
+                    <LoremIpsum units="words" count={200} format="plain" />
+                  </p>
+                </>
+              }
+            />
+            <AccordionItem
+              value="value-2"
+              label="Accordion Item Header 2 with a long text that overflows the container"
+              content={
+                <>
+                  <p>Accordion Item Content 2</p>
+                  <p>
+                    <LoremIpsum units="words" count={200} format="plain" />
+                  </p>
+                </>
+              }
+            />
+          </Accordion>
+        </div>
+      </Grid>
+    </Article>
+  )
+}
+
+ArticleLabelWrap.displayName = 'ArticleLabelWrap'
+
+ArticleLabelWrap.propTypes = {
+  className: PropTypes.string
+}
+
+export default ArticleLabelWrap

--- a/components/molecule/accordion/demo/index.js
+++ b/components/molecule/accordion/demo/index.js
@@ -6,6 +6,7 @@ import ArticleDefault from './articles/ArticleDefault.js'
 import ArticleDisabled from './articles/ArticleDisabled.js'
 import ArticleHeight from './articles/ArticleHeight.js'
 import ArticleIcon from './articles/ArticleIcon.js'
+import ArticleLabelWrap from './articles/ArticleLabelWrap.js'
 import ArticleSpacing from './articles/ArticleSpacing.js'
 import ArticleTransition from './articles/ArticleTransition.js'
 import {CLASS_SECTION} from './settings.js'
@@ -37,6 +38,8 @@ const Demo = () => {
       <ArticleDisabled className={CLASS_SECTION} />
       <br />
       <ArticleCustom className={CLASS_SECTION} />
+      <br />
+      <ArticleLabelWrap className={CLASS_SECTION} />
     </div>
   )
 }

--- a/components/molecule/accordion/src/styles/index.scss
+++ b/components/molecule/accordion/src/styles/index.scss
@@ -109,6 +109,7 @@ $base-class-item-panel: '#{$base-class-item}Panel';
     text-align: inherit;
     &--wrap {
       white-space: wrap;
+      text-wrap: balance;
     }
     &--noWrap {
       text-overflow: ellipsis;


### PR DESCRIPTION
## Molecule/Accordion
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
#### `🔍 Show`
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: [MTR-76371](https://jira.ets.mpi-internal.com/browse/MTR-76371) & [MTR-76164](https://jira.ets.mpi-internal.com/browse/MTR-76164)

### Description, Motivation and Context

- Add demo for **`headerLabelWrap`** behavior
- Add **`text-wrap balance`** property to use if browser support it



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
![image](https://github.com/SUI-Components/sui-components/assets/31726966/6aafb1fd-3daa-42c1-884b-bf36b0f3c397)
![image](https://github.com/SUI-Components/sui-components/assets/31726966/9f4501fe-06e0-4678-9dbc-daf73792e7c0)

