### PR TITLE
❓feat(components/molecule/dropdownOption): change alignment of dropdown options

### DIFF
--- a/components/molecule/dropdownOption/src/styles/index.scss
+++ b/components/molecule/dropdownOption/src/styles/index.scss
@@ -98,7 +98,7 @@ $base-class: '.sui-MoleculeDropdownOption';
 
   &--withDescription {
     flex-direction: column;
-    align-items: flex-start;
+    align-items: stretch;
     justify-content: center;
     padding: $pt-molecule-dropdown-option-with-description $pl-molecule-dropdown-option;
   }


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

When using the `DropdownOption` component with a child element and a description text, both elements will be aligned to the start. If you include two elements as children, such as a text and a button, it is not possible to align these elements independently because they are already aligned to the start by the parent component.

I've changed this alignment to `stretch` so that the children elements will occupy all the full available width.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [x] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
