### PR TITLE
Avoid add event listeners unconditionally

### DIFF
--- a/components/molecule/select/src/index.js
+++ b/components/molecule/select/src/index.js
@@ -20,7 +20,14 @@ import {moleculeDropdownListSizes as SIZES} from '@s-ui/react-molecule-dropdown-
 
 import MoleculeSelectMultipleSelection from './components/MultipleSelection.js'
 import MoleculeSelectSingleSelection from './components/SingleSelection.js'
-import {DropdownContext, ENABLED_KEYS, getClassName, getOptionData, SELECT_STATES, SELECTION_KEYS} from './config.js'
+import {
+  DropdownContext,
+  ENABLED_KEYS,
+  getClassName,
+  getOptionData,
+  SELECT_STATES,
+  SELECTION_KEYS
+} from './config.js'
 
 const useFunctionalRef = () => useReducer((_s, node) => node, null)
 
@@ -97,7 +104,10 @@ const MoleculeSelect = forwardRef((props, forwardedRef) => {
   const handleOutsideClick = useCallback(
     ev => {
       if (disabled) return
-      if (refMoleculeSelect.current && !refMoleculeSelect.current.contains(ev.target)) {
+      if (
+        refMoleculeSelect.current &&
+        !refMoleculeSelect.current.contains(ev.target)
+      ) {
         // outside click
         closeList(ev, {isOutsideEvent: true})
         setFocus(false)
@@ -108,7 +118,9 @@ const MoleculeSelect = forwardRef((props, forwardedRef) => {
 
   const focusFirstOption = useCallback(
     ev => {
-      const options = refsMoleculeSelectOptions.current.map(option => getTarget(option.current))
+      const options = refsMoleculeSelectOptions.current.map(option =>
+        getTarget(option.current)
+      )
       options[0] && options[0].focus()
       ev.preventDefault()
       ev.stopPropagation()
@@ -127,15 +139,19 @@ const MoleculeSelect = forwardRef((props, forwardedRef) => {
   )
 
   const isFirstOptionFocused = useCallback(() => {
-    const options = refsMoleculeSelectOptions.current.map(option => getTarget(option.current))
+    const options = refsMoleculeSelectOptions.current.map(option =>
+      getTarget(option.current)
+    )
 
     return document.activeElement === options[0]
   }, [refsMoleculeSelectOptions])
 
   useEffect(() => {
-    Object.assign(refOptions.current, getOptionData(children))
-    document.addEventListener('touchend', handleOutsideClick)
-    document.addEventListener('mousedown', handleOutsideClick)
+    if (isOpenState) {
+      Object.assign(refOptions.current, getOptionData(children))
+      document.addEventListener('touchend', handleOutsideClick)
+      document.addEventListener('mousedown', handleOutsideClick)
+    }
 
     return () => {
       document.removeEventListener('touchend', handleOutsideClick)
@@ -174,7 +190,9 @@ const MoleculeSelect = forwardRef((props, forwardedRef) => {
       !hasSearch && setTimeout(() => focusFirstOption(ev))
     }
   }
-  const Select = multiselection ? MoleculeSelectMultipleSelection : MoleculeSelectSingleSelection
+  const Select = multiselection
+    ? MoleculeSelectMultipleSelection
+    : MoleculeSelectSingleSelection
 
   const context = {
     hasSearch,

--- a/components/molecule/select/src/index.js
+++ b/components/molecule/select/src/index.js
@@ -20,14 +20,7 @@ import {moleculeDropdownListSizes as SIZES} from '@s-ui/react-molecule-dropdown-
 
 import MoleculeSelectMultipleSelection from './components/MultipleSelection.js'
 import MoleculeSelectSingleSelection from './components/SingleSelection.js'
-import {
-  DropdownContext,
-  ENABLED_KEYS,
-  getClassName,
-  getOptionData,
-  SELECT_STATES,
-  SELECTION_KEYS
-} from './config.js'
+import {DropdownContext, ENABLED_KEYS, getClassName, getOptionData, SELECT_STATES, SELECTION_KEYS} from './config.js'
 
 const useFunctionalRef = () => useReducer((_s, node) => node, null)
 
@@ -104,10 +97,7 @@ const MoleculeSelect = forwardRef((props, forwardedRef) => {
   const handleOutsideClick = useCallback(
     ev => {
       if (disabled) return
-      if (
-        refMoleculeSelect.current &&
-        !refMoleculeSelect.current.contains(ev.target)
-      ) {
+      if (refMoleculeSelect.current && !refMoleculeSelect.current.contains(ev.target)) {
         // outside click
         closeList(ev, {isOutsideEvent: true})
         setFocus(false)
@@ -118,9 +108,7 @@ const MoleculeSelect = forwardRef((props, forwardedRef) => {
 
   const focusFirstOption = useCallback(
     ev => {
-      const options = refsMoleculeSelectOptions.current.map(option =>
-        getTarget(option.current)
-      )
+      const options = refsMoleculeSelectOptions.current.map(option => getTarget(option.current))
       options[0] && options[0].focus()
       ev.preventDefault()
       ev.stopPropagation()
@@ -139,16 +127,14 @@ const MoleculeSelect = forwardRef((props, forwardedRef) => {
   )
 
   const isFirstOptionFocused = useCallback(() => {
-    const options = refsMoleculeSelectOptions.current.map(option =>
-      getTarget(option.current)
-    )
+    const options = refsMoleculeSelectOptions.current.map(option => getTarget(option.current))
 
     return document.activeElement === options[0]
   }, [refsMoleculeSelectOptions])
 
   useEffect(() => {
+    Object.assign(refOptions.current, getOptionData(children))
     if (isOpenState) {
-      Object.assign(refOptions.current, getOptionData(children))
       document.addEventListener('touchend', handleOutsideClick)
       document.addEventListener('mousedown', handleOutsideClick)
     }
@@ -190,9 +176,7 @@ const MoleculeSelect = forwardRef((props, forwardedRef) => {
       !hasSearch && setTimeout(() => focusFirstOption(ev))
     }
   }
-  const Select = multiselection
-    ? MoleculeSelectMultipleSelection
-    : MoleculeSelectSingleSelection
+  const Select = multiselection ? MoleculeSelectMultipleSelection : MoleculeSelectSingleSelection
 
   const context = {
     hasSearch,

--- a/components/molecule/select/src/index.js
+++ b/components/molecule/select/src/index.js
@@ -157,7 +157,7 @@ const MoleculeSelect = forwardRef((props, forwardedRef) => {
       document.removeEventListener('touchend', handleOutsideClick)
       document.removeEventListener('mousedown', handleOutsideClick)
     }
-  }, [children, handleOutsideClick])
+  }, [children, handleOutsideClick, isOpenState])
 
   useEffect(() => {
     isOpenState && setTimeout(() => focusSearchInput())

--- a/components/molecule/selectPopover/src/index.js
+++ b/components/molecule/selectPopover/src/index.js
@@ -1,24 +1,11 @@
-import {
-  cloneElement,
-  Fragment,
-  useCallback,
-  useEffect,
-  useRef,
-  useState
-} from 'react'
+import {cloneElement, Fragment, useCallback, useEffect, useRef, useState} from 'react'
 
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 
 import usePortal from '@s-ui/react-hook-use-portal'
 
-import {
-  BASE_CLASS,
-  getPlacement,
-  OVERLAY_TYPES,
-  PLACEMENTS,
-  SIZES
-} from './config.js'
+import {BASE_CLASS, getPlacement, OVERLAY_TYPES, PLACEMENTS, SIZES} from './config.js'
 import RenderActions from './RenderActions.js'
 
 function usePrevious(value) {
@@ -71,8 +58,7 @@ const MoleculeSelectPopover = ({
   const contentWrapperRef = useRef()
   const {Portal} = usePortal({target: overlayContentRef.current})
 
-  const hasOverlay =
-    Boolean(overlayContentRef.current) && overlayType !== OVERLAY_TYPES.NONE
+  const hasOverlay = Boolean(overlayContentRef.current) && overlayType !== OVERLAY_TYPES.NONE
 
   useEffect(() => {
     forceClosePopover && setIsOpen(false)
@@ -90,15 +76,10 @@ const MoleculeSelectPopover = ({
     }
 
     const getPopoverClassName = () => {
-      if (
-        isOpen &&
-        [PLACEMENTS.AUTO_END, PLACEMENTS.AUTO_START].includes(placement)
-      ) {
-        const {left, right} =
-          contentWrapperRef.current?.getBoundingClientRect() || {}
+      if (isOpen && [PLACEMENTS.AUTO_END, PLACEMENTS.AUTO_START].includes(placement)) {
+        const {left, right} = contentWrapperRef.current?.getBoundingClientRect() || {}
         const outFromTheLeftSide = left < 0
-        const outFromTheRightSide =
-          right > (window.innerWidth || document.documentElement.clientWidth)
+        const outFromTheRightSide = right > (window.innerWidth || document.documentElement.clientWidth)
 
         if (outFromTheRightSide) {
           return cx(`${popoverBaseClass}`, `${popoverBaseClass}--left`)
@@ -107,10 +88,7 @@ const MoleculeSelectPopover = ({
         }
       }
 
-      return cx(
-        `${popoverBaseClass}`,
-        `${popoverBaseClass}--${getPlacement(placement)}`
-      )
+      return cx(`${popoverBaseClass}`, `${popoverBaseClass}--${getPlacement(placement)}`)
     }
 
     setPopoverClassName(getPopoverClassName())
@@ -276,12 +254,7 @@ const MoleculeSelectPopover = ({
       </div>
       {hasOverlay && (
         <Portal as={Fragment} isOpen={isOpen}>
-          <div
-            className={cx(
-              `${BASE_CLASS}-overlay`,
-              `${BASE_CLASS}-overlay--${overlayType}`
-            )}
-          />
+          <div className={cx(`${BASE_CLASS}-overlay`, `${BASE_CLASS}-overlay--${overlayType}`)} />
         </Portal>
       )}
     </>
@@ -320,12 +293,7 @@ MoleculeSelectPopover.propTypes = {
   onOpen: PropTypes.func,
   overlayContentRef: PropTypes.object,
   overlayType: PropTypes.oneOf(Object.values(OVERLAY_TYPES)),
-  placement: PropTypes.oneOf([
-    PLACEMENTS.AUTO_END,
-    PLACEMENTS.AUTO_START,
-    PLACEMENTS.LEFT,
-    PLACEMENTS.RIGHT
-  ]),
+  placement: PropTypes.oneOf([PLACEMENTS.AUTO_END, PLACEMENTS.AUTO_START, PLACEMENTS.LEFT, PLACEMENTS.RIGHT]),
   renderContentWrapper: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   renderSelect: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   renderActions: PropTypes.node,

--- a/components/molecule/selectPopover/src/index.js
+++ b/components/molecule/selectPopover/src/index.js
@@ -1,11 +1,24 @@
-import {cloneElement, Fragment, useCallback, useEffect, useRef, useState} from 'react'
+import {
+  cloneElement,
+  Fragment,
+  useCallback,
+  useEffect,
+  useRef,
+  useState
+} from 'react'
 
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 
 import usePortal from '@s-ui/react-hook-use-portal'
 
-import {BASE_CLASS, getPlacement, OVERLAY_TYPES, PLACEMENTS, SIZES} from './config.js'
+import {
+  BASE_CLASS,
+  getPlacement,
+  OVERLAY_TYPES,
+  PLACEMENTS,
+  SIZES
+} from './config.js'
 import RenderActions from './RenderActions.js'
 
 function usePrevious(value) {
@@ -58,7 +71,8 @@ const MoleculeSelectPopover = ({
   const contentWrapperRef = useRef()
   const {Portal} = usePortal({target: overlayContentRef.current})
 
-  const hasOverlay = Boolean(overlayContentRef.current) && overlayType !== OVERLAY_TYPES.NONE
+  const hasOverlay =
+    Boolean(overlayContentRef.current) && overlayType !== OVERLAY_TYPES.NONE
 
   useEffect(() => {
     forceClosePopover && setIsOpen(false)
@@ -76,10 +90,15 @@ const MoleculeSelectPopover = ({
     }
 
     const getPopoverClassName = () => {
-      if (isOpen && [PLACEMENTS.AUTO_END, PLACEMENTS.AUTO_START].includes(placement)) {
-        const {left, right} = contentWrapperRef.current?.getBoundingClientRect() || {}
+      if (
+        isOpen &&
+        [PLACEMENTS.AUTO_END, PLACEMENTS.AUTO_START].includes(placement)
+      ) {
+        const {left, right} =
+          contentWrapperRef.current?.getBoundingClientRect() || {}
         const outFromTheLeftSide = left < 0
-        const outFromTheRightSide = right > (window.innerWidth || document.documentElement.clientWidth)
+        const outFromTheRightSide =
+          right > (window.innerWidth || document.documentElement.clientWidth)
 
         if (outFromTheRightSide) {
           return cx(`${popoverBaseClass}`, `${popoverBaseClass}--left`)
@@ -88,7 +107,10 @@ const MoleculeSelectPopover = ({
         }
       }
 
-      return cx(`${popoverBaseClass}`, `${popoverBaseClass}--${getPlacement(placement)}`)
+      return cx(
+        `${popoverBaseClass}`,
+        `${popoverBaseClass}--${getPlacement(placement)}`
+      )
     }
 
     setPopoverClassName(getPopoverClassName())
@@ -126,7 +148,10 @@ const MoleculeSelectPopover = ({
         handleOnCancel()
       }
     }
-    window.addEventListener('mousedown', handleClickOutside)
+
+    if (isOpen) {
+      window.addEventListener('mousedown', handleClickOutside)
+    }
 
     return () => {
       window.removeEventListener('mousedown', handleClickOutside)
@@ -251,7 +276,12 @@ const MoleculeSelectPopover = ({
       </div>
       {hasOverlay && (
         <Portal as={Fragment} isOpen={isOpen}>
-          <div className={cx(`${BASE_CLASS}-overlay`, `${BASE_CLASS}-overlay--${overlayType}`)} />
+          <div
+            className={cx(
+              `${BASE_CLASS}-overlay`,
+              `${BASE_CLASS}-overlay--${overlayType}`
+            )}
+          />
         </Portal>
       )}
     </>
@@ -290,7 +320,12 @@ MoleculeSelectPopover.propTypes = {
   onOpen: PropTypes.func,
   overlayContentRef: PropTypes.object,
   overlayType: PropTypes.oneOf(Object.values(OVERLAY_TYPES)),
-  placement: PropTypes.oneOf([PLACEMENTS.AUTO_END, PLACEMENTS.AUTO_START, PLACEMENTS.LEFT, PLACEMENTS.RIGHT]),
+  placement: PropTypes.oneOf([
+    PLACEMENTS.AUTO_END,
+    PLACEMENTS.AUTO_START,
+    PLACEMENTS.LEFT,
+    PLACEMENTS.RIGHT
+  ]),
   renderContentWrapper: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   renderSelect: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   renderActions: PropTypes.node,


### PR DESCRIPTION
## MOLECULE/SELECT
## MOLECULE/SELECTPOPOVER

### Description, Motivation and Context
We have detected that when we click in any part of the window the events are triggered too and this is increasing the tasks of the intereactions.
The motivation of this change is improve INP

### Types of changes

- [X] 🪲 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
