### PR TITLE
Feature/a11y  molecule photo uploader

### DIFF
--- a/components/molecule/photoUploader/src/EmptyView/index.js
+++ b/components/molecule/photoUploader/src/EmptyView/index.js
@@ -25,12 +25,19 @@ const EmptyView = ({
   buttonSize = BUTTON_SIZE,
   icon,
   iconSize,
+  inputId,
   text,
   onClick,
   dividerText = ALTERNATIVE_ACTION_TEXT
 }) => {
   return (
-    <div onClick={onClick} className={EMPTY_VIEW_CLASS_NAME}>
+    <div
+      className={EMPTY_VIEW_CLASS_NAME}
+      onClick={ev => {
+        ev.preventDefault()
+        onClick()
+      }}
+    >
       <div className={ICON_EMPTY_VIEW_CLASS_NAME}>
         <AtomIcon size={iconSize}>{icon}</AtomIcon>
       </div>
@@ -40,7 +47,14 @@ const EmptyView = ({
         {dividerText ? <span className={TEXT_STATE_DIVIDER_CLASS_NAME}>{dividerText}</span> : null}
       </div>
       <div className={BUTTON_STATE_CLASS_NAME}>
-        <Button color={buttonColor} design={buttonDesign} type="button" shape={buttonShape} size={buttonSize}>
+        <Button
+          as="label"
+          color={buttonColor}
+          design={buttonDesign}
+          htmlFor={inputId}
+          shape={buttonShape}
+          size={buttonSize}
+        >
           {buttonText}
         </Button>
       </div>
@@ -58,6 +72,7 @@ EmptyView.propTypes = {
   buttonSize: PropTypes.string,
   icon: PropTypes.node.isRequired,
   iconSize: PropTypes.string.isRequired,
+  inputId: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired,
   dividerText: PropTypes.string,
   onClick: PropTypes.func

--- a/components/molecule/photoUploader/src/PhotosPreview/index.js
+++ b/components/molecule/photoUploader/src/PhotosPreview/index.js
@@ -40,6 +40,7 @@ const PhotosPreview = ({
   dragDelay,
   errorInitialPhotoDownloadErrorText,
   files,
+  inputId,
   isPhotoUploaderFully,
   mainPhotoLabel,
   outputImageAspectRatioDisabled,
@@ -214,7 +215,9 @@ const PhotosPreview = ({
     >
       <>
         {thumbCards(files)}
-        {!isPhotoUploaderFully() && <SkeletonCard icon={addMorePhotosIcon()} text={addPhotoTextSkeleton} />}
+        {!isPhotoUploaderFully() && (
+          <SkeletonCard icon={addMorePhotosIcon()} inputId={inputId} text={addPhotoTextSkeleton} />
+        )}
       </>
     </ReactSortable>
   )
@@ -237,6 +240,7 @@ PhotosPreview.propTypes = {
   dragDelay: PropTypes.number.isRequired,
   errorInitialPhotoDownloadErrorText: PropTypes.string.isRequired,
   files: PropTypes.array.isRequired,
+  inputId: PropTypes.string.isRequired,
   isPhotoUploaderFully: PropTypes.bool.isRequired,
   mainPhotoLabel: PropTypes.string.isRequired,
   outputImageAspectRatioDisabled: PropTypes.isRequired,

--- a/components/molecule/photoUploader/src/SkeletonCard/index.js
+++ b/components/molecule/photoUploader/src/SkeletonCard/index.js
@@ -4,13 +4,15 @@ import AtomIcon, {ATOM_ICON_SIZES} from '@s-ui/react-atom-icon'
 
 import {SKELETON_CLASS_NAME} from './config.js'
 
-const SkeletonCard = ({icon, text}) => {
+const SkeletonCard = ({icon, inputId, text}) => {
   return (
     <li className={SKELETON_CLASS_NAME}>
-      <div className={`${SKELETON_CLASS_NAME}-icon`}>
+      <div className={`${SKELETON_CLASS_NAME}-icon`} aria-hidden>
         <AtomIcon size={ATOM_ICON_SIZES.medium}>{icon}</AtomIcon>
       </div>
-      <div className={`${SKELETON_CLASS_NAME}-text`}>{text}</div>
+      <label className={`${SKELETON_CLASS_NAME}-text`} htmlFor={inputId}>
+        {text}
+      </label>
     </li>
   )
 }
@@ -19,6 +21,7 @@ SkeletonCard.displayName = 'SkeletonCard'
 
 SkeletonCard.propTypes = {
   icon: PropTypes.node.isRequired,
+  inputId: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired
 }
 

--- a/components/molecule/photoUploader/src/config.js
+++ b/components/molecule/photoUploader/src/config.js
@@ -1,3 +1,5 @@
+export const DEFAULT_INPUT_ID = 'sui-MoleculePhotoUploader-id'
+
 export const BASE_CLASS_NAME = 'sui-MoleculePhotoUploader'
 export const DROPZONE_CLASS_NAME = `${BASE_CLASS_NAME}-dropzone`
 export const THUMB_CLASS_NAME = `${BASE_CLASS_NAME}-thumb`

--- a/components/molecule/photoUploader/src/index.js
+++ b/components/molecule/photoUploader/src/index.js
@@ -20,6 +20,7 @@ import {
   DEFAULT_FILE_TYPES_ACCEPTED,
   DEFAULT_IMAGE_ASPECT_RATIO,
   DEFAULT_IMAGE_ROTATION_DEGREES,
+  DEFAULT_INPUT_ID,
   DEFAULT_MAX_FILE_SIZE_ACCEPTED,
   DEFAULT_MAX_IMAGE_HEIGHT,
   DEFAULT_MAX_IMAGE_WIDTH,
@@ -66,6 +67,7 @@ const MoleculePhotoUploader = forwardRef(
       errorFormatPhotoUploadedText,
       errorInitialPhotoDownloadErrorText,
       errorSaveImageEndpoint,
+      id = DEFAULT_INPUT_ID,
       infoIcon = noop,
       initialPhotos = [],
       limitPhotosUploadedNotification,
@@ -275,7 +277,7 @@ const MoleculePhotoUploader = forwardRef(
       <>
         <div className={mainClassName}>
           <div {...getRootProps({className: dropzoneClassName})}>
-            <input {...getInputProps()} ref={inputRef} />
+            <input {...getInputProps()} ref={inputRef} id={id} />
             {isPhotoUploaderEmpty && !isDragActive && (
               <EmptyView
                 onClick={onEmptyViewClick}
@@ -286,6 +288,7 @@ const MoleculePhotoUploader = forwardRef(
                 buttonSize={addPhotoButtonSize}
                 icon={dragPhotosIcon()}
                 iconSize={dragPhotosIconSize}
+                inputId={id}
                 text={dragPhotoTextInitialContent}
                 dividerText={dragPhotoDividerTextInitialContent}
               />
@@ -306,6 +309,7 @@ const MoleculePhotoUploader = forwardRef(
                 dragDelay={dragDelay}
                 errorInitialPhotoDownloadErrorText={errorInitialPhotoDownloadErrorText}
                 files={files}
+                inputId={id}
                 isPhotoUploaderFully={isPhotoUploaderFully}
                 mainPhotoLabel={mainPhotoLabel}
                 outputImageAspectRatioDisabled={outputImageAspectRatioDisabled}
@@ -436,6 +440,9 @@ MoleculePhotoUploader.propTypes = {
 
   /** Text showed when the user drag files into the dropzone, to indicate he can drop */
   dropPhotosHereText: PropTypes.string.isRequired,
+
+  /** Id of the input element */
+  id: PropTypes.string,
 
   /**
    *  In this string you can add

--- a/components/molecule/photoUploader/src/styles/index.scss
+++ b/components/molecule/photoUploader/src/styles/index.scss
@@ -21,6 +21,11 @@ $skeleton-class: '#{$base-class}-skeleton';
       padding: $p-photo-uploader-desktop;
     }
 
+    &:focus-visible {
+      outline: 2px solid transparentize($c-primary, 0.2);
+      outline-offset: 2px;
+    }
+
     &--empty {
       background: $bg-photo-uploader-empty;
       border: $bd-photo-uploader-dropzone-empty;


### PR DESCRIPTION
## Molecule / PhotoUploader

#### `🔍 Show`

### Description, Motivation and Context

Make PhotoUploader a more accessible component to be WCAG compliant.
In this PR we are resolving two issues detected by the auditors:
- We use the "upload images" and "upload more images" texts as labels for the file upload input, as suggested by the auditors.
- We add a focus-visible style:

![looooop](https://github.com/user-attachments/assets/82b3e696-583b-4ccd-b436-db01c1bf18a1)

### Types of changes

- [x] 🦾 a11y
- [x] ✨ New feature (non-breaking change which adds functionality)

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
