### PR TITLE
fix(components/molecule/photoUploader): Pass external props on rotate action

### DIFF
--- a/components/molecule/photoUploader/src/PhotosPreview/index.js
+++ b/components/molecule/photoUploader/src/PhotosPreview/index.js
@@ -99,8 +99,8 @@ const PhotosPreview = ({
         list[index].blob = blob
         list[index].isModified = true
 
-        const {url} = await callbackUploadPhotoHandler(blob, callbackUploadPhoto, list[index].url)
-        list[index].url = url
+        const response = await callbackUploadPhotoHandler(blob, callbackUploadPhoto, list[index].url)
+        list[index] = {...list[index], ...response}
 
         setFiles(list)
         setNotificationError(DEFAULT_NOTIFICATION_ERROR)

--- a/package-lock.json
+++ b/package-lock.json
@@ -182,7 +182,7 @@
     },
     "components/atom/helpText": {
       "name": "@s-ui/react-atom-help-text",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@s-ui/component-dependencies": "1",
@@ -197,6 +197,7 @@
         "@s-ui/react-atom-checkbox": "3",
         "@s-ui/react-atom-icon": "1",
         "@s-ui/react-atom-input": "5",
+        "@s-ui/react-atom-kbd": "1",
         "@s-ui/react-atom-label": "1",
         "@s-ui/react-atom-textarea": "2"
       }
@@ -782,7 +783,7 @@
     },
     "components/molecule/accordion": {
       "name": "@s-ui/react-molecule-accordion",
-      "version": "2.16.0",
+      "version": "2.18.0",
       "license": "MIT",
       "dependencies": {
         "@s-ui/component-dependencies": "1",
@@ -1206,7 +1207,7 @@
     },
     "components/molecule/dropdownOption": {
       "name": "@s-ui/react-molecule-dropdown-option",
-      "version": "2.13.0",
+      "version": "2.14.0",
       "license": "MIT",
       "dependencies": {
         "@s-ui/js": "2",


### PR DESCRIPTION
## MOLECULE / PHOTO UPLOADER
#### `❓ Ask`

**TASK**:  😂  NO IDEA 😂 

### Description, Motivation and Context

As a consumer  of this component, you can pass the `url` and other props to be stored inside the component, and this will let you know more info outside this component when the user performs some action (rotate, delete, order, ...). For example, you can pass an `id`, and this will make your life easier because then a user do an action into the component, the component will pass you all file information. 

With this PR, we aim to improve the `rotate` action, which currently only passes the `url` and not the extra props.

This approach is well-managed in other components' flow, but not in the rotate action. 

### Types of changes

- [x] ✨ New feature (non-breaking change which adds functionality)
