### PR TITLE
Feature/molecule select popover a11y improvements

### DIFF
--- a/components/molecule/selectPopover/demo/Custom/CustomContentWrapper.js
+++ b/components/molecule/selectPopover/demo/Custom/CustomContentWrapper.js
@@ -2,12 +2,12 @@ import PropTypes from 'prop-types'
 
 import MoleculeModal from '@s-ui/react-molecule-modal'
 
-const CustomContentWrapper = ({actions, content, isOpen, setIsOpen}) => {
+const CustomContentWrapper = ({actions, content, id, isOpen, setIsOpen}) => {
   return (
     <MoleculeModal isOpen={isOpen}>
       <MoleculeModal.Overlay />
       <MoleculeModal.Portal>
-        <MoleculeModal.Content>
+        <MoleculeModal.Content id={id}>
           <MoleculeModal.Header>
             <MoleculeModal.Title>Custom select popover</MoleculeModal.Title>
           </MoleculeModal.Header>
@@ -32,6 +32,7 @@ CustomContentWrapper.displayName = 'CustomContentWrapper'
 CustomContentWrapper.propTypes = {
   actions: PropTypes.any,
   content: PropTypes.any,
+  id: PropTypes.string,
   isOpen: PropTypes.bool,
   setIsOpen: PropTypes.func
 }

--- a/components/molecule/selectPopover/demo/index.js
+++ b/components/molecule/selectPopover/demo/index.js
@@ -239,6 +239,7 @@ const Demo = () => {
           fullWidth={isFullWidth}
           hideActions={actionsAreHidden}
           iconArrowDown={IconArrowDown}
+          id="molecule-select-popover-demo"
           isDisabled={isDisabled}
           isSelected={isSelected}
           onAccept={() => setItems(unconfirmedItems)}

--- a/components/molecule/selectPopover/src/config.js
+++ b/components/molecule/selectPopover/src/config.js
@@ -36,3 +36,6 @@ const placements = {
 export const getPlacement = placement => {
   return placements[placement]
 }
+
+export const getContentId = id => `content-${id}`
+export const getLabelId = id => `label-${id}`

--- a/components/molecule/selectPopover/src/index.js
+++ b/components/molecule/selectPopover/src/index.js
@@ -1,4 +1,4 @@
-import {cloneElement, Fragment, useCallback, useEffect, useRef, useState} from 'react'
+import {cloneElement, Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react'
 
 import cx from 'classnames'
 import PropTypes from 'prop-types'
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types'
 import usePortal from '@s-ui/react-hook-use-portal'
 
 import SelectIcon from './components/SelectIcon.js'
-import {BASE_CLASS, getPlacement, OVERLAY_TYPES, PLACEMENTS, SHAPES, SIZES} from './config.js'
+import {BASE_CLASS, getContentId, getLabelId, getPlacement, OVERLAY_TYPES, PLACEMENTS, SHAPES, SIZES} from './config.js'
 import RenderActions from './RenderActions.js'
 
 function usePrevious(value) {
@@ -63,6 +63,8 @@ const MoleculeSelectPopover = ({
   const {Portal} = usePortal({target: overlayContentRef.current})
 
   const hasOverlay = Boolean(overlayContentRef.current) && overlayType !== OVERLAY_TYPES.NONE
+
+  const {contentId, labelId} = useMemo(() => ({contentId: getContentId(id), labelId: getLabelId(id)}), [id])
 
   useEffect(() => {
     forceClosePopover && setIsOpen(false)
@@ -188,7 +190,11 @@ const MoleculeSelectPopover = ({
     }
 
     return (
-      <div
+      <button
+        aria-controls={contentId}
+        aria-expanded={isOpen}
+        aria-haspopup
+        aria-labelledby={labelId}
         className={cx(
           `${BASE_CLASS}-select`,
           shape && `${BASE_CLASS}-select--${shape}`,
@@ -201,11 +207,13 @@ const MoleculeSelectPopover = ({
         )}
         {...newSelectProps}
       >
-        <span className={`${BASE_CLASS}-selectText`}>{selectText}</span>
+        <span className={`${BASE_CLASS}-selectText`} id={labelId}>
+          {selectText}
+        </span>
         <div className={`${BASE_CLASS}-selectIcon`}>
           <SelectIcon iconArrowDown={IconArrowDown} removeButtonOptions={removeButtonOptions} />
         </div>
-      </div>
+      </button>
     )
   }
 
@@ -228,6 +236,7 @@ const MoleculeSelectPopover = ({
       ),
       content: children,
       contentWrapperRef, // required for `handleClickOutside` to work
+      id: contentId,
       isOpen,
       setIsOpen
     }
@@ -244,7 +253,7 @@ const MoleculeSelectPopover = ({
      */
     return (
       pieces.isOpen && (
-        <div className={popoverClassName} ref={contentWrapperRef}>
+        <div className={popoverClassName} id={contentId} ref={contentWrapperRef}>
           <div className={`${BASE_CLASS}-popoverContent`}>{pieces.content}</div>
           {!hideActions && pieces.actions}
         </div>


### PR DESCRIPTION
## Molecule/SelectPopover
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
#### `🔍 Show`
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: [MTR-99281](https://jira.ets.mpi-internal.com/browse/MTR-99281) & [MTR-96049](https://jira.ets.mpi-internal.com/browse/MTR-96049)

### Description, Motivation and Context
# Accessibility Fix: Ensure Accessible Select Controls with Proper Roles and States

## 📌 Issue

Some interactive elements in our filter select components were not accessible to assistive technologies. The following accessibility issues were identified:

- The control had **no permanent visible label** after a selection was made.
- It was missing a **semantic role** (`role="button"` or native `<button>`).
- It did not indicate its **expanded/collapsed state** (`aria-expanded`).
- It lacked the `aria-haspopup` attribute to indicate it **triggers a popup or menu**.
- It was missing `aria-controls` to associate the trigger with the **controlled content**.

## 🧪 Example of the original structure

```html
<div class="sui-MoleculeSelectPopover-select sui-MoleculeSelectPopover-select--m">
  (...)
  <span class="sui-MoleculeSelectPopover-selectText">Marca y modelo</span>
  (...)
</div>

<div class="sui-MoleculeSelectPopover-popover sui-MoleculeSelectPopover-popover–right">
  (...)
</div>
```

This structure lacked semantic role, keyboard support, and ARIA attributes to describe its behavior and relationships.

## ✅ Solution
The DOM structure was updated to:

- Use a native `<button>` element for proper semantics and keyboard support.
- Add a visible and programmatically associated label using `aria-labelledby`.
- Add the following ARIA attributes:
    - `aria-expanded`: indicates whether the content is currently expanded or collapsed.
    - `aria-haspopup="true"`: indicates the element controls a popup.
    - `aria-controls`: points to the id of the element that is being controlled.

## 🛠 Updated structure
```html
<p id="label-mym" class="sui-MoleculeSelectPopover-selectText">Marca y modelo</p>
<button
  class="sui-MoleculeSelectPopover-select sui-MoleculeSelectPopover-select--m"
  aria-expanded="false"
  aria-haspopup="true"
  aria-controls="menu-mym"
  aria-labelledby="label-mym"
>
  (...)
</button>

<div
  class="sui-MoleculeSelectPopover-popover sui-MoleculeSelectPopover-popover--right"
  id="menu-mym"
>
  (...)
</div>
```

## 🎯 Outcome
These changes ensure that:

- The control is **fully navigable and operable** via keyboard.
- **Screen reader users** receive accurate information about the control's name, purpose, state, and relationships.
- The UI now **complies with WCAG 2.1** criteria, particularly:
    - 1.3.1: Info and Relationships
    - 1.3.2: Meaningful Sequence
    - 4.1.2: Name, Role, Value

This improves usability and inclusivity across all user types and assistive technologies.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
