### PR TITLE
feat(components/atom/input): avoid submit the form, if the input pass…

### DIFF
--- a/components/atom/input/src/Password/index.js
+++ b/components/atom/input/src/Password/index.js
@@ -37,6 +37,7 @@ const Password = forwardRef(
         />
         <button
           onClick={toggle}
+          type={`button`}
           className={cx(
             BASE_CLASS_PASSWORD_TOGGLE_BUTTON,
             shape && `${BASE_CLASS_PASSWORD_TOGGLE_BUTTON}-shape-${shape}`


### PR DESCRIPTION
## Category/Component
#### `🔍 Show`

### Description, Motivation and Context

If the atom input is password type, and the field is inside a form, the form is being submitted when the user clicks on the "show" button to see the password. This is causing the password to be visible on the browser's path 😨 
This is fixed by setting the button type as `button`.

### Types of changes

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool
