### PR TITLE
fix(components/primitive/typography): allow for use of className prop

### DIFF
--- a/components/primitive/typography/src/index.js
+++ b/components/primitive/typography/src/index.js
@@ -36,6 +36,7 @@ const PrimitiveTypography = ({
   ...props
 }) => {
   const {...resultingProps} = useTypography({
+    className,
     design,
     variant,
     as,

--- a/components/primitive/typography/src/useTypography.js
+++ b/components/primitive/typography/src/useTypography.js
@@ -34,19 +34,23 @@ const getClassNames = ({
   isBlurred,
   isLinked
 }) => {
-  return cx(BASE_CLASS, [`${BASE_CLASS}-design-${design}`, `${BASE_CLASS}-variant-${variant}`], {
-    [`${BASE_CLASS}-linked`]: isLinked,
-    [`${BASE_CLASS}-fontSize-${fontSize}`]: fontSize !== undefined,
-    [`${BASE_CLASS}-fontFamily-${fontFamily}`]: fontFamily !== undefined,
-    [`${BASE_CLASS}-fontWeight-${fontWeight}`]: fontWeight !== undefined,
-    [`${BASE_CLASS}-fontStyle-${fontStyle}`]: fontStyle !== undefined,
-    [`${BASE_CLASS}-fontStretch-${fontStretch}`]: fontStretch !== undefined,
-    [`${BASE_CLASS}-letterSpacing-${letterSpacing}`]: letterSpacing !== undefined,
-    [`${BASE_CLASS}-lineHeight-${lineHeight}`]: lineHeight !== undefined,
-    [`${BASE_CLASS}-textDecorationLine-${textDecorationLine}`]: textDecorationLine !== undefined,
-    [`${BASE_CLASS}-blurred-${isBlurred}`]: isBlurred !== undefined,
+  return cx(
+    BASE_CLASS,
+    [`${BASE_CLASS}-design-${design}`, `${BASE_CLASS}-variant-${variant}`],
+    {
+      [`${BASE_CLASS}-linked`]: isLinked,
+      [`${BASE_CLASS}-fontSize-${fontSize}`]: fontSize !== undefined,
+      [`${BASE_CLASS}-fontFamily-${fontFamily}`]: fontFamily !== undefined,
+      [`${BASE_CLASS}-fontWeight-${fontWeight}`]: fontWeight !== undefined,
+      [`${BASE_CLASS}-fontStyle-${fontStyle}`]: fontStyle !== undefined,
+      [`${BASE_CLASS}-fontStretch-${fontStretch}`]: fontStretch !== undefined,
+      [`${BASE_CLASS}-letterSpacing-${letterSpacing}`]: letterSpacing !== undefined,
+      [`${BASE_CLASS}-lineHeight-${lineHeight}`]: lineHeight !== undefined,
+      [`${BASE_CLASS}-textDecorationLine-${textDecorationLine}`]: textDecorationLine !== undefined,
+      [`${BASE_CLASS}-blurred-${isBlurred}`]: isBlurred !== undefined
+    },
     className
-  })
+  )
 }
 
 const useTypography = ({
@@ -87,6 +91,7 @@ const useTypography = ({
       isLinked
     })
   )
+
   return {
     ...props,
     ...{


### PR DESCRIPTION
## Primitive/Typography
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
`🔍 Show`
<!-- #### `❓ Ask` -->

**TASK**: N/A

### Description, Motivation and Context
Currently, passing `className` to `<PrimitiveTypography/>` as a prop doesn't do anything, although it is documented as a legit prop.

This fixes the issue and allows for the extension of styles via classes when using this component.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Code example

Given this piece of React code:

```
<PrimitiveTypography as="h1" design="body-1" fontWeight="semi-bold" className="mt-TypographyBasic">
      lorem ipsum
</PrimitiveTypography>
```

The current output would be:

```html
<h1 class="sui-PrimitiveTypography sui-PrimitiveTypography-design-body-1 sui-PrimitiveTypography-variant-default sui-PrimitiveTypography-fontSize-m sui-PrimitiveTypography-fontWeight-semi-bold sui-PrimitiveTypography-lineHeight-xl">lorem ipsum</h1>
```

The fix will make the output to be:

```html
<h1 class="sui-PrimitiveTypography sui-PrimitiveTypography-design-body-1 sui-PrimitiveTypography-variant-default sui-PrimitiveTypography-fontSize-m sui-PrimitiveTypography-fontWeight-semi-bold sui-PrimitiveTypography-lineHeight-xl mt-TypographyBasic">lorem ipsum</h1>
```


