### PR TITLE
feat(components/atom/button): avoid pass SHAPE prop as button element…

### DIFF
--- a/components/atom/button/src/config.js
+++ b/components/atom/button/src/config.js
@@ -109,6 +109,7 @@ export const OWN_PROPS = [
   'loadingText',
   'negative',
   'rightIcon',
+  'shape',
   'type'
 ]
 


### PR DESCRIPTION
## Category/Component

#### `🔍 Show`

### Description, Motivation, and Context

Avoid passing `SHAPE` prop as a button element attribute as it is not a valid attribute.

### Types of changes

- [x] 🦾 a11y
- [x] ✨ New feature (non-breaking change which adds functionality)
