### PR TITLE
feat(components/atom/checkbox): assign different test ids to input and icon

### DIFF
--- a/components/atom/checkbox/demo/articles/ArticleDefault.js
+++ b/components/atom/checkbox/demo/articles/ArticleDefault.js
@@ -109,6 +109,7 @@ const ArticleDefault = ({className}) => {
             indeterminateIcon={ICONS.AiOutlineLine}
             indeterminate={indeterminateStatus}
             checked={checkedStatus}
+            data-testid="checkBoxExample"
           />
           <PrimitiveVisuallyHidden>
             <Label htmlFor="checkBoxExample">checkBoxExampleButton</Label>

--- a/components/atom/checkbox/src/index.js
+++ b/components/atom/checkbox/src/index.js
@@ -19,6 +19,12 @@ import {
   updateStatus
 } from './config.js'
 
+const getTestId = (testId, icon, suffix) => {
+  if (!testId) return undefined
+  if (icon) return `${testId}-${suffix}`
+  return testId
+}
+
 const AtomCheckbox = forwardRef(
   (
     {
@@ -161,7 +167,7 @@ const AtomCheckbox = forwardRef(
             }),
             ...props
           }}
-          data-testid={testId ? `${testId}-input` : undefined}
+          data-testid={getTestId(testId, Icon, 'input')}
         />
         <CheckboxIcon
           disabled={disabled}
@@ -173,7 +179,7 @@ const AtomCheckbox = forwardRef(
           isNative={isNative}
           icon={Icon}
           {...props}
-          data-testid={testId ? `${testId}-icon` : undefined}
+          data-testid={getTestId(testId, Icon, 'icon')}
         />
       </span>
     )

--- a/components/atom/checkbox/src/index.js
+++ b/components/atom/checkbox/src/index.js
@@ -40,6 +40,7 @@ const AtomCheckbox = forwardRef(
       size = CHECKBOX_SIZES.MEDIUM,
       value,
       className,
+      'data-testid': testId,
       ...props
     },
     forwardedRef
@@ -160,6 +161,7 @@ const AtomCheckbox = forwardRef(
             }),
             ...props
           }}
+          data-testid={testId ? `${testId}-input` : undefined}
         />
         <CheckboxIcon
           disabled={disabled}
@@ -171,6 +173,7 @@ const AtomCheckbox = forwardRef(
           isNative={isNative}
           icon={Icon}
           {...props}
+          data-testid={testId ? `${testId}-icon` : undefined}
         />
       </span>
     )
@@ -235,7 +238,10 @@ AtomCheckbox.propTypes = {
   status: PropTypes.oneOf(Object.values(CHECKBOX_STATUS)),
 
   /* Additional classes */
-  className: PropTypes.string
+  className: PropTypes.string,
+
+  /* data-testid attribute for testing purposes */
+  'data-testid': PropTypes.string
 }
 
 export default AtomCheckbox

--- a/components/atom/checkbox/src/index.js
+++ b/components/atom/checkbox/src/index.js
@@ -21,6 +21,7 @@ import {
 
 const getTestId = (testId, icon, suffix) => {
   if (!testId) return undefined
+  if (!suffix) return testId
   if (icon) return `${testId}-${suffix}`
   return testId
 }
@@ -167,7 +168,7 @@ const AtomCheckbox = forwardRef(
             }),
             ...props
           }}
-          data-testid={getTestId(testId, Icon, 'input')}
+          data-testid={getTestId(testId, Icon)}
         />
         <CheckboxIcon
           disabled={disabled}

--- a/components/atom/checkbox/test/index.test.js
+++ b/components/atom/checkbox/test/index.test.js
@@ -739,6 +739,30 @@ describe(json.name, () => {
         expect(element).to.not.be.null
       })
 
+      it('should have different data test ids for internal checkbox and icon', () => {
+        // Given
+        const testId = 'demo-testid'
+
+        const props = {
+          'data-testid': testId,
+          checkedIcon: () => <i />,
+          uncheckedIcon: () => <i />,
+          indeterminateIcon: () => <i />
+        }
+
+        // When
+        const component = setup(props)
+        const {getByTestId, queryByTestId} = component
+        const elementWithDefaultTestId = queryByTestId(testId)
+        const inputElement = getByTestId(`${testId}-input`)
+        const iconElement = getByTestId(`${testId}-icon`)
+
+        // Then
+        expect(elementWithDefaultTestId).to.be.null
+        expect(inputElement).to.not.be.null
+        expect(iconElement).to.not.be.null
+      })
+
       it('should have aria attributes', () => {
         // Given
         const props = {

--- a/components/atom/checkbox/test/index.test.js
+++ b/components/atom/checkbox/test/index.test.js
@@ -782,13 +782,11 @@ describe(json.name, () => {
 
         // When
         const component = setup(props)
-        const {getByTestId, queryByTestId} = component
-        const elementWithDefaultTestId = queryByTestId(testId)
-        const inputElement = getByTestId(`${testId}-input`)
+        const {getByTestId} = component
+        const inputElement = getByTestId(testId)
         const iconElement = getByTestId(`${testId}-icon`)
 
         // Then
-        expect(elementWithDefaultTestId).to.be.null
         expect(inputElement).to.not.be.null
         expect(iconElement).to.not.be.null
       })

--- a/components/atom/checkbox/test/index.test.js
+++ b/components/atom/checkbox/test/index.test.js
@@ -87,6 +87,21 @@ describe(json.name, () => {
       expect(element).to.not.be.null
     })
 
+    it('should have data test id', () => {
+      // Given
+      const testId = 'demo-testid'
+
+      const props = {'data-testid': testId}
+
+      // When
+      const component = setup(props)
+      const {getByTestId} = component
+      const elementWithDefaultTestId = getByTestId(testId)
+
+      // Then
+      expect(elementWithDefaultTestId).to.not.be.null
+    })
+
     it('should have aria attributes', () => {
       // Given
       const props = {'aria-attribute': 'aria-attribute'}
@@ -135,6 +150,21 @@ describe(json.name, () => {
 
         // Then
         expect(element).to.not.be.null
+      })
+
+      it('should have data test id', () => {
+        // Given
+        const testId = 'demo-testid'
+
+        const props = {'data-testid': testId}
+
+        // When
+        const component = setup(props)
+        const {getByTestId} = component
+        const elementWithDefaultTestId = getByTestId(testId)
+
+        // Then
+        expect(elementWithDefaultTestId).to.not.be.null
       })
 
       it('should have aria attributes', () => {


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
❓ Ask

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

When passing a data-testid to a checkbox with icon, both the icon and the input have the same testid.
This pr changes the test id and assigns a unique one to both elements, the input keeps the original testid, while the icon gets an "-icon" suffix

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->

Before: same test id for input and icon (button)
![Screenshot 2025-04-17 at 15 04 23](https://github.com/user-attachments/assets/e7b59ba1-6bbe-46b0-b067-59e92b506706)

After: input and icon (button) have different test ids
![Screenshot 2025-04-17 at 15 31 03](https://github.com/user-attachments/assets/1ece822b-a62f-4e1b-a14f-8b9e1111e059)


