### PR TITLE
feat(components/molecule/tabs): Add additional SCSS color variable for SUI tabs component

### DIFF
--- a/components/molecule/tabs/src/_settings.scss
+++ b/components/molecule/tabs/src/_settings.scss
@@ -16,7 +16,7 @@ $bt-sui-molecule-tabs-content: $bdw-sui-molecule-tabs-highlighted solid $bdc-sui
 $c-sui-molecule-tabs-active: $c-primary !default;
 $c-sui-molecule-tabs-disabled: $c-gray-lightest !default;
 $c-sui-molecule-tabs-highlighted-active: $c-primary !default;
-$c-sui-molecule-tabs-icon-active: red !default;
+$c-sui-molecule-tabs-icon-active: $c-primary !default;
 $c-sui-molecule-tabs: $c-gray-dark-3 !default;
 $fw-sui-molecule-tabs-active: $fw-regular !default;
 $fw-sui-molecule-tabs: inherit !default;

--- a/components/molecule/tabs/src/_settings.scss
+++ b/components/molecule/tabs/src/_settings.scss
@@ -3,7 +3,7 @@ $bb-sui-molecule-tabs-fullwidth: 1px solid $bdc-sui-molecule-tabs !default;
 $bc-sui-molecule-tabs-highlighted: transparent !default;
 $bdc-sui-molecule-tabs-highlighted-vertical-right: $bdc-sui-molecule-tabs !default;
 $bdc-sui-molecule-tabs-highlighted: transparent !default;
-$bdbc-sui-molecule-tabs-highlighted-active: $c-primary !default;
+$bdc-sui-molecule-tabs-highlighted-active: $c-primary !default;
 $bdrs-sui-molecule-tabs: 0 !default;
 $bdw-sui-molecule-tabs: $p-s !default;
 $bdw-sui-molecule-tabs-highlighted-active: $bdw-sui-molecule-tabs !default;

--- a/components/molecule/tabs/src/_settings.scss
+++ b/components/molecule/tabs/src/_settings.scss
@@ -3,6 +3,7 @@ $bb-sui-molecule-tabs-fullwidth: 1px solid $bdc-sui-molecule-tabs !default;
 $bc-sui-molecule-tabs-highlighted: transparent !default;
 $bdc-sui-molecule-tabs-highlighted-vertical-right: $bdc-sui-molecule-tabs !default;
 $bdc-sui-molecule-tabs-highlighted: transparent !default;
+$bdbc-sui-molecule-tabs-highlighted-active: $c-primary !default;
 $bdrs-sui-molecule-tabs: 0 !default;
 $bdw-sui-molecule-tabs: $p-s !default;
 $bdw-sui-molecule-tabs-highlighted-active: $bdw-sui-molecule-tabs !default;
@@ -15,7 +16,7 @@ $bt-sui-molecule-tabs-content: $bdw-sui-molecule-tabs-highlighted solid $bdc-sui
 $c-sui-molecule-tabs-active: $c-primary !default;
 $c-sui-molecule-tabs-disabled: $c-gray-lightest !default;
 $c-sui-molecule-tabs-highlighted-active: $c-primary !default;
-$c-sui-molecule-tabs-icon-active: $c-primary !default;
+$c-sui-molecule-tabs-icon-active: red !default;
 $c-sui-molecule-tabs: $c-gray-dark-3 !default;
 $fw-sui-molecule-tabs-active: $fw-regular !default;
 $fw-sui-molecule-tabs: inherit !default;

--- a/components/molecule/tabs/src/styles/index.scss
+++ b/components/molecule/tabs/src/styles/index.scss
@@ -119,8 +119,8 @@ $item-base-class: '#{$base-class}-item';
 
       &.is-active {
         background: $bgc-sui-molecule-tabs-active;
-        border-bottom: $bdw-sui-molecule-tabs-highlighted-active solid $c-primary;
-        border-bottom-color: $c-primary;
+        border-bottom: $bdw-sui-molecule-tabs-highlighted-active solid $bdbc-sui-molecule-tabs-highlighted-active;
+        border-bottom-color: $bdbc-sui-molecule-tabs-highlighted-active;
         color: $c-sui-molecule-tabs-highlighted-active;
         font-weight: $fw-sui-molecule-tabs-active;
 
@@ -154,7 +154,7 @@ $item-base-class: '#{$base-class}-item';
 
       &.is-active {
         background: $bgc-sui-molecule-tabs-active;
-        border-right: $bdw-sui-molecule-tabs-highlighted-active solid $c-primary;
+        border-right: $bdw-sui-molecule-tabs-highlighted-active solid $bdbc-sui-molecule-tabs-highlighted-active;
         color: $c-sui-molecule-tabs-active;
         font-weight: $fw-sui-molecule-tabs-active;
 

--- a/components/molecule/tabs/src/styles/index.scss
+++ b/components/molecule/tabs/src/styles/index.scss
@@ -119,8 +119,8 @@ $item-base-class: '#{$base-class}-item';
 
       &.is-active {
         background: $bgc-sui-molecule-tabs-active;
-        border-bottom: $bdw-sui-molecule-tabs-highlighted-active solid $bdbc-sui-molecule-tabs-highlighted-active;
-        border-bottom-color: $bdbc-sui-molecule-tabs-highlighted-active;
+        border-bottom: $bdw-sui-molecule-tabs-highlighted-active solid $bdc-sui-molecule-tabs-highlighted-active;
+        border-bottom-color: $bdc-sui-molecule-tabs-highlighted-active;
         color: $c-sui-molecule-tabs-highlighted-active;
         font-weight: $fw-sui-molecule-tabs-active;
 
@@ -154,7 +154,7 @@ $item-base-class: '#{$base-class}-item';
 
       &.is-active {
         background: $bgc-sui-molecule-tabs-active;
-        border-right: $bdw-sui-molecule-tabs-highlighted-active solid $bdbc-sui-molecule-tabs-highlighted-active;
+        border-right: $bdw-sui-molecule-tabs-highlighted-active solid $bdc-sui-molecule-tabs-highlighted-active;
         color: $c-sui-molecule-tabs-active;
         font-weight: $fw-sui-molecule-tabs-active;
 


### PR DESCRIPTION
## Category/Component
#### `❓ Ask`

<!-- https://github.com/SUI-Components/sui-components/issues -->

### Description, Motivation and Context
In order to be able to further customise the SUI tabs look from a Theme, we needed to add an additional SCSS variable for the border color of a highlighted and active tab.

A new color can be used in the variable _$bdbc-sui-molecule-tabs-highlighted-active_.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [x] 💄 Styles
- [ ] 🛠️ Tool
