### PR TITLE
Feature/remove button molecule select popover

### DIFF
--- a/components/molecule/selectPopover/demo/Icons/index.js
+++ b/components/molecule/selectPopover/demo/Icons/index.js
@@ -27,4 +27,12 @@ const IconArrowDown = props => (
   </AtomIcon>
 )
 
-export {IconCheck, IconHalfCheck, IconArrowDown}
+const IconClose = props => (
+  <AtomIcon {...props}>
+    <svg viewBox="0 0 24 24">
+      <path d="M 4.7070312 3.2929688 L 3.2929688 4.7070312 L 10.585938 12 L 3.2929688 19.292969 L 4.7070312 20.707031 L 12 13.414062 L 19.292969 20.707031 L 20.707031 19.292969 L 13.414062 12 L 20.707031 4.7070312 L 19.292969 3.2929688 L 12 10.585938 L 4.7070312 3.2929688 z"></path>
+    </svg>
+  </AtomIcon>
+)
+
+export {IconCheck, IconClose, IconHalfCheck, IconArrowDown}

--- a/components/molecule/selectPopover/demo/index.js
+++ b/components/molecule/selectPopover/demo/index.js
@@ -51,6 +51,7 @@ const Demo = () => {
   const [hasCustomRenderActions, setCustomRenderActions] = useState(false)
   const [hasForceClosePopover, setHasForceClosePopover] = useState(false)
   const [forceClosePopover, setForceClosePopover] = useState(false)
+  const [hasRemoveOption, setHasRemoveOption] = useState(false)
 
   const overlayContentRef = useRef()
 
@@ -95,6 +96,7 @@ const Demo = () => {
       </MoleculeModal>
     )
   }
+  console.log(unconfirmedItems)
 
   const checkedItems = items.filter(item => item.checked)
   const isSelected = checkedItems.length > 0
@@ -232,16 +234,36 @@ const Demo = () => {
             Force close popover
           </label>
         </div>
+        <div>
+          <label>
+            <input type="checkbox" checked={hasRemoveOption} onChange={ev => setHasRemoveOption(ev.target.checked)} />
+            With remove option
+          </label>
+        </div>
 
         <h3>Component</h3>
         <MoleculeSelectPopover
           acceptButtonText="Aceptar"
+          acceptButtonOptions={{disabled: unconfirmedItems.every(item => !item.checked)}}
           cancelButtonText="Cancelar"
           customButtonText={addCustomButton && 'Borrar'}
           customButtonOptions={{
             design: 'outline',
             negative: false,
             color: 'accent'
+          }}
+          removeButtonOptions={{
+            design: 'flat',
+            shape: 'circular',
+            size: 'medium',
+            rightIcon: IconClose,
+            isShown: isSelected,
+            negative: false,
+            onClick: () => {
+              setItems(demoExample)
+              setUnconfirmedItems(demoExample)
+              setForceClosePopover({})
+            }
           }}
           renderContentWrapper={customContentWrapper && renderContentWrapper}
           renderSelect={renderSelect && <button>Now I'm a button!</button>}

--- a/components/molecule/selectPopover/demo/index.scss
+++ b/components/molecule/selectPopover/demo/index.scss
@@ -1,9 +1,12 @@
+$c-primary-flat-hover: rgba(0, 0, 0, 0.24);
+
 @import '~@s-ui/theme/lib/index';
 @import '~@s-ui/react-molecule-modal/lib/index';
 @import '~@s-ui/react-molecule-select/lib/index';
 @import '~@s-ui/react-molecule-dropdown-option/lib/index';
 @import 'components/molecule/checkboxField/src/index';
 @import 'components/organism/nestedCheckboxes/src/index';
+@import '~@s-ui/react-atom-button/lib/index';
 @import 'components/atom/icon/src/index';
 
 @import '../src/index';

--- a/components/molecule/selectPopover/src/_settings.scss
+++ b/components/molecule/selectPopover/src/_settings.scss
@@ -6,4 +6,5 @@ $bdrs-select-popover-content: 0px !default;
 $bxsh-select-popover: 0 1px 4px 0 rgba(0, 0, 0, 0.24) !default;
 $mw-select-popover: 250px !default;
 $w-select-popover: 344px !default;
+$p-select-popover-select-with-remove: $p-m 0 $p-m $p-l !default;
 $sizes-molecule-select-popover-heights: (m $h-atom-input--m, s $h-atom-input--s, xs $h-atom-input--xs) !default;

--- a/components/molecule/selectPopover/src/components/SelectIcon.js
+++ b/components/molecule/selectPopover/src/components/SelectIcon.js
@@ -1,0 +1,51 @@
+import PropTypes from 'prop-types'
+import AtomButton, {atomButtonDesigns, atomButtonShapes, atomButtonSizes} from '@s-ui/react-atom-button'
+import {BASE_CLASS} from '../config.js'
+
+const NO_OP = () => {}
+
+const SelectIcon = ({iconArrowDown: IconArrowDown, removeButtonOptions}) => {
+  if (!removeButtonOptions) return <IconArrowDown />
+
+  const {
+    design = atomButtonDesigns.FLAT,
+    isShown = false,
+    negative = false,
+    onClick = NO_OP,
+    rightIcon: RightIcon,
+    shape = atomButtonShapes.CIRCULAR,
+    size = atomButtonSizes.MEDIUM
+  } = removeButtonOptions
+
+  const handleOnButtonClick = evt => {
+    evt.stopPropagation()
+    onClick()
+  }
+
+  return (
+    <div className={`${BASE_CLASS}-selectIcon--withRemoveOption`}>
+      <AtomButton
+        design={isShown ? design : atomButtonDesigns.LINK}
+        shape={shape}
+        size={size}
+        negative={negative}
+        rightIcon={isShown ? <RightIcon /> : <IconArrowDown />}
+        onClick={isShown ? handleOnButtonClick : NO_OP}
+      />
+    </div>
+  )
+}
+
+SelectIcon.propTypes = {
+  iconArrowDown: PropTypes.elementType.isRequired,
+  removeButtonOptions: PropTypes.shape({
+    design: PropTypes.string,
+    isShown: PropTypes.bool,
+    negative: PropTypes.bool,
+    onClick: PropTypes.func,
+    rightIcon: PropTypes.elementType.isRequired,
+    shape: PropTypes.string,
+    size: PropTypes.string
+  })
+}
+export default SelectIcon

--- a/components/molecule/selectPopover/src/index.js
+++ b/components/molecule/selectPopover/src/index.js
@@ -7,6 +7,7 @@ import usePortal from '@s-ui/react-hook-use-portal'
 
 import {BASE_CLASS, getPlacement, OVERLAY_TYPES, PLACEMENTS, SHAPES, SIZES} from './config.js'
 import RenderActions from './RenderActions.js'
+import SelectIcon from './components/SelectIcon.js'
 
 function usePrevious(value) {
   const ref = useRef()
@@ -42,6 +43,7 @@ const MoleculeSelectPopover = ({
   overlayContentRef = {},
   overlayType = OVERLAY_TYPES.NONE,
   placement,
+  removeButtonOptions = null,
   renderContentWrapper: renderContentWrapperProp,
   renderSelect: renderSelectProp,
   renderActions: renderActionsProp,
@@ -161,6 +163,7 @@ const MoleculeSelectPopover = ({
         shape && `${BASE_CLASS}-select--${shape}`,
         `${BASE_CLASS}-select--${size}`,
         {
+          [`${BASE_CLASS}-select--withRemoveOption`]: removeButtonOptions,
           'is-open': isOpen,
           'is-selected': isSelected
         }
@@ -191,6 +194,7 @@ const MoleculeSelectPopover = ({
           shape && `${BASE_CLASS}-select--${shape}`,
           `${BASE_CLASS}-select--${size}`,
           {
+            [`${BASE_CLASS}-select--withRemoveOption`]: removeButtonOptions,
             'is-open': isOpen,
             'is-selected': isSelected
           }
@@ -199,7 +203,7 @@ const MoleculeSelectPopover = ({
       >
         <span className={`${BASE_CLASS}-selectText`}>{selectText}</span>
         <div className={`${BASE_CLASS}-selectIcon`}>
-          <IconArrowDown />
+          <SelectIcon iconArrowDown={IconArrowDown} removeButtonOptions={removeButtonOptions} />
         </div>
       </div>
     )
@@ -305,6 +309,15 @@ MoleculeSelectPopover.propTypes = {
   overlayContentRef: PropTypes.object,
   overlayType: PropTypes.oneOf(Object.values(OVERLAY_TYPES)),
   placement: PropTypes.oneOf([PLACEMENTS.AUTO_END, PLACEMENTS.AUTO_START, PLACEMENTS.LEFT, PLACEMENTS.RIGHT]),
+  removeButtonOptions: PropTypes.shape({
+    design: PropTypes.string,
+    isShowng: PropTypes.bool,
+    negative: PropTypes.bool,
+    onClick: PropTypes.func,
+    rightIcon: PropTypes.elementType.isRequired,
+    shape: PropTypes.string,
+    size: PropTypes.string
+  }),
   renderContentWrapper: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   renderSelect: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   renderActions: PropTypes.node,

--- a/components/molecule/selectPopover/src/styles/index.scss
+++ b/components/molecule/selectPopover/src/styles/index.scss
@@ -37,6 +37,10 @@ $base-class: '.sui-MoleculeSelectPopover ';
       border-radius: $bdrs-select-popover-circular;
     }
 
+    &--withRemoveOption {
+      padding: $p-select-popover-select-with-remove;
+    }
+
     &Text {
       overflow: hidden;
       text-overflow: ellipsis;
@@ -45,6 +49,10 @@ $base-class: '.sui-MoleculeSelectPopover ';
 
     &Icon {
       margin-left: $m-m;
+
+      &--withRemoveOption {
+        display: flex;
+      }
     }
 
     &:hover,

--- a/components/molecule/selectPopover/test/index.test.js
+++ b/components/molecule/selectPopover/test/index.test.js
@@ -12,9 +12,11 @@ import chaiDOM from 'chai-dom'
 
 import {fireEvent} from '@testing-library/react'
 
+import sinon from 'sinon'
 import json from '../package.json'
 import {PLACEMENTS} from '../src/config.js'
 import * as pkg from '../src/index.js'
+import IconClose from '../../../atom/popover/demo/Icons/IconClose.js'
 
 chai.use(chaiDOM)
 
@@ -254,6 +256,42 @@ describe(json.name, () => {
       const select = container.querySelector('[class="sui-MoleculeSelectPopover-selectIcon"]')
       fireEvent.click(select)
       expect(container.innerHTML).to.include('sui-MoleculeSelectPopover-popover--right')
+    })
+  })
+
+  describe('selectPopover remove button', () => {
+    it('should response to the click on the remove button', () => {
+      const spy = sinon.spy()
+
+      // Given
+      const props = {
+        isSelected: true,
+        acceptButtonText: 'acceptButtonText',
+        cancelButtonText: 'cancelButtonText',
+        iconArrowDown: () => <svg />,
+        selectText: 'selectText',
+        children: 'children',
+        removeButtonOptions: {
+          design: 'flat',
+          shape: 'circular',
+          size: 'medium',
+          rightIcon: () => <IconClose />,
+          isShown: true,
+          negative: false,
+          onClick: spy
+        }
+      }
+
+      // When
+      const {container} = setup(props)
+
+      // Then
+      const removeButton = container.querySelector(
+        '[class="sui-MoleculeSelectPopover-selectIcon--withRemoveOption"] button'
+      )
+      fireEvent.click(removeButton)
+
+      sinon.assert.calledOnce(spy)
     })
   })
 })


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
`🔍 Show`
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- https://jira.ets.mpi-internal.com/browse/MTR-89499 -->

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
Requested from Motor UX, we need a remove button on the molecule select popover that allow us to remove the content selected via callback

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [X] 📷 Demo
- [X] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
![removeButton](https://github.com/user-attachments/assets/4bd90ed6-4c77-47f3-9d05-0030ba03fea1)

