### PR TITLE
Feature/a11y  aria described by help text

### DIFF
--- a/components/atom/helpText/src/index.js
+++ b/components/atom/helpText/src/index.js
@@ -6,11 +6,11 @@ import Injector from '@s-ui/react-primitive-injector'
 
 import {BASE_CLASS} from './settings.js'
 
-const AtomHelpText = forwardRef(({id, text}, forwardedRef) => {
+const AtomHelpText = forwardRef(({text, ...props}, forwardedRef) => {
   const isTextString = typeof text === 'string'
   const Component = isTextString ? 'span' : Injector
   return (
-    <Component className={BASE_CLASS} id={id} {...(isTextString && {ref: forwardedRef})}>
+    <Component className={BASE_CLASS} {...props} {...(isTextString && {ref: forwardedRef})}>
       {text}
     </Component>
   )
@@ -19,7 +19,6 @@ const AtomHelpText = forwardRef(({id, text}, forwardedRef) => {
 AtomHelpText.displayName = 'AtomHelpText'
 
 AtomHelpText.propTypes = {
-  id: PropTypes.string,
   text: PropTypes.oneOfType([PropTypes.element, PropTypes.node]).isRequired
 }
 

--- a/components/atom/helpText/src/index.js
+++ b/components/atom/helpText/src/index.js
@@ -6,11 +6,11 @@ import Injector from '@s-ui/react-primitive-injector'
 
 import {BASE_CLASS} from './settings.js'
 
-const AtomHelpText = forwardRef(({text}, forwardedRef) => {
+const AtomHelpText = forwardRef(({id, text}, forwardedRef) => {
   const isTextString = typeof text === 'string'
   const Component = isTextString ? 'span' : Injector
   return (
-    <Component className={BASE_CLASS} {...(isTextString && {ref: forwardedRef})}>
+    <Component className={BASE_CLASS} id={id} {...(isTextString && {ref: forwardedRef})}>
       {text}
     </Component>
   )
@@ -19,6 +19,7 @@ const AtomHelpText = forwardRef(({text}, forwardedRef) => {
 AtomHelpText.displayName = 'AtomHelpText'
 
 AtomHelpText.propTypes = {
+  id: PropTypes.string,
   text: PropTypes.oneOfType([PropTypes.element, PropTypes.node]).isRequired
 }
 

--- a/components/molecule/field/src/index.js
+++ b/components/molecule/field/src/index.js
@@ -48,11 +48,14 @@ const MoleculeField = ({
     fullWidth && CLASS_FULLWIDTH
   )
 
+  const helpTextId = `${name}-help-text`
+
   const extendedChildren = Children.toArray(children)
     .filter(Boolean)
     .map((child, index) => {
       return cloneElement(child, {
-        onChange: onChangeFromProps
+        onChange: onChangeFromProps,
+        ...(helpText && {[`aria-describedby`]: helpTextId})
       })
     })
 
@@ -92,7 +95,7 @@ const MoleculeField = ({
         {!disabled && validationTextValue && (
           <AtomValidationText type={validationTextStatus} text={validationTextValue} />
         )}
-        {helpText && <AtomHelpText text={helpText} />}
+        {helpText && <AtomHelpText id={helpTextId} text={helpText} />}
       </div>
     </div>
   )

--- a/components/molecule/select/src/components/SingleSelection.js
+++ b/components/molecule/select/src/components/SingleSelection.js
@@ -19,7 +19,6 @@ const MoleculeSelectSingleSelection = forwardRef(
     {
       value = '',
       children,
-      'aria-describedby': ariaDescribedBy,
       isOpen,
       onToggle,
       onTriggerClick,
@@ -88,7 +87,7 @@ const MoleculeSelectSingleSelection = forwardRef(
           size={selectSize}
           tabIndex={tabIndex}
         >
-          <AtomInput aria-describedby={ariaDescribedBy} ref={forwardedRef} inputMode={inputTypes.NONE} noBorder />
+          <AtomInput ref={forwardedRef} inputMode={inputTypes.NONE} noBorder {...props} />
         </MoleculeInputSelect>
         <div className={CLASS_SEARCH_CONTAINER}>
           {hasSearch && <Search ref={refSearch} />}
@@ -110,7 +109,6 @@ const MoleculeSelectSingleSelection = forwardRef(
 MoleculeSelectSingleSelection.propTypes = {
   value: PropTypes.string,
   children: PropTypes.node,
-  'aria-describedby': PropTypes.string,
   isOpen: PropTypes.bool,
   onToggle: PropTypes.func,
   onChange: PropTypes.func,

--- a/components/molecule/select/src/components/SingleSelection.js
+++ b/components/molecule/select/src/components/SingleSelection.js
@@ -19,6 +19,7 @@ const MoleculeSelectSingleSelection = forwardRef(
     {
       value = '',
       children,
+      'aria-describedby': ariaDescribedBy,
       isOpen,
       onToggle,
       onTriggerClick,
@@ -87,7 +88,7 @@ const MoleculeSelectSingleSelection = forwardRef(
           size={selectSize}
           tabIndex={tabIndex}
         >
-          <AtomInput ref={forwardedRef} inputMode={inputTypes.NONE} noBorder />
+          <AtomInput aria-describedby={ariaDescribedBy} ref={forwardedRef} inputMode={inputTypes.NONE} noBorder />
         </MoleculeInputSelect>
         <div className={CLASS_SEARCH_CONTAINER}>
           {hasSearch && <Search ref={refSearch} />}
@@ -109,6 +110,7 @@ const MoleculeSelectSingleSelection = forwardRef(
 MoleculeSelectSingleSelection.propTypes = {
   value: PropTypes.string,
   children: PropTypes.node,
+  'aria-describedby': PropTypes.string,
   isOpen: PropTypes.bool,
   onToggle: PropTypes.func,
   onChange: PropTypes.func,

--- a/components/molecule/select/src/index.js
+++ b/components/molecule/select/src/index.js
@@ -48,6 +48,7 @@ const MoleculeSelect = forwardRef(
       keysSelection = SELECTION_KEYS,
       multiselection = false,
       hasSearch = false,
+      iconCloseTag,
       tagSize,
       searchIcon,
       searchPlaceholder,
@@ -301,7 +302,10 @@ const MoleculeSelect = forwardRef(
             selectSize={selectSize}
             tagSize={tagSize}
             multiselection={multiselection}
-            keysSelection={keysSelection}
+            {...(multiselection && {
+              iconCloseTag,
+              keysSelection
+            })}
           >
             {numOptions > 0 ? extendedChildren : noResults}
           </Select>


### PR DESCRIPTION
## atom/helpText, molecule/field, molecule/select

#### `🔍 Show`

### Description, Motivation and Context

To solve an a11y issue, we need to add a relationship between the field's help text and the input component, we need to add an id to the helpText and an aria-describedby prop to the input, with the same id.
The Molecule Field component can manage that, setting an ID from the `name` prop.

### Types of changes

- [x] 🦾 a11y
- [x] ✨ New feature (non-breaking change which adds functionality)