### PR TITLE
feat(components/molecule/tabs): making molecule tab more accessible - Claude 3.7

### DIFF
--- a/components/molecule/tabs/src/_settings.scss
+++ b/components/molecule/tabs/src/_settings.scss
@@ -33,3 +33,4 @@ $sz-sui-molecule-tabs-icon: $sz-icon-l !default;
 $ta-sui-molecule-tabs-vertical-item: center !default;
 $w-sui-molecule-tabs-vertical-item: 100% !default;
 $ws-sui-molecule-tabs-vertical-item: nowrap !default;
+$bxsh-focus: 0 0 0 1px $c-primary !default;

--- a/components/molecule/tabs/src/components/MoleculeTab.js
+++ b/components/molecule/tabs/src/components/MoleculeTab.js
@@ -29,6 +29,13 @@ const MoleculeTab = forwardRef(
       !disabled && onChange(ev, {numTab})
     }
 
+    const handleKeyDown = ev => {
+      if (!disabled && (ev.key === 'Enter' || ev.key === ' ')) {
+        ev.preventDefault()
+        onChange(ev, {numTab})
+      }
+    }
+
     useEffect(() => {
       if (autoScrollIntoView && active && isIntersecting) {
         innerRef.current.scrollIntoView({
@@ -44,16 +51,26 @@ const MoleculeTab = forwardRef(
       [CLASS_TAB_DISABLED]: disabled
     })
 
+    const ariaLabel = typeof label === 'string' ? undefined : `Tab ${numTab}`
+
     return (
       <li
         className={className}
         onClick={handleChange}
+        onKeyDown={handleKeyDown}
         ref={useMergeRefs(innerRef, forwardedRef)}
         role="tab"
+        tabIndex={disabled ? -1 : 0}
         aria-selected={active}
+        aria-disabled={disabled}
         aria-controls={`${id}-${numTab}`}
+        aria-label={ariaLabel}
       >
-        {icon && <span className={CLASS_TAB_ICON}>{icon}</span>}
+        {icon && (
+          <span className={CLASS_TAB_ICON} aria-hidden="true">
+            {icon}
+          </span>
+        )}
         {!isNaN(count) && <span className={CLASS_TAB_COUNT}>{count}</span>}
         <span>{label}</span>
       </li>

--- a/components/molecule/tabs/src/styles/index.scss
+++ b/components/molecule/tabs/src/styles/index.scss
@@ -245,6 +245,14 @@ $item-base-class: '#{$base-class}-item';
     width: 100%;
     scroll-snap-align: $ssa-sui-molecule-tabs;
 
+    &:focus-visible {
+      box-shadow: $bxsh-focus;
+      outline: $bdw-s solid $c-primary;
+      outline-offset: 2px;
+      position: relative;
+      z-index: 1;
+    }
+
     &:first-of-type {
       margin: $m-sui-molecule-tabs-first-item;
     }


### PR DESCRIPTION
## molecule/tabs
Trying out GH's Copilot with Claude 3.7 Sonnet for a particular a11y ticket.

Given the prompt:
> _How would you make this React component more accessible?_

Given the file:
> [components/molecule/tabs/src/components/MoleculeTab.js](https://github.com/SUI-Components/sui-components/pull/2870/files#diff-9aa39d14feda7f4229414b2169e19f0d83c8d02216295d2a54a41f1bce7d97bb)

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
N/A

### AI response

# Accessibility Improvements for MoleculeTab

The MoleculeTab component has a good foundation for accessibility but could be enhanced with several improvements:

1. **Add keyboard navigation support**:
   - The component currently only responds to clicks
   - Add keyboard support (specifically Enter/Space keys)

2. **Improve ARIA attributes**:
   - Add `tabIndex` for keyboard focus
   - Include `aria-disabled` for disabled state
   - Add more descriptive `aria-label` when needed

3. **Add focus styling**:
   - Ensure focus state is visible for keyboard users

Here's how I would modify the component:

```javascript
import {forwardRef, useEffect, useRef} from 'react'

import cx from 'classnames'
import PropTypes from 'prop-types'

import useMergeRefs from '@s-ui/react-hooks/lib/useMergeRefs'

import {CLASS_TAB, CLASS_TAB_ACTIVE, CLASS_TAB_COUNT, CLASS_TAB_DISABLED, CLASS_TAB_ICON} from './config.js'

const MoleculeTab = forwardRef(
  (
    {
      active,
      autoScrollIntoView = true,
      count,
      disabled,
      icon,
      id = 'molecule-tab-content',
      isIntersecting,
      label,
      numTab,
      onChange
    },
    forwardedRef
  ) => {
    const innerRef = useRef()

    const handleChange = ev => {
      !disabled && onChange(ev, {numTab})
    }

    const handleKeyDown = ev => {
      if (!disabled && (ev.key === 'Enter' || ev.key === ' ')) {
        ev.preventDefault()
        onChange(ev, {numTab})
      }
    }

    useEffect(() => {
      if (autoScrollIntoView && active && isIntersecting) {
        innerRef.current.scrollIntoView({
          behavior: 'smooth',
          block: 'nearest',
          inline: 'start'
        })
      }
    }, [autoScrollIntoView, active, isIntersecting, innerRef])

    const className = cx(CLASS_TAB, {
      [CLASS_TAB_ACTIVE]: active,
      [CLASS_TAB_DISABLED]: disabled
    })

    const ariaLabel = typeof label === 'string' ? undefined : `Tab ${numTab}`;
    
    return (
      <li
        className={className}
        onClick={handleChange}
        onKeyDown={handleKeyDown}
        ref={useMergeRefs(innerRef, forwardedRef)}
        role="tab"
        tabIndex={disabled ? -1 : 0}
        aria-selected={active}
        aria-disabled={disabled}
        aria-controls={`${id}-${numTab}`}
        aria-label={ariaLabel}
      >
        {icon && <span className={CLASS_TAB_ICON} aria-hidden="true">{icon}</span>}
        {!isNaN(count) && <span className={CLASS_TAB_COUNT}>{count}</span>}
        <span>{label}</span>
      </li>
    )
  }
)

MoleculeTab.propTypes = {
  /** Enable scroll into view funcionality */
  autoScrollIntoView: PropTypes.bool,

  /** Handler on Change Tabs */
  onChange: PropTypes.func,

  /** icon (React component) */
  icon: PropTypes.node,

  /** id used to make tabs unique per page */
  id: PropTypes.string,

  /** count to display */
  count: PropTypes.string,

  /** text to display */
  label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),

  /** Tab number */
  numTab: PropTypes.number,

  /** is active */
  active: PropTypes.bool,

  /** is disabled */
  disabled: PropTypes.bool,

  /** determines if the container element is intersecting in the view **/
  isIntersecting: PropTypes.bool
}

export default MoleculeTab
```

The key improvements are:

1. Added keyboard support with `onKeyDown` handler for Enter and Space keys
2. Added `tabIndex` attribute to make the tab focusable with keyboard
3. Added `aria-disabled` attribute to communicate disabled state to screen readers
4. Made the icon explicitly non-readable with `aria-hidden="true"` since it's decorative
5. Added fallback `aria-label` when the label isn't a string

Additionally, ensure the parent component that uses MoleculeTab:
- Has `role="tablist"` 
- Implements proper keyboard navigation between tabs using arrow keys
- Has appropriate CSS for focus states (like a visible outline or highlight)

----

## Subsequent prompting and context

Given the prompt:
> how would you make it so that a tab that has the current focus while navigating via keyboard outstands visually?

Given the component folder as context.

### AI response

# Solution for Improving Visibility of Active Tab Items

To improve the visibility of active tab items, I'll make several style enhancements to make the active state more prominent. The key changes will focus on improving visual contrast and adding clear indicators for the active tab.

## Step-by-Step Solution:

1. Enhance the active tab styling by adding more visual contrast
2. Add a stronger color indicator for active tabs
3. Implement a clearer border or highlight for active state
4. Ensure consistent active state styles across different tab variants

### [_settings.scss](file:///Users/jordi.munoz/sui-components/components/molecule/tabs/src/_settings.scss)

Add new SCSS variables to control the active tab appearance and update existing ones for better contrast.

````scss
$bdc-sui-molecule-tabs: $c-gray-light-3 !default;
$bb-sui-molecule-tabs-fullwidth: 1px solid $bdc-sui-molecule-tabs !default;
$bc-sui-molecule-tabs-highlighted: transparent !default;
$bdc-sui-molecule-tabs-highlighted-vertical-right: $bdc-sui-molecule-tabs !default;
$bdc-sui-molecule-tabs-highlighted: transparent !default;
$bdc-sui-molecule-tabs-highlighted-active: $c-primary !default;
$bdrs-sui-molecule-tabs: 0 !default;
$bdw-sui-molecule-tabs: $p-s !default;
$bdw-sui-molecule-tabs-highlighted-active: 3px !default; // Increased thickness for highlighted active border
$bdw-sui-molecule-tabs-highlighted: 0 !default;
$bg-sui-molecule-tab-item: transparent !default;
$bg-sui-molecule-tabs-content: transparent !default;
$bgc-sui-molecule-tabs-active: rgba($c-primary, 0.1) !default; // Light background for active tab
$bgc-sui-molecule-tabs: transparent !default;
$bt-sui-molecule-tabs-content: $bdw-sui-molecule-tabs-highlighted solid $bdc-sui-molecule-tabs-highlighted !default;
$c-sui-molecule-tabs-active: $c-primary !default;
$c-sui-molecule-tabs-disabled: $c-gray-lightest !default;
$c-sui-molecule-tabs-highlighted-active: $c-primary !default;
$c-sui-molecule-tabs-icon-active: $c-primary !default;
$c-sui-molecule-tabs: $c-gray-dark-3 !default;
$fw-sui-molecule-tabs-active: $fw-semi-bold !default; // Changed to semi-bold for better visibility
$fw-sui-molecule-tabs: inherit !default;
$fz-sui-molecule-tabs-counter: $fz-m !default;
$fz-sui-molecule-tabs: $fz-m !default;
$m-sui-molecule-tabs-item: 0 !default;
$m-sui-molecule-tabs-first-item: $m-sui-molecule-tabs-item !default;
$mt-sui-molecule-tabs-active: 1px !default;
$p-sui-molecule-tabs-item: $p-m $p-l !default;
$p-sui-molecule-tabs-vertical-item: $p-sui-molecule-tabs-item !default;
$ssa-sui-molecule-tabs: start !default;
$sst-sui-molecule-tabs: x mandatory !default;
$sz-sui-molecule-tabs-icon: $sz-icon-l !default;
$ta-sui-molecule-tabs-vertical-item: center !default;
$w-sui-molecule-tabs-vertical-item: 100% !default;
$ws-sui-molecule-tabs-vertical-item: nowrap !default;
$bxsh-focus: 0 0 0 1px $c-primary !default;
$bxsh-active-tab: 0 2px 4px rgba(0, 0, 0, 0.1) !default; // New shadow for active tab
````

### [index.scss](file:///Users/jordi.munoz/sui-components/components/molecule/tabs/src/styles/index.scss)

Update the styles to make active tabs more visually prominent.

````scss


Made changes.

````scss
// ...existing code...

  &--classic#{$base-class}--horizontal,
  &--classic#{$base-class}--fullWidth {
    #{$item-base-class} {
      border: $bdw-s solid transparent;
      border-bottom-color: $bdc-sui-molecule-tabs;
      display: flex;
      flex-direction: column;
      font-weight: $fw-sui-molecule-tabs;
      transition: all 0.3s ease; // Add transition for smoother state changes

      &.is-active {
        background: $bgc-sui-molecule-tabs-active;
        border-bottom: 0;
        border-color: $bdc-sui-molecule-tabs;
        color: $c-sui-molecule-tabs-active;
        font-weight: $fw-sui-molecule-tabs-active;
        margin-top: $mt-sui-molecule-tabs-active;
        box-shadow: $bxsh-active-tab; // Add shadow for depth

        span {
          transform: translateY(-1px);
        }

        svg {
          fill: $c-sui-molecule-tabs-icon-active;
        }
      }

      &:hover:not(.is-disabled) {
        color: $c-sui-molecule-tabs-active;
        cursor: pointer;

        svg {
          fill: $c-sui-molecule-tabs-icon-active;
        }
      }
    }
  }

  &--classic#{$base-class}--vertical {
    #{$item-base-class} {
      border: $bdw-s solid transparent;
      border-right-color: $bdc-sui-molecule-tabs;
      font-weight: $fw-sui-molecule-tabs;
      transition: all 0.3s ease; // Add transition for smoother state changes

      &.is-active {
        background: $bgc-sui-molecule-tabs-active;
        border-color: $bdc-sui-molecule-tabs;
        border-right-color: transparent;
        color: $c-sui-molecule-tabs-active;
        font-weight: $fw-sui-molecule-tabs-active;
        box-shadow: $bxsh-active-tab; // Add shadow for depth

        svg {
          fill: $c-sui-molecule-tabs-active;
        }
      }

      &:hover:not(.is-disabled) {
        color: $c-sui-molecule-tabs-active;
        cursor: pointer;

        svg {
          fill: $c-sui-molecule-tabs-active;
        }
      }
    }
  }

  &--highlighted#{$base-class}--horizontal,
  &--highlighted#{$base-class}--fullWidth {
    border-bottom: $bb-sui-molecule-tabs-fullwidth;

    #{$item-base-class} {
      border: 0 none transparent;
      border-bottom: $bdw-sui-molecule-tabs-highlighted solid $bc-sui-molecule-tabs-highlighted;
      text-align: center;
      font-weight: $fw-sui-molecule-tabs;
      transition: all 0.3s ease; // Add transition for smoother state changes

      &.is-active {
        background: $bgc-sui-molecule-tabs-active;
        border-bottom: $bdw-sui-molecule-tabs-highlighted-active solid $bdc-sui-molecule-tabs-highlighted-active;
        border-bottom-color: $bdc-sui-molecule-tabs-highlighted-active;
        color: $c-sui-molecule-tabs-highlighted-active;
        font-weight: $fw-sui-molecule-tabs-active;
        box-shadow: $bxsh-active-tab; // Add shadow for depth

        svg {
          fill: $c-sui-molecule-tabs-active;
        }
      }

      &:hover:not(.is-disabled) {
        color: $c-sui-molecule-tabs-active;
        cursor: pointer;

        svg {
          fill: $c-sui-molecule-tabs-active;
        }
      }
    }

    .sui-MoleculeTabs-content {
      border-top: $bt-sui-molecule-tabs-content;
    }
  }

  &--highlighted#{$base-class}--vertical {
    border-right: 1px solid $bdc-sui-molecule-tabs-highlighted-vertical-right;

    #{$item-base-class} {
      border: 0 none transparent;
      cursor: pointer;
      font-weight: $fw-sui-molecule-tabs;
      transition: all 0.3s ease; // Add transition for smoother state changes

      &.is-active {
        background: $bgc-sui-molecule-tabs-active;
        border-right: $bdw-sui-molecule-tabs-highlighted-active solid $bdc-sui-molecule-tabs-highlighted-active;
        color: $c-sui-molecule-tabs-active;
        font-weight: $fw-sui-molecule-tabs-active;
        box-shadow: $bxsh-active-tab; // Add shadow for depth

        svg {
          fill: $c-sui-molecule-tabs-active;
        }
      }

      &:hover:not(.is-disabled) {
        color: $c-sui-molecule-tabs-active;
        cursor: pointer;

        svg {
          fill: $c-sui-molecule-tabs-active;
        }
      }
    }

    .sui-MoleculeTabs-content {
      border-left: $bdw-sui-molecule-tabs-highlighted solid $bdc-sui-molecule-tabs-highlighted;
    }
  }

// ...existing code...

  &-item {
    @include reset-link;
    align-items: center;
    background: $bg-sui-molecule-tab-item;
    color: $c-sui-molecule-tabs;
    flex: 1 1 auto;
    font-size: $fz-sui-molecule-tabs;
    margin: $m-sui-molecule-tabs-item;
    outline: 0 none;
    padding: $p-sui-molecule-tabs-item;
    text-decoration: none;
    white-space: nowrap;
    width: 100%;
    scroll-snap-align: $ssa-sui-molecule-tabs;
    position: relative; // Added for pseudo-element positioning

    // Add active indicator/marker
    &.is-active::after {
      content: '';
      position: absolute;
      top: 0;
      left: 0;
      width: 4px;
      height: 100%;
      background-color: $c-sui-molecule-tabs-active;
      display: block;
    }

    // Remove left indicator for horizontal tabs
    #{$base-class}--horizontal &.is-active::after,
    #{$base-class}--fullWidth &.is-active::after {
      top: 0;
      left: 0;
      width: 100%;
      height: 4px;
    }

    // ...existing code...
````

These changes will significantly improve the visibility of active tabs by:

1. Adding a light background color ($bgc-sui-molecule-tabs-active) to active tabs
2. Adding a subtle box shadow for depth
3. Increasing the font weight of active tabs to semi-bold
4. Adding a colored indicator bar (pseudo-element) for active tabs
5. Increasing the thickness of the highlighted border for active tabs
6. Adding smooth transitions between states

The combination of these changes will make the active tab much more visually distinct while maintaining the component's overall design aesthetic.

Made changes.

## Notes on AI behaviour

- after the second prompt and given the context of the whole component folder, the visual appearance of the tab with `focus-visible` wasn't quite right
![image](https://github.com/user-attachments/assets/6151d02b-5b30-423d-ac40-566833e67d6d)
