### PR TITLE
❓  Fix/atom checkbox v3 firefox border

### DIFF
--- a/components/atom/checkbox/src/styles/index.scss
+++ b/components/atom/checkbox/src/styles/index.scss
@@ -6,6 +6,7 @@ $class-icon: '#{$base-class}--Icon';
   vertical-align: middle;
   box-sizing: border-box;
   color: $c-atom-checkbox;
+
   &#{$base-class}--native-disabled {
     #{$class-icon} {
       padding: 0;
@@ -25,6 +26,7 @@ $class-icon: '#{$base-class}--Icon';
       &:focus {
         outline: none;
       }
+
       &:focus-visible {
         outline: 2px solid transparentize($c-primary, 0.6);
       }
@@ -36,6 +38,7 @@ $class-icon: '#{$base-class}--Icon';
         justify-content: center;
       }
     }
+
     input[type='checkbox'] {
       display: none;
     }
@@ -44,6 +47,7 @@ $class-icon: '#{$base-class}--Icon';
   @each $size-name, $size-values in $sz-icon {
     $width: map-get($size-values, width);
     $height: map-get($size-values, height);
+
     &#{$base-class}--size-#{$size-name} {
       width: $width;
       height: $height;
@@ -59,11 +63,13 @@ $class-icon: '#{$base-class}--Icon';
   // semantic status
   &#{$base-class}--native-disabled #{$class-icon},
   &#{$base-class}--native-enabled input[type='checkbox'] {
-    border-color: inherit;
+    border-color: $bdc-atom-checkbox;
     background-color: $c-atom-checkbox;
+
     &::before {
       box-shadow: inset 1em 1em $c-primary;
     }
+
     &.is-checked,
     &.is-indeterminate,
     &:checked,
@@ -75,6 +81,7 @@ $class-icon: '#{$base-class}--Icon';
         box-shadow: inset 1em 1em $c-atom-checkbox;
       }
     }
+
     &:disabled {
       color: $bdc-atom-checkbox-is-disabled;
       background-color: $bgc-checked-atom-checkbox-is-disabled;
@@ -84,14 +91,17 @@ $class-icon: '#{$base-class}--Icon';
         box-shadow: none;
       }
     }
+
     @each $status, $color in $status-atom-checkbox {
       &[data-status='#{$status}']:not(:disabled) {
         border-color: $color;
         color: $color;
         background-color: $c-atom-checkbox;
+
         &::before {
           box-shadow: inset 1em 1em $c-atom-checkbox;
         }
+
         &.is-checked,
         &.is-indeterminate,
         &:checked,
@@ -117,6 +127,7 @@ $class-icon: '#{$base-class}--Icon';
       border-style: solid;
       border-radius: 0.15em;
       display: flex;
+
       &::before {
         margin: 10%;
         content: '';
@@ -126,21 +137,25 @@ $class-icon: '#{$base-class}--Icon';
         transition: 120ms transform ease-in-out;
         transform-origin: bottom left;
       }
+
       &:checked {
         &::before {
           transform: scale(1);
           clip-path: polygon(10% 40%, 0% 55%, 50% 90%, 100% 10%, 85% 0%, 46% 65%);
         }
       }
+
       &:indeterminate {
         &::before {
           transform: scale(1);
           clip-path: polygon(0% 44%, 100% 44%, 100% 56%, 0% 56%);
         }
       }
+
       &:focus {
         outline: none;
       }
+
       &:focus-visible {
         outline: 2px solid transparentize($c-primary, 0.6);
       }

--- a/components/atom/checkbox/src/styles/settings.scss
+++ b/components/atom/checkbox/src/styles/settings.scss
@@ -1,4 +1,5 @@
 $bdrs-atom-checkbox: $bdrs-m !default;
+$bdc-atom-checkbox: rgb(118, 118, 118) !default;
 $c-atom-checkbox: $c-white !default;
 $h-atom-checkbox-small: $sz-icon-s !default;
 $w-atom-checkbox-small: $sz-icon-s !default;

--- a/components/atom/checkbox/src/styles/settings.scss
+++ b/components/atom/checkbox/src/styles/settings.scss
@@ -1,5 +1,5 @@
 $bdrs-atom-checkbox: $bdrs-m !default;
-$bdc-atom-checkbox: rgb(118, 118, 118) !default;
+$bdc-atom-checkbox: $c-gray-light-2 !default;
 $c-atom-checkbox: $c-white !default;
 $h-atom-checkbox-small: $sz-icon-s !default;
 $w-atom-checkbox-small: $sz-icon-s !default;

--- a/components/atom/helpText/demo/package.json
+++ b/components/atom/helpText/demo/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@s-ui/react-atom-checkbox": "2",
+    "@s-ui/react-atom-checkbox": "3",
     "@s-ui/react-atom-icon": "1",
     "@s-ui/react-atom-input": "5",
     "@s-ui/react-atom-label": "1",

--- a/components/atom/label/demo/package.json
+++ b/components/atom/label/demo/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@s-ui/react-atom-button": "1",
-    "@s-ui/react-atom-checkbox": "2",
+    "@s-ui/react-atom-checkbox": "3",
     "@s-ui/react-atom-icon": "1",
     "@s-ui/react-atom-input": "5"
   }

--- a/components/atom/slider/demo/package.json
+++ b/components/atom/slider/demo/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@s-ui/react-atom-button": "1",
-    "@s-ui/react-atom-checkbox": "2",
+    "@s-ui/react-atom-checkbox": "3",
     "@s-ui/react-atom-icon": "1",
     "@s-ui/react-atom-input": "5"
   }

--- a/components/atom/spinner/demo/package.json
+++ b/components/atom/spinner/demo/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@s-ui/react-atom-button": "1",
-    "@s-ui/react-atom-checkbox": "2",
+    "@s-ui/react-atom-checkbox": "3",
     "@s-ui/react-atom-icon": "1",
     "@s-ui/react-atom-input": "5"
   }

--- a/components/molecule/dropdownOption/package.json
+++ b/components/molecule/dropdownOption/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@s-ui/js": "2",
-    "@s-ui/react-atom-checkbox": "2",
+    "@s-ui/react-atom-checkbox": "3",
     "@s-ui/react-hooks": "1"
   },
   "peerDependencies": {

--- a/components/organism/nestedCheckboxes/package.json
+++ b/components/organism/nestedCheckboxes/package.json
@@ -9,7 +9,7 @@
     "build:styles": "cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/react-molecule-checkbox-field": "4"
+    "@s-ui/react-molecule-checkbox-field": "5"
   },
   "peerDependencies": {
     "@s-ui/component-dependencies": "1"

--- a/themes/infojobs.scss
+++ b/themes/infojobs.scss
@@ -1,6 +1,6 @@
 // Settings
-$ff-sans-serif: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial,
-  sans-serif, Apple Color Emoji, Segoe UI Emoji;
+$ff-sans-serif: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji,
+  Segoe UI Emoji;
 $fz-base: 16px;
 
 // Inherit from original theme


### PR DESCRIPTION
## ATOM/CHECKBOX
#### `❓ Ask`

**TASK**: NO TICKET

### Description, Motivation and Context
If you open `sui-components` and see the `AtomCheckbox`, `MoleculeCheckboxField` or `OrganismNestedCheckboxes` [demo](https://sui-components.vercel.app/workbench/atom/checkbox/demo
) on Chrome and Firefox, you will see a style issue when checkbox is unchecked. The border of the checkbox is not displaying well, because is not defined trough CSS and not all browser have defined a default style. 

| Chrome | Firefox | 
|-------|-----|
| ![image](https://github.com/SUI-Components/sui-components/assets/3933098/9a13d5c3-58a0-44d7-b587-049684f2cd39) | ![image](https://github.com/SUI-Components/sui-components/assets/3933098/9d7f5605-2cd8-47c9-8ecd-fdc3ac4794d1) | 

On the other hand, I've updated all components that are using an old version of checkbox to the new one. 

Components affected for this update: 
- `molecule/dropdownOption`
- `organism/nestedCheckboxes`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📷 Demo
- [x] 💄 Styles

### Screenshots - Animations

| Component | Before Firefox | After Firefocx | 
|-------|-----|-----|
| `AtomCheckbox` | ![image](https://github.com/SUI-Components/sui-components/assets/3933098/704f0c42-438a-451f-a9af-a796ba45480e) | ![image](https://github.com/SUI-Components/sui-components/assets/3933098/9e661f4c-9b34-4fd6-9dbf-9d81e9406335) | 
| `MoleculeCheckboxField` | ![image](https://github.com/SUI-Components/sui-components/assets/3933098/34d3710c-2e55-4832-83ac-9e6f0e0923d2) | ![image](https://github.com/SUI-Components/sui-components/assets/3933098/0214ddde-18f5-4445-acdc-0ff85be60503) |
| `OrganismNestedCheckbox` | ![image](https://github.com/SUI-Components/sui-components/assets/3933098/f5927df6-c191-4d3d-a11c-dd0b44c43829) | ![image](https://github.com/SUI-Components/sui-components/assets/3933098/7060d4b8-2516-4381-baa8-5f854bd05c58) |

