### PR TITLE
fix(components/molecule/photoUploader): Migrate isButton prop to type=button

### DIFF
--- a/components/molecule/photoUploader/src/EmptyView/index.js
+++ b/components/molecule/photoUploader/src/EmptyView/index.js
@@ -40,7 +40,7 @@ const EmptyView = ({
         {dividerText ? <span className={TEXT_STATE_DIVIDER_CLASS_NAME}>{dividerText}</span> : null}
       </div>
       <div className={BUTTON_STATE_CLASS_NAME}>
-        <Button color={buttonColor} design={buttonDesign} isButton shape={buttonShape} size={buttonSize}>
+        <Button color={buttonColor} design={buttonDesign} type="button" shape={buttonShape} size={buttonSize}>
           {buttonText}
         </Button>
       </div>


### PR DESCRIPTION
## MOLECULE / PHOTO UPLOADER
#### `❓ Ask`

**TASK**: NO TICKET

### Description, Motivation and Context
- `isButton` prop is depreceted on `AtomButton`. 
- Use `type=button` because by default a button type default value is `submit` and can trigger a form submit action.

### Types of changes

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool
