### PR TITLE
feat(components/molecule/accordion): Remove aria-expanded from ItemPanel

### DIFF
--- a/components/molecule/accordion/src/AccordionItemPanel.js
+++ b/components/molecule/accordion/src/AccordionItemPanel.js
@@ -38,12 +38,15 @@ const AccordionItemPanel = forwardRef(
     } = useAccordionContext({isExpanded, value})
     const maxHeight = maxHeightProp !== undefined ? maxHeightProp : maxHeightContext
     const animationDuration = animationDurationProp || animationDurationContext
+
+    const className = cx(BASE_CLASS_ITEM_PANEL, BASE_CLASS_ELEMENT, {
+      [`${BASE_CLASS_ITEM_PANEL}--expanded`]: values.includes(value)
+    })
     return (
       <div
         id={id}
         ref={forwardedRef}
-        className={cx(BASE_CLASS_ITEM_PANEL, BASE_CLASS_ELEMENT)}
-        aria-expanded={values.includes(value)}
+        className={className}
         aria-disabled={disabled}
         style={{
           overflowY: height > maxHeight && maxHeight !== 0 ? 'scroll' : 'hidden',

--- a/components/molecule/accordion/src/styles/index.scss
+++ b/components/molecule/accordion/src/styles/index.scss
@@ -51,10 +51,10 @@ $base-class-item-panel: '#{$base-class-item}Panel';
   #{$base-class-item-panel} {
     border-width: 0;
   }
-  #{$base-class-item-panel}[aria-expanded='false'] {
+  #{$base-class-item-panel} {
     border-top-width: 0;
   }
-  #{$base-class-item-panel}[aria-expanded='true'] {
+  #{$base-class-item-panel}--expanded {
     border-top-width: $bdw-accordion-item;
   }
 }
@@ -173,15 +173,9 @@ $base-class-item-panel: '#{$base-class-item}Panel';
 
 #{$base-class-item-panel} {
   overflow: hidden;
+  max-height: 0;
+  border-bottom: 0;
 
-  &[aria-expanded='false'] {
-    max-height: 0;
-    opacity: 0;
-    border-bottom: 0;
-  }
-  &[aria-collapsed='true'] {
-    opacity: 1;
-  }
   #{$base-class-item-panel}Content {
     background-color: $bgc-accordion-item-panel;
     padding: $p-accordion-item-panel;

--- a/components/molecule/accordion/test/index.test.js
+++ b/components/molecule/accordion/test/index.test.js
@@ -257,11 +257,12 @@ describe(json.name, () => {
       const panels = getAllByTestId(DATA_TEST_ID)
 
       // Then
+      const classNameExpanded = 'sui-MoleculeAccordionItemPanel--expanded'
       panels.forEach(panel => {
         if (['content 1', 'content 2'].includes(panel.innerText)) {
-          expect(Boolean(panel.hasAttribute('aria-expanded'))).to.be.true
+          expect(panel.classList.contains(classNameExpanded)).to.be.true
         } else if (['content 3'].includes(panel.innerText)) {
-          expect(Boolean(panel.hasAttribute('aria-collapsed'))).to.be.false
+          expect(panel.classList.contains(classNameExpanded)).to.be.false
         }
         expect(['content 1', 'content 2', 'content 3'].some(text => panel.innerText === text)).to.be.true
       })


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASKS**: 
- [DO-2280](https://jira.ets.mpi-internal.com/browse/DO-2280)
- [MTR-97995](https://jira.ets.mpi-internal.com/browse/MTR-97995)

### Description, Motivation and Context
# ♿️ Accessibility: Removed `aria-expanded` attribute
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] ✨ New feature (non-breaking change which adds functionality)
