### PR TITLE
Feature/atom card conditional role button

### DIFF
--- a/components/atom/card/src/index.js
+++ b/components/atom/card/src/index.js
@@ -25,7 +25,8 @@ const AtomCard = ({
   href,
   blank,
   onClick,
-  tabIndex
+  tabIndex,
+  ...props
 }) => {
   const onClickHandler = e => {
     typeof onClick === 'function' ? onClick(e) : redirectToHref({href, blank})
@@ -48,7 +49,14 @@ const AtomCard = ({
   )
 
   return (
-    <div className={classNames} tabIndex={tabIndex} role="button" onClick={onClickHandler} onKeyDown={redirectOnEnter}>
+    <div
+      className={classNames}
+      onClick={onClickHandler}
+      onKeyDown={redirectOnEnter}
+      tabIndex={tabIndex}
+      {...(!href && {role: 'button'})}
+      {...props}
+    >
       {Media && (
         <div className={CLASS_MEDIA}>
           <Media />

--- a/components/atom/card/test/index.test.js
+++ b/components/atom/card/test/index.test.js
@@ -15,6 +15,12 @@ import * as pkg from '../src/index.js'
 
 chai.use(chaiDOM)
 
+const DATA_TEST_ID = 'atom-card'
+
+const sharedProps = {
+  'data-testId': DATA_TEST_ID
+}
+
 describe(json.name, () => {
   const {default: Component} = pkg
   const setup = setupEnvironment(Component)
@@ -64,7 +70,7 @@ describe(json.name, () => {
       expect(container.innerHTML).to.not.have.lengthOf(0)
     })
 
-    it('should NOT extend classNames', () => {
+    it('should extend classNames', () => {
       // Given
       const props = {content: noop, className: 'extended-classNames'}
       const findSentence = str => string => string.match(new RegExp(`S*${str}S*`))
@@ -74,45 +80,61 @@ describe(json.name, () => {
       const findClassName = findSentence(props.className)
 
       // Then
-      expect(findClassName(container.innerHTML)).to.be.null
+      expect(findClassName(container.innerHTML)).to.not.be.null
     })
 
     it('should have link class when having onClick', () => {
       const props = {
         onClick: () => console.log('Hello!'), // eslint-disable-line no-console
-        content: () => <span>card with click</span>
+        content: () => <span>card with click</span>,
+        ...sharedProps
       }
-      const {getByRole} = setup(props)
-      const card = getByRole('button')
+      const {getByTestId} = setup(props)
+      const card = getByTestId(DATA_TEST_ID)
       expect(card).to.have.class('sui-AtomCard-link')
     })
 
     it('should have link class when having href', () => {
       const props = {
         href: 'http://www.google.com',
-        content: () => <span>card with click</span>
+        content: () => <span>card with click</span>,
+        ...sharedProps
       }
-      const {getByRole} = setup(props)
-      const card = getByRole('button')
+      const {getByTestId} = setup(props)
+      const card = getByTestId(DATA_TEST_ID)
       expect(card).to.have.class('sui-AtomCard-link')
     })
 
     it('should NOT have link class when not having href or onClick', () => {
       const props = {
-        content: () => <span>card with click</span>
+        content: () => <span>card with click</span>,
+        ...sharedProps
       }
-      const {getByRole} = setup(props)
-      const card = getByRole('button')
+      const {getByTestId} = setup(props)
+      const card = getByTestId(DATA_TEST_ID)
       expect(card).to.have.not.class('sui-AtomCard-link')
+    })
+
+    it('should not have role button when href is provided', () => {
+      const props = {
+        href: 'http://www.google.com',
+        content: () => <span>card with click</span>,
+        'data-testid': 'atom-card'
+      }
+      const {getByTestId, queryByRole} = setup(props)
+      expect(queryByRole('button')).to.be.null
+      const card = getByTestId('atom-card')
+      expect(card).to.have.class('sui-AtomCard-link')
     })
 
     it('should have rounded class when having borders rounded', () => {
       const props = {
         rounded: 's',
-        content: () => <span>card</span>
+        content: () => <span>card</span>,
+        ...sharedProps
       }
-      const {getByRole} = setup(props)
-      const card = getByRole('button')
+      const {getByTestId} = setup(props)
+      const card = getByTestId(DATA_TEST_ID)
       expect(card).to.have.class('sui-AtomCard--rounded-s')
       expect(card).to.have.not.class('sui-AtomCard--rounded-m')
       expect(card).to.have.not.class('sui-AtomCard--rounded-l')
@@ -120,10 +142,11 @@ describe(json.name, () => {
 
     it('should NOT have rounded class when not having border rounded ', () => {
       const props = {
-        content: () => <span>card</span>
+        content: () => <span>card</span>,
+        ...sharedProps
       }
-      const {getByRole} = setup(props)
-      const card = getByRole('button')
+      const {getByTestId} = setup(props)
+      const card = getByTestId(DATA_TEST_ID)
       expect(card).to.have.not.class('sui-AtomCard--rounded-s')
       expect(card).to.have.not.class('sui-AtomCard--rounded-m')
       expect(card).to.have.not.class('sui-AtomCard--rounded-l')
@@ -132,10 +155,11 @@ describe(json.name, () => {
     it('should have box-shadow class when having elevated border', () => {
       const props = {
         elevation: 's',
-        content: () => <span>card</span>
+        content: () => <span>card</span>,
+        ...sharedProps
       }
-      const {getByRole} = setup(props)
-      const card = getByRole('button')
+      const {getByTestId} = setup(props)
+      const card = getByTestId(DATA_TEST_ID)
       expect(card).to.have.class('sui-AtomCard--elevation-s')
       expect(card).to.have.not.class('sui-AtomCard--elevation-m')
       expect(card).to.have.not.class('sui-AtomCard--elevation-l')
@@ -143,10 +167,11 @@ describe(json.name, () => {
 
     it('should NOT have rounded class when not having elevated border ', () => {
       const props = {
-        content: () => <span>card</span>
+        content: () => <span>card</span>,
+        ...sharedProps
       }
-      const {getByRole} = setup(props)
-      const card = getByRole('button')
+      const {getByTestId} = setup(props)
+      const card = getByTestId(DATA_TEST_ID)
       expect(card).to.have.not.class('sui-AtomCard--elevation-s')
       expect(card).to.have.not.class('sui-AtomCard--elevation-m')
       expect(card).to.have.not.class('sui-AtomCard--elevation-l')

--- a/components/atom/card/test/index.test.js
+++ b/components/atom/card/test/index.test.js
@@ -119,7 +119,7 @@ describe(json.name, () => {
       const props = {
         href: 'http://www.google.com',
         content: () => <span>card with click</span>,
-        'data-testid': 'atom-card'
+        ...sharedProps
       }
       const {getByTestId, queryByRole} = setup(props)
       expect(queryByRole('button')).to.be.null


### PR DESCRIPTION
## Atom/Card
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
`🔍 Show`
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: [MTR-96041](https://jira.ets.mpi-internal.com/browse/MTR-96041)

### Description, Motivation and Context
### ♿ Accessibility Fix: Remove `role="button"` from `AtomCard` when it contains a link

#### What has changed?

This update modifies the `AtomCard` component to **avoid assigning `role="button"`** when its content includes an anchor tag (`<a href="...">`). This change improves accessibility compliance and prevents **nested interactive elements**, which can create problems for screen readers and keyboard navigation.

#### Why is this necessary?

Previously, the component rendered markup like this:

```html
<div class="sui-AtomCard" role="button">
  ...
  <a href="/some-url" title="OPEL Corsa 1.5D DT GSLine">...</a>
  ...
</div>
```

#### Why is this necessary?

This results in accessibility violations:

- **Error: Buttons with nested links**  
  Wrapping a link inside an element with `role="button"` is semantically incorrect and creates confusion for assistive technologies.

- **WCAG Guidelines affected:**
  - **[4.1.2 Name, Role, Value (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html):**  
    Elements must expose the correct name, role, and value to assistive technologies.
  - **[2.4.4 Link Purpose (In Context) (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html):**  
    Links must have a clear purpose and should not be obscured by conflicting roles.

- **ARIA Authoring Practices** discourage combining interactive roles (e.g., `button` + `link`) in a single container:  
  https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/
  
#### Summary

- ✅ Removes `role="button"` from `AtomCard` if an `<a href>` is present in its children.
- 🚫 Prevents nested interactive roles.
- ♿ Aligns with WCAG 2.1 Level A and ARIA best practices for accessible interaction.
  
  
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
