### PR TITLE
Feature/a11y  aria described by validation text

### DIFF
--- a/components/atom/validationText/src/index.js
+++ b/components/atom/validationText/src/index.js
@@ -6,11 +6,11 @@ import Injector from '@s-ui/react-primitive-injector'
 
 import {getClassNames, TYPES} from './settings.js'
 
-const AtomValidationText = forwardRef(({type, text}, forwardedRef) => {
+const AtomValidationText = forwardRef(({text, type, ...props}, forwardedRef) => {
   const isTextString = typeof text === 'string'
   const Component = isTextString ? 'span' : Injector
   return (
-    <Component className={getClassNames(type)} {...(isTextString && {ref: forwardedRef})}>
+    <Component className={getClassNames(type)} {...props} {...(isTextString && {ref: forwardedRef})}>
       {text}
     </Component>
   )

--- a/components/molecule/field/src/index.js
+++ b/components/molecule/field/src/index.js
@@ -48,17 +48,6 @@ const MoleculeField = ({
     fullWidth && CLASS_FULLWIDTH
   )
 
-  const helpTextId = `${name}-help-text`
-
-  const extendedChildren = Children.toArray(children)
-    .filter(Boolean)
-    .map((child, index) => {
-      return cloneElement(child, {
-        onChange: onChangeFromProps,
-        ...(helpText && {[`aria-describedby`]: helpTextId})
-      })
-    })
-
   const typeValidationLabel = useTypeValidationLabel({
     useContrastLabel,
     errorText,
@@ -75,6 +64,18 @@ const MoleculeField = ({
     status,
     statusText
   })
+
+  const helpTextId = `${name}-help-text`
+  const isHelpOrValidationText = helpText || validationTextValue
+
+  const extendedChildren = Children.toArray(children)
+    .filter(Boolean)
+    .map((child, index) => {
+      return cloneElement(child, {
+        onChange: onChangeFromProps,
+        ...(isHelpOrValidationText && {[`aria-describedby`]: helpTextId})
+      })
+    })
 
   return (
     <div
@@ -93,7 +94,12 @@ const MoleculeField = ({
       <div className={cx(CLASS_INPUT_CONTAINER, isAligned && `${CLASS_INPUT_CONTAINER}--aligned`)}>
         {!inline && extendedChildren}
         {!disabled && validationTextValue && (
-          <AtomValidationText type={validationTextStatus} text={validationTextValue} />
+          <AtomValidationText
+            id={helpTextId}
+            text={validationTextValue}
+            type={validationTextStatus}
+            {...(validationTextStatus === AtomValidationTextTypes.ERROR && {role: 'alert'})}
+          />
         )}
         {helpText && <AtomHelpText id={helpTextId} text={helpText} />}
       </div>


### PR DESCRIPTION
## atom/validationText + molecule/field

#### `🔍 Show`

### Description, Motivation, and Context

To solve an a11y issue, we need to add a relationship between the field's help text and the input component.

In this case, we are applying the [same changes we did](https://github.com/SUI-Components/sui-components/pull/2865) to the `helpText` component, but in the `validationText` component.

We need to add an id to the `validationText` but also a `role="alert"` if the status is `ERROR`.

The Molecule Field component can manage that, setting an ID from the `name` prop, and setting the role if it is needed.

### Types of changes

- [x] 🦾 a11y
- [x] ✨ New feature (non-breaking change which adds functionality)