### PR TITLE
Fix/atom tag title attribute

### DIFF
--- a/components/atom/tag/src/Actionable/index.js
+++ b/components/atom/tag/src/Actionable/index.js
@@ -59,7 +59,7 @@ const ActionableTag = forwardRef(
             iconPlacement={ICON_PLACEMENTS.LEFT}
           />
           {label ? (
-            <span className="sui-AtomTag-label" title={title || label}>
+            <span className="sui-AtomTag-label" title={title}>
               {label}
             </span>
           ) : null}

--- a/components/atom/tag/src/Standard.js
+++ b/components/atom/tag/src/Standard.js
@@ -52,7 +52,7 @@ const StandardTag = forwardRef(
         <Component ref={forwardedRef} {...props}>
           {icon && <span className="sui-AtomTag-icon">{icon}</span>}
           {label ? (
-            <span className="sui-AtomTag-label" title={title || label}>
+            <span className="sui-AtomTag-label" title={title}>
               {label}
             </span>
           ) : null}

--- a/components/atom/tag/test/index.test.js
+++ b/components/atom/tag/test/index.test.js
@@ -215,6 +215,35 @@ describe(json.name, () => {
       sinon.assert.notCalled(spy)
     })
 
+    it('should add a title attribute when defined', () => {
+      // Given
+      const props = {
+        label: 'tag with title',
+        title: 'title'
+      }
+
+      // When
+      const {getByText} = setup(props)
+      const tag = getByText(props.label)
+
+      // Then
+      expect(tag).to.have.attribute('title', 'title')
+    })
+
+    it('should not add a title attribute when not defined', () => {
+      // Given
+      const props = {
+        label: 'tag without title'
+      }
+
+      // When
+      const {getByText} = setup(props)
+      const tag = getByText(props.label)
+
+      // Then
+      expect(tag).to.not.have.attribute('title')
+    })
+
     describe('closeIcon', () => {
       it('given a closeIcon and clicking on it should fire onClose event', () => {
         // Given


### PR DESCRIPTION
## Atom/Tag
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
 #### `🔍 Show`
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: [MTR-97905](https://jira.ets.mpi-internal.com/browse/MTR-97905) & [MTR-97906](https://jira.ets.mpi-internal.com/browse/MTR-97906)

### Description, Motivation and Context
# Accessibility Improvement: Title Attribute Usage

## Summary

This PR addresses an accessibility issue reported during an audit.

Previously, our component automatically set the `title` attribute using the `label` prop. This resulted in redundant information for screen reader users and other assistive technologies, violating accessibility best practices.

According to **WCAG 2.1**, Success Criterion **[2.4.6 - Headings and Labels (AA)](https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels.html)**, headings and labels must describe the topic or purpose without unnecessary or redundant information.

## Changes introduced

- The `title` attribute will no longer be set automatically based on the `label` prop.
- A `title` attribute will only be added if an explicit `title` prop is provided.
- This ensures that the title is only used to provide *additional* information when necessary, avoiding duplication of existing labels.

## Why this change?

The `title` attribute is meant to offer supplementary information on hover. When it simply duplicates visible text (like a label), it does not add any meaningful value and can even hinder accessibility by causing confusion for assistive technology users.

This update ensures our components are more compliant with accessibility standards and offer a better experience for all users.

## Reference

- **WCAG 2.1 - Success Criterion 2.4.6 (AA):** [Headings and Labels](https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels.html)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
![image](https://github.com/user-attachments/assets/80d19b69-f192-4330-b9ca-9a240e2efe93)

