### PR TITLE
feat(components/atom/button): Allow circular buttons in groups

### DIFF
--- a/components/atom/button/demo/articles/ArticleIsFitted.js
+++ b/components/atom/button/demo/articles/ArticleIsFitted.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types'
 import {Article, Box, Code, H2, ListItem, Paragraph, RadioButton, UnorderedList} from '@s-ui/documentation-library'
 
 import AtomButton, {atomButtonGroupPositions} from '../../src/index.js'
+import {atomButtonShapesIterator} from '../settings.js'
 
 const ArticleIsFitted = ({className}) => {
   const [isFitted, setIsFitted] = useState()
@@ -38,23 +39,29 @@ const ArticleIsFitted = ({className}) => {
           <AtomButton isFitted={isFitted}>button 5</AtomButton>
         </Box>
         <Paragraph>It works even with group not affecting its spacings</Paragraph>
-        <Box style={{padding: '8px 0'}}>
-          <AtomButton groupPosition={atomButtonGroupPositions.FIRST} isFitted={isFitted}>
-            button 1
-          </AtomButton>
-          <AtomButton groupPosition={atomButtonGroupPositions.MIDDLE} isFitted={isFitted}>
-            button 2
-          </AtomButton>
-          <AtomButton groupPosition={atomButtonGroupPositions.MIDDLE} isFitted={isFitted}>
-            button 3
-          </AtomButton>
-          <AtomButton groupPosition={atomButtonGroupPositions.MIDDLE} isFitted={isFitted}>
-            button 4
-          </AtomButton>
-          <AtomButton groupPosition={atomButtonGroupPositions.LAST} isFitted={isFitted}>
-            button 5
-          </AtomButton>
-        </Box>
+
+        {atomButtonShapesIterator.map(([{key, shape}]) => (
+          <Box key={key} style={{padding: 8, display: 'flex', gap: 8, alignItems: 'center'}}>
+            <div>{`Shape="${shape}"`}</div>
+            <div>
+              <AtomButton shape={shape} groupPosition={atomButtonGroupPositions.FIRST} isFitted={isFitted}>
+                button 1
+              </AtomButton>
+              <AtomButton shape={shape} groupPosition={atomButtonGroupPositions.MIDDLE} isFitted={isFitted}>
+                button 2
+              </AtomButton>
+              <AtomButton shape={shape} groupPosition={atomButtonGroupPositions.MIDDLE} isFitted={isFitted}>
+                button 3
+              </AtomButton>
+              <AtomButton shape={shape} groupPosition={atomButtonGroupPositions.MIDDLE} isFitted={isFitted}>
+                button 4
+              </AtomButton>
+              <AtomButton shape={shape} groupPosition={atomButtonGroupPositions.LAST} isFitted={isFitted}>
+                button 5
+              </AtomButton>
+            </div>
+          </Box>
+        ))}
       </div>
     </Article>
   )

--- a/components/atom/button/src/styles/index.scss
+++ b/components/atom/button/src/styles/index.scss
@@ -45,13 +45,15 @@ $base-class: '.sui-AtomButton';
 
     &--first {
       &#{$base-class} {
-        border-radius: $bdrs-atom-button-first;
+        border-bottom-right-radius: 0;
+        border-top-right-radius: 0;
       }
     }
 
     &--last {
       &#{$base-class} {
-        border-radius: $bdrs-atom-button-last;
+        border-bottom-left-radius: 0;
+        border-top-left-radius: 0;
       }
     }
 


### PR DESCRIPTION
## Category/Component
❓ Ask

**TASK**: <!--- #issueID -->

### Description, Motivation and Context
Change the way the "first" and "last" classes for the button groups set the border radius, from setting all 4 corners to only removing any radius from the inner corners, allowing for circular groups

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ x] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
![image](https://github.com/user-attachments/assets/d87a1264-d5a1-4fd2-a1bb-1a70ba92a07b)

