### PR TITLE
 make tag compatible without theme-v7 deprecated sui-theme module

### DIFF
--- a/components/atom/tag/demo/index.js
+++ b/components/atom/tag/demo/index.js
@@ -7,6 +7,7 @@ import ArticleIsFitted from './articles/ArticleIsFitted.js'
 import ArticleSize from './articles/ArticleSize.js'
 import ArticleResponsive from './articles/ArticleResponsive.js'
 import ArticleTypes from './articles/ArticleTypes.js'
+import ArticleResponsive from './articles/ArticleResponsive.js'
 import {CLASS_SECTION, closeIcon, icon} from './settings.js'
 
 import './index.scss'

--- a/components/atom/tag/demo/index.js
+++ b/components/atom/tag/demo/index.js
@@ -5,7 +5,6 @@ import ArticleDesign from './articles/ArticleDesign.js'
 import ArticleIcons from './articles/ArticleIcons.js'
 import ArticleIsFitted from './articles/ArticleIsFitted.js'
 import ArticleSize from './articles/ArticleSize.js'
-import ArticleResponsive from './articles/ArticleResponsive.js'
 import ArticleTypes from './articles/ArticleTypes.js'
 import ArticleResponsive from './articles/ArticleResponsive.js'
 import {CLASS_SECTION, closeIcon, icon} from './settings.js'
@@ -26,7 +25,7 @@ export default () => (
     <br />
     <ArticleIcons className={CLASS_SECTION} />
     <br />
-    <Article className={CLASS_SECTION}></Article>
+    <Article className={CLASS_SECTION} />
     <br />
     <ArticleTypes className={CLASS_SECTION} icon={icon} closeIcon={closeIcon} />
     <br />

--- a/components/atom/tag/src/index.js
+++ b/components/atom/tag/src/index.js
@@ -29,8 +29,8 @@ const AtomTag = forwardRef(
 
     const classNames = cx(
       'sui-AtomTag',
-      `sui-AtomTag-${size}`,
-      design && `sui-AtomTag--${design}`,
+      `sui-AtomTag--size-${size}`,
+      design && `sui-AtomTag--design-${design}`,
       icon && 'sui-AtomTag-hasIcon',
       responsive && 'sui-AtomTag--responsive',
       type && `sui-AtomTag--${type}`,

--- a/components/atom/tag/src/index.scss
+++ b/components/atom/tag/src/index.scss
@@ -1,4 +1,3 @@
-@import '~@s-ui/theme/lib/settings-compat-v7/index';
 @import '~@s-ui/theme/lib/index';
 
 @import './styles/settings.scss';

--- a/components/atom/tag/src/styles/index.scss
+++ b/components/atom/tag/src/styles/index.scss
@@ -2,19 +2,19 @@ $base-class: '.sui-AtomTag';
 
 #{$base-class} {
   $self: &;
+  border-radius: ceil($h-atom-tag-m * 0.5);
+  height: $h-atom-tag-m;
+  padding: $p-atom-tag-m;
+  border: $bd-atom-tag;
   align-items: center;
   align-content: center;
   background-color: $bgc-atom-tag;
-  border: $bd-atom-tag;
-  border-radius: ceil($h-atom-tag-m * 0.5);
   box-sizing: border-box;
   cursor: default;
   display: inline-flex;
   font-size: $fz-s;
-  height: $h-atom-tag-m;
   justify-content: center;
   margin: 0 $m-atom-tag $m-atom-tag 0;
-  padding: $p-atom-tag-m;
   position: relative;
   white-space: nowrap;
 
@@ -75,10 +75,12 @@ $base-class: '.sui-AtomTag';
 
   &-icon {
     @include icon-atom-tag(icon);
+    margin-left: 0;
   }
 
   &-secondary-icon {
     @include icon-atom-tag(icon-secondary);
+    margin-right: 0;
   }
   &-actionable {
     background-color: $bgc-atom-tag-actionable;
@@ -111,7 +113,7 @@ $base-class: '.sui-AtomTag';
       }
     }
 
-    &#{$self}--outline {
+    &#{$self}--design-outline {
       border-color: $c-atom-tag-actionable-invert;
       color: $c-atom-tag-actionable-invert;
       fill: $c-atom-tag-actionable-invert;
@@ -133,58 +135,48 @@ $base-class: '.sui-AtomTag';
     }
   }
 
-  &-small {
-    height: $h-atom-tag-s;
-    padding: $p-atom-tag-s;
-    &.sui-AtomTag-hasIcon.sui-AtomTag-hasClose {
-      padding: map-get($p-atom-tag-hasIcon-hasClose, 'small');
+  &--size {
+    &-small {
+      border-radius: ceil($h-atom-tag-s * 0.5);
+      height: $h-atom-tag-s;
+      padding: $p-atom-tag-s;
+      &.sui-AtomTag-hasIcon.sui-AtomTag-hasClose {
+        padding: map-get($p-atom-tag-hasIcon-hasClose, 'small');
+      }
+
+      & .sui-AtomTag-label {
+        line-height: $h-atom-tag-s;
+      }
+
+      .sui-AtomTag-closeable {
+        @include icon-secondary-clickable-area($h-atom-tag-s);
+      }
     }
 
-    & .sui-AtomTag-label {
-      line-height: $h-atom-tag-s;
+    &-medium {
+      height: $h-atom-tag-m;
+      padding: $p-atom-tag-m;
+      border-radius: ceil($h-atom-tag-m * 0.5);
+      &.sui-AtomTag-hasIcon.sui-AtomTag-hasClose {
+        padding: map-get($p-atom-tag-hasIcon-hasClose, 'medium');
+      }
+
+      & .sui-AtomTag-label {
+        line-height: $h-atom-tag-m;
+      }
+
+      .sui-AtomTag-closeable {
+        @include icon-secondary-clickable-area($h-atom-tag-m);
+      }
     }
 
-    .sui-AtomTag-closeable {
-      @include icon-secondary-clickable-area($h-atom-tag-s);
-    }
-
-    .sui-AtomTag-icon {
-      margin-left: 0;
-    }
-
-    .sui-AtomTag-secondary-icon {
-      margin-right: 0;
-    }
-  }
-
-  &-medium {
-    &.sui-AtomTag-hasIcon.sui-AtomTag-hasClose {
-      padding: map-get($p-atom-tag-hasIcon-hasClose, 'medium');
-    }
-  }
-
-  &-large {
-    border-radius: ceil($h-atom-tag-l * 0.5);
-    height: $h-atom-tag-l;
-    padding: $p-atom-tag-l;
-    &.sui-AtomTag-hasIcon.sui-AtomTag-hasClose {
-      padding: map-get($p-atom-tag-hasIcon-hasClose, 'large');
-    }
-
-    & .sui-AtomTag-label {
-      line-height: $h-atom-tag-l;
-    }
-
-    .sui-AtomTag-closeable {
-      @include icon-secondary-clickable-area($h-atom-tag-l);
-    }
-  }
-
-  &--responsive {
-    @include media-breakpoint-down(s) {
+    &-large {
       border-radius: ceil($h-atom-tag-l * 0.5);
       height: $h-atom-tag-l;
       padding: $p-atom-tag-l;
+      &.sui-AtomTag-hasIcon.sui-AtomTag-hasClose {
+        padding: map-get($p-atom-tag-hasIcon-hasClose, 'large');
+      }
 
       & .sui-AtomTag-label {
         line-height: $h-atom-tag-l;
@@ -196,7 +188,55 @@ $base-class: '.sui-AtomTag';
     }
   }
 
-  &--outline {
+  &--responsive {
+    border-radius: ceil($h-atom-tag-l * 0.5);
+    height: $h-atom-tag-l;
+    padding: $p-atom-tag-l;
+    & .sui-AtomTag-label {
+      line-height: $h-atom-tag-l;
+    }
+    .sui-AtomTag-closeable {
+      @include icon-secondary-clickable-area($h-atom-tag-l);
+    }
+
+    @include media-breakpoint-up(s) {
+      &#{$self}--size {
+        &-small {
+          border-radius: ceil($h-atom-tag-s * 0.5);
+          height: $h-atom-tag-s;
+          padding: $p-atom-tag-s;
+          &.sui-AtomTag-hasIcon.sui-AtomTag-hasClose {
+            padding: map-get($p-atom-tag-hasIcon-hasClose, 'small');
+          }
+
+          & .sui-AtomTag-label {
+            line-height: $h-atom-tag-s;
+          }
+
+          .sui-AtomTag-closeable {
+            @include icon-secondary-clickable-area($h-atom-tag-s);
+          }
+        }
+        &-medium {
+          height: $h-atom-tag-m;
+          padding: $p-atom-tag-m;
+          &.sui-AtomTag-hasIcon.sui-AtomTag-hasClose {
+            padding: map-get($p-atom-tag-hasIcon-hasClose, 'medium');
+          }
+
+          & .sui-AtomTag-label {
+            line-height: $h-atom-tag-m;
+          }
+
+          .sui-AtomTag-closeable {
+            @include icon-secondary-clickable-area($h-atom-tag-m);
+          }
+        }
+      }
+    }
+  }
+
+  &--design-outline {
     background-color: $bgc-atom-tag-outline;
     border: $bdw-atom-tag-outline solid $bc-atom-tag-outline;
   }


### PR DESCRIPTION
# Atom/Tag
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
`🔍 Show`
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [x] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
