### PR TITLE
add white support in atom icon

### DIFF
--- a/components/atom/icon/src/settings.js
+++ b/components/atom/icon/src/settings.js
@@ -7,7 +7,8 @@ export const ATOM_ICON_COLORS = {
   error: 'error',
   primary: 'primary',
   success: 'success',
-  gray: 'gray'
+  gray: 'gray',
+  white: 'white',
 }
 
 export const ATOM_ICON_SIZES = {

--- a/components/atom/icon/src/styles/settings.scss
+++ b/components/atom/icon/src/styles/settings.scss
@@ -14,5 +14,6 @@ $atom-icon-colors: (
   'error': $c-error,
   'primary': $c-primary,
   'success': $c-success,
-  'gray': $c-gray
+  'gray': $c-gray,
+  'white': $c-white,
 );


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
❓ 

<!-- https://github.com/SUI-Components/sui-components/issues -->

### Description, Motivation and Context

I've found that we don't support white in our icons, and i think white is a contrast color that can be useful in a design system. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [x] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
