### PR TITLE
refactor(components/molecule/coachmark): Use div instead of p to wrap the step content

### DIFF
--- a/components/molecule/coachmark/src/Tooltip/index.js
+++ b/components/molecule/coachmark/src/Tooltip/index.js
@@ -56,7 +56,7 @@ const Tooltip = ({
 
           <div className={`${BASE_CLASS}-tooltipTexts`}>
             {step.title && <h1 className={`${BASE_CLASS}-tooltipHeadingText`}>{step.title}</h1>}
-            <p className={`${BASE_CLASS}-tooltipBodyText`}>{step.content}</p>
+            <div className={`${BASE_CLASS}-tooltipBodyText`}>{step.content}</div>
           </div>
         </div>
 


### PR DESCRIPTION
## molecule/coachmark
#### `🔍 Show` 

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
As you can see at the image below, currently we are wrapping the step content inside a `<p>`. It's not a good practice put inside a `<p>` some extra HTML such as a `<div>` for example. The `validateDOMNEsting` function is causing warning comments in our browser console or testing terminal. 

We have decided to change it with a `<div>` because make more sense in terms of HTML. 

### Types of changes

- [x] 🧠 Refactor

### Screenshots - Animations
![image](https://github.com/user-attachments/assets/3ea98f1e-10cd-49ef-9dae-eb1a291f7f12)

