### PR TITLE
feat(components/molecule/dropdownList): Change border radious when placed on top

### DIFF
--- a/components/molecule/dropdownList/src/styles/index.scss
+++ b/components/molecule/dropdownList/src/styles/index.scss
@@ -17,6 +17,7 @@ $base-class: '.sui-MoleculeDropdownList';
     &-top {
       display: flex;
       flex-direction: column-reverse;
+      border-radius: $bdrs-dropdown-list-top;
     }
   }
 

--- a/components/molecule/dropdownList/src/styles/settings.scss
+++ b/components/molecule/dropdownList/src/styles/settings.scss
@@ -9,4 +9,5 @@ $bd-dropdown-list: $bdw-s solid color-variation($c-gray, 2) !default;
 $p-dropdown-list: $p-s !default;
 $bxsh-dropdown-list: $bxsh-l !default;
 $bdrs-dropdown-list: 0 !default;
+$bdrs-dropdown-list-top: 0 !default;
 $bxz-dropdown-list: border-box !default;


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
 #### `🔍 Show` 
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

We need a different border-radius when dropdown is placed on top since should be rendered in reverse mode

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool
