### PR TITLE
fix(components/molecule/photoUploader): Avoid crashes on getExifOrien…

### DIFF
--- a/components/molecule/photoUploader/src/photoTools.js
+++ b/components/molecule/photoUploader/src/photoTools.js
@@ -256,6 +256,10 @@ function getExifOrientation(file) {
       const length = view.byteLength
       let offset = 2
       while (offset < length) {
+        if (offset + 2 > view.byteLength) {
+          break
+        }
+
         if (view.getUint16(offset + 2, false) <= 8) resolve(-1)
         const marker = view.getUint16(offset, false)
         offset += 2


### PR DESCRIPTION
…tation

## molecule/photoUploader

#### `🔍 Show`

### Description, Motivation and Context

`getExifOrientation` was crashing sometimes. This change doesn't modify its functionality, but avoid crashes and ensures the flow works as expected even if the function cannot offer a specific result.

### Types of changes

- [X] 🪲 Bug fix (non-breaking change which fixes an issue)
