### PR TITLE
feat(components/atom/input): Add padding right to input password

### DIFF
--- a/components/atom/input/src/Password/styles/index.scss
+++ b/components/atom/input/src/Password/styles/index.scss
@@ -4,9 +4,14 @@ $base-class-password: '#{$base-class-input}-password';
   position: relative;
   width: 100%;
 
+  & > input {
+    padding-right: $pr-atom-input-password;
+  }
+
   &--toggleButton {
     color: $c-atom-input-password-toggle-button;
     cursor: pointer;
+    display: flex;
     position: absolute;
     right: $r-atom-input-password-toggle-button;
     top: 50%;

--- a/components/atom/input/src/Password/styles/settings.scss
+++ b/components/atom/input/src/Password/styles/settings.scss
@@ -1,2 +1,3 @@
 $r-atom-input-password-toggle-button: $gutter !default;
 $c-atom-input-password-toggle-button: $c-primary !default;
+$pr-atom-input-password: 36px !default;


### PR DESCRIPTION
## Atom/Input
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
 #### `🚢 Ship`
<!-- #### `🔍 Show` -->
<!-- #### `❓ Ask` -->

### Description, Motivation and Context
Align icon atom input password
Add padding to input password, due is covered by the icon

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

