### PR TITLE
fix(components/atom/switch): Fix Box Shadow variable for variants

### DIFF
--- a/components/atom/switch/src/styles/settings.scss
+++ b/components/atom/switch/src/styles/settings.scss
@@ -64,36 +64,36 @@ $c-atom-switch--active-array: (
   primary: (
     bgc: $c-atom-switch--active,
     bdc: color-variation($c-atom-switch--active, -1),
-    bxsh: 0 0 4px 1px $c-atom-switch-shadow
+    bxsh: $bxsh-atom-switch-circle
   ),
   accent: (
     bgc: $c-accent,
     bdc: color-variation($c-accent, -1),
-    bxsh: 0 0 4px 1px $c-atom-switch-shadow
+    bxsh: $bxsh-atom-switch-circle
   ),
   success: (
     bgc: $c-success,
     bdc: color-variation($c-success, -1),
-    bxsh: 0 0 4px 1px $c-atom-switch-shadow
+    bxsh: $bxsh-atom-switch-circle
   ),
   alert: (
     bgc: $c-alert,
     bdc: color-variation($c-alert, -1),
-    bxsh: 0 0 4px 1px $c-atom-switch-shadow
+    bxsh: $bxsh-atom-switch-circle
   ),
   error: (
     bgc: $c-error,
     bdc: color-variation($c-error, -1),
-    bxsh: 0 0 4px 1px $c-atom-switch-shadow
+    bxsh: $bxsh-atom-switch-circle
   ),
   neutral: (
     bgc: $c-gray,
     bdc: color-variation($c-gray, -1),
-    bxsh: 0 0 4px 1px $c-atom-switch-shadow
+    bxsh: $bxsh-atom-switch-circle
   ),
   surface: (
     bgc: $c-white,
     bdc: color-variation($c-white, 1),
-    bxsh: 0 0 4px 1px $c-atom-switch-shadow
+    bxsh: $bxsh-atom-switch-circle
   )
 );


### PR DESCRIPTION
## Category/Component
 `🔍 Show`

**TASK**: https://jira.ets.mpi-internal.com/browse/PI-85025

### Description, Motivation and Context
The AtomSwith variants were overwritting the variable $bxsh-atom-switch-circle, so it could not be defined in theme.

With this change the value of $bxsh-atom-switch-circle is applying to the box shadow of the circle properly

### Types of changes

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

