### PR TITLE
feat(components/molecule/breadcrumb): Align breadcrumb items centrally

### DIFF
--- a/components/molecule/breadcrumb/src/styles/index.scss
+++ b/components/molecule/breadcrumb/src/styles/index.scss
@@ -29,6 +29,7 @@ $base-class: '.sui-BreadcrumbBasic';
     display: flex;
     flex-wrap: wrap;
     padding: $sz-base;
+    align-items: center;
 
     .is-scrollable & {
       flex-wrap: nowrap;


### PR DESCRIPTION
## molecule/Breadcrumb
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Added  to ensure breadcrumb items are vertically aligned within their

container. This improves the visual consistency, especially in cases with different item heights.

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [x] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
