### PR TITLE
feat(components/atom/button): Remove attr shape from button

### DIFF
--- a/components/atom/button/src/config.js
+++ b/components/atom/button/src/config.js
@@ -104,7 +104,8 @@ export const OWN_PROPS = [
   'leftIcon',
   'loadingText',
   'negative',
-  'rightIcon'
+  'rightIcon',
+  'shape'
 ]
 
 /**


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: [DO-2257](https://jira.ets.mpi-internal.com/browse/DO-2257)

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

Add shape to OWN_PROPS, so it gets removed as an attribute from the button and we will address this issue:

> Attribute `shape` not allowed on element `button` at this point.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
