### PR TITLE
Feat/loading switch

### DIFF
--- a/components/atom/switch/README.md
+++ b/components/atom/switch/README.md
@@ -24,8 +24,9 @@ import AtomSwitch from '@s-ui/react-atom-switch'
 return (
   <AtomSwitch
     disabled={false}
-    isFitted={false}
     initialValue={false}
+    isFitted={false}
+    isLoading={true}
     label="Label"
     labelLeft="Off"
     labelOptionalText="Optional label"

--- a/components/atom/switch/demo/articles/ArticleLoading.js
+++ b/components/atom/switch/demo/articles/ArticleLoading.js
@@ -1,0 +1,35 @@
+import PropTypes from 'prop-types'
+
+import {Article, Cell, Code, Grid, H2, Label, Paragraph} from '@s-ui/documentation-library'
+
+import AtomSwitch, {atomSwitchSizes} from '../../src/index.js'
+import {flexCenteredStyle} from '../settings.js'
+
+const ArticleLoading = ({className}) => (
+  <Article className={className}>
+    <H2>IsLoading</H2>
+    <Paragraph>
+      If <Code>isLoading</Code> is set to <Code>true</Code> the switch will display a loading icon.
+    </Paragraph>
+    <Grid cols={Object.values(atomSwitchSizes).length} style={{width: 800}}>
+      {Object.values(atomSwitchSizes).map((size, index) => (
+        <Cell key={index} style={flexCenteredStyle}>
+          <Label>{size}</Label>
+        </Cell>
+      ))}
+      {Object.values(atomSwitchSizes).map((size, index) => (
+        <Cell key={index} style={flexCenteredStyle}>
+          <AtomSwitch isLoading size={size} name="name" />
+        </Cell>
+      ))}
+    </Grid>
+  </Article>
+)
+
+ArticleLoading.displayName = 'ArticleLoading'
+
+ArticleLoading.propTypes = {
+  className: PropTypes.string
+}
+
+export default ArticleLoading

--- a/components/atom/switch/demo/index.js
+++ b/components/atom/switch/demo/index.js
@@ -5,6 +5,7 @@ import ArticleControlledAndUncontrolled from './articles/ArticleControlledAndUnc
 import ArticleDisabled from './articles/ArticleDisabled.js'
 import ArticleFullWidth from './articles/ArticleFullWidth.js'
 import ArticleIsFitted from './articles/ArticleIsFitted.js'
+import ArticleLoading from './articles/ArticleLoading.js'
 import ArticleSizes from './articles/ArticleSizes.js'
 import ArticleState from './articles/ArticleState.js'
 import ArticleToggle from './articles/ArticleToggle.js'
@@ -40,6 +41,8 @@ const Demo = () => {
         <ArticleToggle className={CLASS_SECTION} />
         <br />
         <ArticleFullWidth className={CLASS_SECTION} />
+        <br />
+        <ArticleLoading className={CLASS_SECTION} />
       </div>
     </div>
   )

--- a/components/atom/switch/package.json
+++ b/components/atom/switch/package.json
@@ -9,7 +9,8 @@
     "build:styles": "cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/react-atom-label": "1"
+    "@s-ui/react-atom-label": "1",
+    "@s-ui/react-primitive-loading-icon": "1"
   },
   "peerDependencies": {
     "@s-ui/component-dependencies": "1"

--- a/components/atom/switch/src/SwitchType/single.js
+++ b/components/atom/switch/src/SwitchType/single.js
@@ -4,6 +4,7 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 
 import AtomLabel from '@s-ui/react-atom-label'
+import PrimitiveLoadingIcon from '@s-ui/react-primitive-loading-icon'
 
 import {LABELS, TYPES} from '../config.js'
 import {suitClass, switchClassNames} from './helpers.js'
@@ -19,6 +20,7 @@ export const SingleSwitchTypeRender = forwardRef(
       labelLeft,
       iconLeft,
       iconRight,
+      isLoading,
       labelOptionalText,
       labelRight,
       name,
@@ -79,9 +81,15 @@ export const SingleSwitchTypeRender = forwardRef(
             id={name}
             {...(!disabled && {tabIndex: 0})}
           >
-            <div className={cx(suitClass({element: 'icon-left'}))}>{iconLeft}</div>
-            <div className={cx(suitClass({element: 'circle'}))} />
-            <div className={cx(suitClass({element: 'icon-right'}))}>{iconRight}</div>
+            {!isLoading ? <div className={cx(suitClass({element: 'icon-left'}))}>{iconLeft}</div> : null}
+            <div className={cx(suitClass({element: 'circle'}))}>
+              {isLoading ? (
+                <div className={cx(suitClass({element: 'circleLoading'}))}>
+                  <PrimitiveLoadingIcon />
+                </div>
+              ) : null}
+            </div>
+            {!isLoading ? <div className={cx(suitClass({element: 'icon-right'}))}>{iconRight}</div> : null}
           </button>
           {showLabelRight && <AtomLabel name={name} text={labelRight} optionalText={labelOptionalText} />}
         </div>
@@ -133,6 +141,10 @@ SingleSwitchTypeRender.propTypes = {
    * Is component toggle
    */
   isToggle: PropTypes.bool,
+  /**
+   * Is the switch loading
+   */
+  isLoading: PropTypes.bool,
   /**
    * Callback on focus element
    */

--- a/components/atom/switch/src/SwitchType/toggle.js
+++ b/components/atom/switch/src/SwitchType/toggle.js
@@ -4,6 +4,7 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 
 import AtomLabel from '@s-ui/react-atom-label'
+import PrimitiveLoadingIcon from '@s-ui/react-primitive-loading-icon'
 
 import {TYPES} from '../config.js'
 import {suitClass, switchClassNames} from './helpers.js'
@@ -14,6 +15,7 @@ export const ToggleSwitchTypeRender = forwardRef(
       disabled,
       isFitted,
       isToggle,
+      isLoading,
       label,
       labelLeft,
       iconLeft,
@@ -76,9 +78,15 @@ export const ToggleSwitchTypeRender = forwardRef(
             {...(!disabled && {tabIndex: 0})}
             onClick={onToggle()}
           >
-            {<div className={cx(suitClass({element: 'icon-left'}))}>{iconLeft}</div>}
-            <div className={cx(suitClass({element: 'circle'}))} />
-            <div className={cx(suitClass({element: 'icon-right'}))}>{iconRight}</div>
+            {!isLoading ? <div className={cx(suitClass({element: 'icon-left'}))}>{iconLeft}</div> : null}
+            <div className={cx(suitClass({element: 'circle'}))}>
+              {isLoading ? (
+                <div className={cx(suitClass({element: 'circleLoading'}))}>
+                  <PrimitiveLoadingIcon />
+                </div>
+              ) : null}
+            </div>
+            {!isLoading ? <div className={cx(suitClass({element: 'icon-right'}))}>{iconRight}</div> : null}
           </button>
           <span
             className={cx(suitClass({element: 'text'}), suitClass({element: 'right'}))}
@@ -161,5 +169,9 @@ ToggleSwitchTypeRender.propTypes = {
   /** element node which appears inside the switch circle when it's in right position **/
   iconRight: PropTypes.node,
   /** element in right or left position (checked means right)**/
-  isChecked: PropTypes.bool
+  isChecked: PropTypes.bool,
+  /**
+   * Is the switch loading
+   */
+  isLoading: PropTypes.bool
 }

--- a/components/atom/switch/src/index.js
+++ b/components/atom/switch/src/index.js
@@ -55,6 +55,9 @@ AtomSwitch.propTypes = {
   /** The padding of the container is set to 0 */
   isFitted: PropTypes.bool,
 
+  /** Is the switch loading **/
+  isLoading: PropTypes.bool,
+
   /** Left label to be printed */
   labelLeft: PropTypes.string,
 

--- a/components/atom/switch/src/index.scss
+++ b/components/atom/switch/src/index.scss
@@ -1,5 +1,6 @@
 @import '~@s-ui/theme/lib/index';
 @import '~@s-ui/react-atom-label/lib/index';
+@import '~@s-ui/react-primitive-loading-icon/lib/index';
 
 @import './styles/settings.scss';
 @import './styles/index.scss';

--- a/components/atom/switch/src/styles/index.scss
+++ b/components/atom/switch/src/styles/index.scss
@@ -133,13 +133,22 @@ $base-class: '.sui-AtomSwitch';
       box-sizing: border-box;
       background-color: $c-atom-switch-circle;
       border-radius: ($h-atom-switch-default - 2) * 0.5;
-      border: $bdw-s solid $c-atom-switch-circle;
-      box-shadow: 2px 0 2px 0 $c-gray-light;
+      border: $bd-atom-switch-circle;
+      box-shadow: $bxsh-atom-switch-circle;
       height: $h-atom-switch-circle-default - 2px;
       width: $w-atom-switch-circle-default - 2px;
       transition: margin-left $atom-switch-transition-time ease-in-out;
-      margin: 0px;
+      margin: $m-atom-switch-circle;
       display: block;
+
+      &Loading {
+        color: $c-atom-switch-circle-loading;
+        height: $h-atom-switch-circle-loading;
+        left: $l-atom-switch-circle-loading;
+        position: relative;
+        top: $t-atom-switch-circle-loading;
+        width: $w-atom-switch-circle-loading;
+      }
     }
 
     #{$base-class}-icon-right,
@@ -208,6 +217,13 @@ $base-class: '.sui-AtomSwitch';
             border-radius: $w-atom-switch-small * 0.5;
             height: $h-atom-switch-input-container-small - 2px;
             width: $h-atom-switch-input-container-small - 2px;
+
+            &Loading {
+              height: $h-atom-switch-circle-loading-small;
+              left: $l-atom-switch-circle-loading-small;
+              top: $t-atom-switch-circle-loading-small - 1px;
+              width: $w-atom-switch-circle-loading-small;
+            }
           }
           &--right {
             #{$base-class}-circle {

--- a/components/atom/switch/src/styles/settings.scss
+++ b/components/atom/switch/src/styles/settings.scss
@@ -35,3 +35,18 @@ $bd-atom-switch-default: $bdw-atom-switch-default solid color-variation($c-atom-
 $bxsh-atom-switch-container: 0 0 4px 0 transparent !default;
 
 $atom-switch-transition-time: 0.3s !default;
+
+$bd-atom-switch-circle: $bdw-s solid $c-atom-switch-circle !default;
+$bxsh-atom-switch-circle: 2px 0 2px 0 $c-gray-light !default;
+$m-atom-switch-circle: 0px !default;
+
+$c-atom-switch-circle-loading: currentColor !default;
+$t-atom-switch-circle-loading: 20% !default;
+$w-atom-switch-circle-loading: 60% !default;
+$h-atom-switch-circle-loading: 60% !default;
+$l-atom-switch-circle-loading: 20% !default;
+
+$t-atom-switch-circle-loading-small: 0 !default;
+$w-atom-switch-circle-loading-small: 100% !default;
+$h-atom-switch-circle-loading-small: 100% !default;
+$l-atom-switch-circle-loading-small: 0 !default;

--- a/components/primitive/loadingIcon/src/index.scss
+++ b/components/primitive/loadingIcon/src/index.scss
@@ -1,8 +1,8 @@
 @import '~@s-ui/theme/lib/index';
 
 $bdw-primitive-loading-icon: $bdw-m !default;
-$w-primitive-loading-icon: 1em !default;
-$h-primitive-loading-icon: 1em !default;
+$w-primitive-loading-icon: 100% !default;
+$h-primitive-loading-icon: 100% !default;
 
 @keyframes spin {
   0% {
@@ -23,5 +23,4 @@ $h-primitive-loading-icon: 1em !default;
   width: $w-primitive-loading-icon;
   height: $h-primitive-loading-icon;
   box-sizing: border-box;
-  position: absolute;
 }


### PR DESCRIPTION
## atom/switch
#### `🔍 Show`

### Description, Motivation and Context

This PR adds a new property to the `atom/switch` component. If set to `true`, the component will show a loading icon (similar to the behavior of `atom/button`).

### Types of changes

- [x] ✨ New feature (non-breaking change which adds functionality)