### PR TITLE
feat(components/atom/upload): Remove unnecesary width

### DIFF
--- a/components/atom/upload/src/styles/index.scss
+++ b/components/atom/upload/src/styles/index.scss
@@ -48,10 +48,6 @@ $base-class: '.sui-AtomUpload';
     height: $h-atom-upload-icon;
     justify-content: center;
     width: $w-atom-upload-icon;
-
-    & > * {
-      width: 100%;
-    }
   }
 
   &--active {


### PR DESCRIPTION
## Atom/Upload
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
#### `🚢 Ship`
<!-- #### `🔍 Show` -->
<!-- #### `❓ Ask` -->


### Description, Motivation and Context
The Atom Upload has the icon with a weird aligment, because the component is invading the Icon that is inserted by prop

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
**BEFORE**
![Screenshot 2023-12-21 at 12 34 48](https://github.com/SUI-Components/sui-components/assets/10158601/3736b990-22df-4342-ad1b-b0677ad853c8)
![Screenshot 2023-12-21 at 12 35 02](https://github.com/SUI-Components/sui-components/assets/10158601/e670e694-82f2-49b4-8abb-67c38162b59e)

**AFTER (with changes applied)**
![Screenshot 2023-12-21 at 12 35 06](https://github.com/SUI-Components/sui-components/assets/10158601/f5a1cce6-ae36-4d1a-8b49-15d8fedd201f)
![Screenshot 2023-12-21 at 12 35 14](https://github.com/SUI-Components/sui-components/assets/10158601/04afebdc-9078-4e67-a69e-a45077f4d1b1)


