### PR TITLE
feat(components/atom/input): Enable full input features on Mask input

### DIFF
--- a/components/atom/input/demo/index.js
+++ b/components/atom/input/demo/index.js
@@ -152,6 +152,25 @@ const TypeDemo = () => {
             }
           ],
           [
+            'MASK WITH RIGHT ICON',
+            {
+              type: inputTypes.MASK,
+              mask: {mask: 'ES00 0000 0000 00 0000000000'},
+              placeholder: 'ES00 0000 0000 00 0000000000',
+              charsSize: 31,
+              value: 'ES1234567890123456789012',
+              rightIcon: '€'
+            },
+            {
+              description: (
+                <>
+                  Let the user define its own mask for custom purposes. More info at{' '}
+                  <Anchor href="http://shorturl.at/foBF1">http://shorturl.at/foBF1</Anchor>
+                </>
+              )
+            }
+          ],
+          [
             'NUMBER',
             {
               type: inputTypes.NUMBER,

--- a/components/atom/input/demo/index.js
+++ b/components/atom/input/demo/index.js
@@ -155,11 +155,14 @@ const TypeDemo = () => {
             'MASK WITH RIGHT ICON',
             {
               type: inputTypes.MASK,
-              mask: {mask: 'ES00 0000 0000 00 0000000000'},
+              mask: {mask: Number},
               placeholder: 'ES00 0000 0000 00 0000000000',
               charsSize: 31,
-              value: 'ES1234567890123456789012',
-              rightIcon: '€'
+              value: '100000',
+              rightIcon: '€',
+              radix: ',',
+              thousandsSeparator: '.',
+              mapToRadix: ['.']
             },
             {
               description: (

--- a/components/atom/input/src/Mask/iMask.js
+++ b/components/atom/input/src/Mask/iMask.js
@@ -1,6 +1,6 @@
 import {IMaskMixin} from 'react-imask'
 
-import Input from '../Input/Component/index.js'
+import Input from '../Input/index.js'
 
 const IMask = IMaskMixin(({inputRef, value, size, ...props}) => {
   return <Input type="text" ref={inputRef} size={size} value={value} {...props} />

--- a/components/atom/input/test/index.test.js
+++ b/components/atom/input/test/index.test.js
@@ -387,6 +387,32 @@ describe(json.name, () => {
       expect(findClassName(container.innerHTML)).to.be.null
       expect(value).to.equal('')
     })
+
+    it('should be able to display addons', () => {
+      const props = {
+        className: 'extended-classNames',
+        type: pkg.inputTypes.MASK,
+        mask: {mask: Number},
+        placeholder: 'Ex: 100.000,00',
+        charsSize: 31,
+        value: '100000',
+        rightIcon: '€',
+        radix: ',',
+        thousandsSeparator: '.',
+        mapToRadix: ['.'],
+        leftAddon: 'leftAddon',
+        rightAddon: 'rightAddon'
+      }
+
+      // When
+      const {getByRole, getByText} = setup(props)
+      const input = getByRole('textbox')
+
+      // Then
+      expect(input).to.have.value('100.000')
+      expect(getByText('leftAddon')).to.exist
+      expect(getByText('rightAddon')).to.exist
+    })
   })
 
   describe(`${Component.displayName} ${pkg.inputTypes.SUI_PASSWORD}`, () => {


### PR DESCRIPTION
## Atom/Input

#### `❓ Ask`

### Description, Motivation and Context

When we use the `AtomInput` with `type=mask`, we are not able to use all capabilities for other AtomInputs, such as: `rightIcons`, `leftIcons`, `buttons`, ...

With this Pull Requests, we are enabling this possibility. 

### Types of changes

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
![image](https://github.com/user-attachments/assets/8f2babd6-56a7-4cbc-bc02-0d9edebe082a)


