### PR TITLE
feat(components/molecule/avatar): use paragraph and aria hide the nam…

### DIFF
--- a/components/molecule/avatar/src/AvatarFallbackName/index.js
+++ b/components/molecule/avatar/src/AvatarFallbackName/index.js
@@ -21,9 +21,9 @@ const MoleculeAvatarFallbackName = ({
   })
 
   return (
-    <div className={className} aria-label={nameProp} style={{backgroundColor}} {...others}>
+    <p className={className} aria-hidden="true" aria-label={nameProp} style={{backgroundColor}} {...others}>
       {name}
-    </div>
+    </p>
   )
 }
 

--- a/components/molecule/avatar/src/AvatarFallbackName/index.js
+++ b/components/molecule/avatar/src/AvatarFallbackName/index.js
@@ -21,7 +21,7 @@ const MoleculeAvatarFallbackName = ({
   })
 
   return (
-    <p className={className} aria-hidden="true" aria-label={nameProp} style={{backgroundColor}} {...others}>
+    <p className={className} aria-hidden aria-label={nameProp} style={{backgroundColor}} {...others}>
       {name}
     </p>
   )

--- a/components/molecule/avatar/src/AvatarFallbackName/index.scss
+++ b/components/molecule/avatar/src/AvatarFallbackName/index.scss
@@ -1,11 +1,12 @@
 $base-class-fallback-name: #{$base-class}FallbackName;
 
 #{$base-class-fallback-name} {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  justify-content: center;
   align-items: center;
   color: $c-avatar-fallback-name;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  margin: 0;
   text-transform: uppercase;
+  width: 100%;
 }


### PR DESCRIPTION
## Molecule/Avatar

#### `🔍 Show`

### Description, Motivation and Context

This PR addresses an accessibility issue reported during an audit.

We should use the paragraph semantic tag ( `<p>` ) in the name fallback (the initials of the username).
Also, we must mark it with `aria-hidden="true"` so it cannot be read by screen readers.

### Types of changes

- [x] 🦾 a11y
- [x] ✨ New feature (non-breaking change which adds functionality)