### PR TITLE
feat(components/atom/button): Allow SUI button to have an alternate colors for oultine, flat and link variations

### DIFF
--- a/components/atom/button/src/styles/index.scss
+++ b/components/atom/button/src/styles/index.scss
@@ -133,6 +133,8 @@ $base-class: '.sui-AtomButton';
   @each $name, $pair in $c-atom-button-colors {
     $color: nth($pair, 1);
     $color-invert: nth($pair, 2);
+    // Alternate color for Outline, Flat and Link variations
+    $color-alt: if(length($pair) > 4, nth($pair, 5), $color);
 
     &--#{$name} {
       &#{$base-class}--solid {
@@ -165,8 +167,8 @@ $base-class: '.sui-AtomButton';
         $c-atom-button-focused: $color !default;
         $c-atom-button-focused-invert: $color-invert !default;
 
-        border-color: $color;
-        color: $color;
+        border-color: $color-alt;
+        color: $color-alt;
         text-decoration-line: none;
 
         @include button-focused {
@@ -194,7 +196,7 @@ $base-class: '.sui-AtomButton';
         $c-atom-button-link-focused: $c-atom-button-focused !default;
         $c-atom-button-focused-invert: color-variation($color-invert, -1) !default;
 
-        color: $color;
+        color: $color-alt;
         @include button-focused {
           color: $c-atom-button-link-focused;
         }


### PR DESCRIPTION
## Category/Component
#### `❓ Ask`

<!-- https://github.com/SUI-Components/sui-components/issues -->

### Description, Motivation and Context
In order to be able to further customise the SUI buttons look from a Theme, we needed to add an additional variable for an alternate colors for Outline, Flat and Link button variations.

A new color can be used in the variable _$c-atom-button-colors_ in the position 5 that overrides the default primary color for all non-solid buttons.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [x] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
Example:
![Screenshot 2024-04-30 at 16 11 57](https://github.com/SUI-Components/sui-components/assets/101415581/e1fa079a-517a-4e47-a5b1-e31821747555)

