### PR TITLE
feat(components/atom/upload): Change heading by paragraph

### DIFF
--- a/components/atom/upload/src/index.js
+++ b/components/atom/upload/src/index.js
@@ -41,7 +41,7 @@ const AtomUpload = ({
         <input type="hiden" {...getInputProps()} />
         <span className={classNameIcon}>{IconStatus}</span>
         <div className={CLASS_BLOCK_TEXT}>
-          <h4 className={CLASS_BLOCK_TEXT_MAIN}>{textStatus}</h4>
+          <p className={CLASS_BLOCK_TEXT_MAIN}>{textStatus}</p>
           {isActive && (hasTextExplanation || hasButton) && (
             <>
               {Button}


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
`🔍 Show`
<!-- #### `❓ Ask` -->


<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: https://jira.ets.mpi-internal.com/browse/PI-83437
In order to fix [this a11y incidence](https://docs.google.com/spreadsheets/d/1Npm_yl7j6gzaV_p5fpIhvMEUeM0xuzY7/edit?gid=815113551#gid=815113551&range=D48)


### Description, Motivation and Context

Change heading by paragraph to stop breaking headings hierarchy. Since the component is adding by default a h4 it is causing a11y issues depending on its position in the headings hierarchy for instance: if a page only has a H1 heading, by including the AtomUpload we are breaking the hierarchy since there are not H2 and H3 prior to the same branch of the DOM tree.

Since this element was styled it does not have any visual change by changing to a `<p>` tag

### Types of changes

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots

![image](https://github.com/user-attachments/assets/760d6ee2-142e-4224-ab53-ce296de2d492)

