### PR TITLE
feat(components/molecule/selectPopover): add overflow hidden to preve…

### DIFF
--- a/components/molecule/selectPopover/src/styles/index.scss
+++ b/components/molecule/selectPopover/src/styles/index.scss
@@ -22,6 +22,7 @@ $base-class: '.sui-MoleculeSelectPopover ';
     display: flex;
     justify-content: space-between;
     max-width: $mw-select-popover;
+    overflow: hidden;
     padding: $p-m $p-l;
     user-select: none;
 


### PR DESCRIPTION
## Molecule/SelectPopover
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
#### `🔍 Show`
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**:  N/A

### Description, Motivation and Context
This PR fixes an issue where the remove button for clearing a filter selection via _**`removeButtonOptions`**_ could exceed the height of the select component. When this happens, the button overlays the select, hiding its borders.

### Types of changes
To prevent this, we’ve added **_`overflow: hidden`_** to the container, ensuring that any content received through this prop never exceeds its boundaries.

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [x] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
#### BEFORE
![image](https://github.com/user-attachments/assets/66016008-1f12-4b53-bfa8-9c22f3a31696)


#### AFTER
![image](https://github.com/user-attachments/assets/4c17d5bf-3c81-4633-941b-429ed0ea8ecb)

