### PR TITLE
Fix atom badge title attribute

### DIFF
--- a/components/atom/badge/src/config.js
+++ b/components/atom/badge/src/config.js
@@ -30,15 +30,6 @@ export const CLASS_ICON_RIGHT = `${CLASS_ICON}--iconRight`
 export const CLASS_TEXT = `${CLASS_ICON}-text`
 
 /**
- * Cuts off exceeded char limit
- * @param  {string} label
- * @return {string}
- */
-export const truncateText = function (label) {
-  return label.length < MAX_LABEL_LENGTH ? label : label.substr(0, MAX_LABEL_LENGTH)
-}
-
-/**
  * @param  {object} options
  * @param  {string} options.size
  * @param  {boolean} options.transparent

--- a/components/atom/badge/src/index.js
+++ b/components/atom/badge/src/index.js
@@ -9,7 +9,6 @@ import {
   getClassNames,
   shouldRenderIcon,
   SIZES,
-  truncateText,
   TYPES
 } from './config.js'
 
@@ -21,9 +20,9 @@ const AtomBadge = ({
   type = TYPES.SUCCESS,
   design = DESIGNS.SOLID,
   className,
+  title,
   ...props
 }) => {
-  const truncatedLabel = truncateText(label)
   const classNames = getClassNames({
     icon,
     label,
@@ -37,7 +36,7 @@ const AtomBadge = ({
   return (
     <div className={classNames} {...props}>
       {shouldRenderIcon({icon, ...props}) && !iconRight && <span className={CLASS_ICON}>{icon}</span>}
-      <span className={CLASS_TEXT} title={truncatedLabel}>
+      <span className={CLASS_TEXT} title={title}>
         {label}
       </span>
       {shouldRenderIcon({icon, ...props}) && iconRight && (
@@ -77,7 +76,10 @@ AtomBadge.propTypes = {
   ]),
 
   /* Custom class name */
-  className: PropTypes.string
+  className: PropTypes.string,
+
+  /** Custom title attribute for the badge */
+  title: PropTypes.string
 }
 
 export default AtomBadge

--- a/components/atom/badge/test/index.test.js
+++ b/components/atom/badge/test/index.test.js
@@ -11,7 +11,7 @@ import chai, {expect} from 'chai'
 import chaiDOM from 'chai-dom'
 
 import json from '../package.json'
-import {MAX_LABEL_LENGTH, shouldRenderIcon, truncateText} from '../src/config.js'
+import {shouldRenderIcon} from '../src/config.js'
 import * as pkg from '../src/index.js'
 
 chai.use(chaiDOM)
@@ -99,6 +99,30 @@ describe(json.name, () => {
 
       // Then
       expect(element).to.not.be.null
+    })
+
+    it(`should have a title attribute when it's defined`, () => {
+      // Given
+      const props = {label: 'label', title: 'title'}
+
+      // When
+      const {getByText} = setup(props)
+      const element = getByText(props.label)
+
+      // Then
+      expect(element).to.have.attribute('title', props.title)
+    })
+
+    it(`should NOT have a title attribute when it's NOT defined`, () => {
+      // Given
+      const props = {label: 'label'}
+
+      // When
+      const {getByText} = setup(props)
+      const element = getByText(props.label)
+
+      // Then
+      expect(element).to.not.have.attribute('title')
     })
   })
 
@@ -208,32 +232,6 @@ describe(json.name, () => {
         expect(Object.keys(actual).includes(expectedKey)).to.be.true
         expect(actual[expectedKey]).to.equal(expectedValue)
       })
-    })
-  })
-
-  describe('truncateText', () => {
-    it('given small string should return full string', () => {
-      // Given
-      const expected = 'Lorem ipsum dolor sit amet'
-
-      // When
-      const actual = truncateText(expected)
-
-      // Then
-      expect(actual).to.equal(expected)
-    })
-
-    it('given large string should return first part of the string', () => {
-      // Given
-      const expected =
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent luctus, massa nec tincidunt semper, ex ipsum fermentum elit, convallis auctor sem nunc ut neque. Proin a mi eu libero condimentum viverra a a metus. Phasellus tincidunt placerat viverra. Cras in consectetur ex, eget viverra leo. Phasellus lacinia hendrerit cursus. Nulla facilisi. Nunc cursus ligula metus, eget pretium urna lacinia a. Morbi vel convallis elit. Donec sollicitudin augue non vulputate pellentesque.'
-
-      // When
-      const actual = truncateText(expected)
-
-      // Then
-      expect(actual.length).to.equal(MAX_LABEL_LENGTH)
-      expect(actual).to.equal(expected.slice(0, MAX_LABEL_LENGTH))
     })
   })
 


### PR DESCRIPTION
## Atom/Badge
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
 #### `🔍 Show`
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: [MTR-97905](https://jira.ets.mpi-internal.com/browse/MTR-97905) & [MTR-97906](https://jira.ets.mpi-internal.com/browse/MTR-97906)

### Description, Motivation and Context
# Accessibility Improvement: Title Attribute Usage

## Summary

This PR addresses an accessibility issue reported during an audit.

Previously, our component automatically set the `title` attribute using the `label` prop. This resulted in redundant information for screen reader users and other assistive technologies, violating accessibility best practices.

According to **WCAG 2.1**, Success Criterion **[2.4.6 - Headings and Labels (AA)](https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels.html)**, headings and labels must describe the topic or purpose without unnecessary or redundant information.

## Changes introduced

- The `title` attribute will no longer be set automatically based on the `label` prop.
- A `title` attribute will only be added if an explicit `title` prop is provided.
- This ensures that the title is only used to provide *additional* information when necessary, avoiding duplication of existing labels.

## Why this change?

The `title` attribute is meant to offer supplementary information on hover. When it simply duplicates visible text (like a label), it does not add any meaningful value and can even hinder accessibility by causing confusion for assistive technology users.

This update ensures our components are more compliant with accessibility standards and offer a better experience for all users.

## Reference

- **WCAG 2.1 - Success Criterion 2.4.6 (AA):** [Headings and Labels](https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels.html)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
![image](https://github.com/user-attachments/assets/80d19b69-f192-4330-b9ca-9a240e2efe93)

