### PR TITLE
feat(components/atom/slider): Add additional SCSS color variables for SUI slider component

### DIFF
--- a/components/atom/slider/src/styles/index.scss
+++ b/components/atom/slider/src/styles/index.scss
@@ -53,6 +53,7 @@ $class-tooltip-hidden: '#{$class-tooltip}-hidden';
   #{$class-handle} {
     background-color: $c-white;
     border: $b-atom-slider-handle;
+    border-color: $c-atom-slider-handle;
     height: $h-atom-slider-handle;
     margin-left: $ml-atom-slider-handle;
     margin-top: -8px;
@@ -66,7 +67,7 @@ $class-tooltip-hidden: '#{$class-tooltip}-hidden';
   }
 
   #{$class-track} {
-    background: $c-primary;
+    background: $c-atom-slider-track-active;
     height: $h-atom-slider-track;
   }
 
@@ -134,7 +135,7 @@ $class-tooltip-hidden: '#{$class-tooltip}-hidden';
 
   &--inverse {
     #{$class-rail} {
-      background: $c-primary;
+      background: $c-atom-slider-track-active;
     }
 
     #{$class-track} {

--- a/components/atom/slider/src/styles/index.scss
+++ b/components/atom/slider/src/styles/index.scss
@@ -124,7 +124,7 @@ $class-tooltip-hidden: '#{$class-tooltip}-hidden';
     }
 
     #{$class-rail} {
-      height: 8px;
+      height: $h-atom-slider-track;
     }
 
     #{$class-track} {

--- a/components/atom/slider/src/styles/settings.scss
+++ b/components/atom/slider/src/styles/settings.scss
@@ -4,6 +4,7 @@ $c-atom-slider-tooltip: $c-gray-dark !default;
 
 $c-atom-slider-rail: $c-gray-light-4 !default;
 $c-atom-slider-track: $c-gray-light !default;
+$c-atom-slider-track-active: $c-primary !default;
 
 $ff-atom-slider: $ff-sans-serif !default;
 $fz-atom-slider: $fz-m !default;
@@ -18,6 +19,7 @@ $w-atom-slider-label: auto !default;
 $w-atom-slider-handle: 24px !default;
 $b-atom-slider-handle: $bdw-s solid $c-primary !default;
 $bxsh-atom-slider-handle: none !default;
+$c-atom-slider-handle: $c-primary !default;
 
 $h-atom-slider-track: 8px !default;
 $p-atom-slider: $p-l !default;


### PR DESCRIPTION
## Category/Component
❓ Ask

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
In order to be able to further customise the SUI tabs look from a Theme, we needed to add an additional SCSS variable for the slider track and handle.

The new colors can be used in the variables `$c-atom-slider-track-active` and `$c-atom-slider-handle`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
