### PR TITLE
feat(components/molecule/carousel): suggest use of new colour token variables

### DIFF
--- a/components/molecule/carousel/src/styles/index.scss
+++ b/components/molecule/carousel/src/styles/index.scss
@@ -1,9 +1,9 @@
 $base-class: '.sui-MoleculeCarousel';
 
 #{$base-class} {
-  -webkit-tap-highlight-color: $c-transparent;
+  -webkit-tap-highlight-color: $wthc-molecule-carousel;
   backface-visibility: hidden;
-  background: $c-background;
+  background: $bgc-molecule-carousel;
   min-height: $mh;
   position: relative;
   user-select: none;

--- a/components/molecule/carousel/src/styles/settings.scss
+++ b/components/molecule/carousel/src/styles/settings.scss
@@ -1,7 +1,7 @@
-$c-background: transparent !default;
+$bgc-molecule-carousel: transparent !default;
+$wthc-molecule-carousel: rgba(0, 0, 0, 0) !default;
 $c-nav-background: rgba(255, 255, 255, 0.8) !default;
 $c-nav-color: #aaaaaa !default;
-$c-transparent: rgba(0, 0, 0, 0) !default;
 $h-image: auto !default;
 $mh: 50px !default;
 


### PR DESCRIPTION
## molecule/carousel
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
<!-- #### `❓ Ask` -->

### Description, Motivation and Context
Since `$c-background` and `$c-transparent` are too broad to be used for the purposes they're being used here, I suggest using more specific variables so we don't have conflicts in case a `$c-background` variable is already in use on the theme and we want to keep a different background colour for the component, for instance, or we want to specify a different tap highlight colour.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [x] 🧠 Refactor
- [x] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
