### PR TITLE
Feature/avoid page scrolling when drawer open prop

### DIFF
--- a/components/molecule/drawer/demo/DemoPageScrollable.js
+++ b/components/molecule/drawer/demo/DemoPageScrollable.js
@@ -1,0 +1,52 @@
+import {useRef, useState} from 'react'
+
+import PropTypes from 'prop-types'
+
+import {Article, Box, H2, H4, Label, Paragraph, RadioButton} from '@s-ui/documentation-library'
+
+import {MoleculeDrawer, moleculeDrawerSizes} from '../src/index.js'
+
+const DemoPageScroll = ({className}) => {
+  const [opened, setOpened] = useState(false)
+  const drawerRef = useRef()
+
+  return (
+    <Article className={className}>
+      <H2>Page scroll</H2>
+      <Paragraph>The drawer can avoid the page to scroll when is opened</Paragraph>
+      <RadioButton label={<Label>OPEN</Label>} checked={opened} onClick={() => setOpened(!opened)} />
+      <br />
+      <br />
+      <Box
+        style={{
+          backgroundColor: '#f5f5f5',
+          padding: 0
+        }}
+      >
+        <div style={{height: '25%', width: '100%'}}>
+          <MoleculeDrawer
+            isOpen={opened}
+            onOpen={(event, {isOpen}) => {
+              setOpened(isOpen)
+            }}
+            onClose={(event, {isOpen}) => {
+              setOpened(isOpen)
+            }}
+            size={moleculeDrawerSizes.M}
+            isPageScrollable={false}
+            ref={drawerRef}
+            closeOnOutsideClick
+          >
+            <H4>None</H4>
+          </MoleculeDrawer>
+        </div>
+      </Box>
+    </Article>
+  )
+}
+
+DemoPageScroll.propTypes = {
+  className: PropTypes.string
+}
+
+export default DemoPageScroll

--- a/components/molecule/drawer/demo/index.js
+++ b/components/molecule/drawer/demo/index.js
@@ -5,6 +5,7 @@ import {Anchor, Button, Code, H1, Label, ListItem, Paragraph, UnorderedList} fro
 import {MoleculeDrawer, moleculeDrawerPlacements, moleculeDrawerSizes} from '../src/index.js'
 import DemoAnimationDuration from './DemoAnimationDuration.js'
 import DemoDefault from './DemoDefault.js'
+import DemoPageScrollable from './DemoPageScrollable.js'
 import DemoPlacement from './DemoPlacement.js'
 import DemoSize from './DemoSize.js'
 
@@ -58,6 +59,7 @@ const Demo = () => {
         <DemoSize className={CLASS_SECTION} />
         <br />
         <DemoAnimationDuration className={CLASS_SECTION} />
+        <DemoPageScrollable className={CLASS_SECTION} />
       </div>
     </>
   )

--- a/components/molecule/drawer/src/index.js
+++ b/components/molecule/drawer/src/index.js
@@ -21,6 +21,7 @@ const MoleculeDrawer = forwardRef(
       animationDuration = moleculeDrawerAnimationDuration.FAST,
       children,
       isOpen = false,
+      isPageScrollable = true,
       onOpen,
       onClose,
       placement = moleculeDrawerPlacements.LEFT,
@@ -37,19 +38,35 @@ const MoleculeDrawer = forwardRef(
       }
     }, [target])
 
+    useEffect(() => {
+      if (isOpen && !isPageScrollable) blockScrollPage()
+      else if (!isOpen && !isPageScrollable) enableScrollPage()
+
+      if (!isPageScrollable) return () => enableScrollPage()
+    }, [isOpen, isPageScrollable])
+
+    const closeDrawer = event => {
+      if (!isPageScrollable) enableScrollPage()
+
+      onClose(event, {isOpen: false})
+    }
+
     useEventListener('keydown', event => {
       if (isOpen === false) return
       if (event.key === 'Escape') {
-        onClose(event, {isOpen: false})
+        closeDrawer(event)
       }
     })
 
     useEventListener('mousedown', event => {
       if (isOpen === false || !forwardedRef || !closeOnOutsideClick) return
       if (!forwardedRef.current.contains(event.target)) {
-        onClose(event, {isOpen: false})
+        closeDrawer(event)
       }
     })
+
+    const blockScrollPage = () => (document.body.style.overflow = 'hidden')
+    const enableScrollPage = () => (document.body.style.overflow = 'auto')
 
     return (
       <div
@@ -79,6 +96,8 @@ MoleculeDrawer.propTypes = {
   children: PropTypes.node,
   /** Tells if the drawer is open or not */
   isOpen: PropTypes.bool,
+  /** false to prevent scroll body */
+  isPageScrollable: PropTypes.bool,
   /** On open callback triggered after animation */
   onOpen: PropTypes.func,
   /** On close callback triggered after animation */

--- a/components/molecule/drawer/test/index.test.js
+++ b/components/molecule/drawer/test/index.test.js
@@ -199,4 +199,31 @@ describe(json.name, () => {
       })
     })
   })
+
+  describe('moleculeDrawerPageScrollable', () => {
+    it('should set the body overflow style to hidden when is opened and overflow to auto when is not opened', () => {
+      // Given
+      const props = {
+        isOpen: true,
+        isPageScrollable: false
+      }
+
+      // When
+      const {rerender} = render(<Component {...props} />)
+      const overflowStyleHidden = document.body.style.overflow
+
+      // Then
+      expect(overflowStyleHidden).to.be.equal('hidden')
+
+      // When
+      const newProps = {
+        isOpen: false
+      }
+      rerender(<Component {...newProps} />)
+      const overflowStyleAuto = document.body.style.overflow
+
+      // Then
+      expect(overflowStyleAuto).to.be.equal('auto')
+    })
+  })
 })


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
`🔍 Show`
<!-- #### `❓ Ask` -->

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
Allow a new prop to avoid the scroll on a page when the drawer is opened. The same feature is already implemented in the molecule/modal component.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [X] 📷 Demo
- [X] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool


