### PR TITLE
Feature/a11y  molecule photo uploader  make thumb card buttons navigable

### DIFF
--- a/components/molecule/photoUploader/src/PhotosPreview/index.js
+++ b/components/molecule/photoUploader/src/PhotosPreview/index.js
@@ -1,3 +1,4 @@
+import {forwardRef} from 'react'
 import {flushSync} from 'react-dom'
 import {ReactSortable} from 'react-sortablejs'
 
@@ -27,17 +28,19 @@ import {PREVIEW_CARD_CLASS_NAME} from './config.js'
 
 const PhotosPreview = ({
   _callbackPhotosUploaded,
-  _onSortPhotoStart,
   _onSortPhotoEnd,
+  _onSortPhotoStart,
   _scrollToBottom,
   addMorePhotosIcon,
   addPhotoTextSkeleton,
+  ariaLabel,
   callbackUploadPhoto,
   content,
   defaultFormatToBase64Options,
+  deleteButtonAriaLabel,
   deleteIcon,
-  dragIcon,
   dragDelay,
+  dragIcon,
   errorInitialPhotoDownloadErrorText,
   files,
   inputId,
@@ -45,9 +48,11 @@ const PhotosPreview = ({
   mainPhotoLabel,
   outputImageAspectRatioDisabled,
   rejectPhotosIcon,
+  retryButtonAriaLabel,
+  retryIcon,
+  rotateButtonAriaLabel,
   rotateIcon,
   rotationDirection,
-  retryIcon,
   setFiles,
   setIsLoading,
   setNotificationError,
@@ -166,20 +171,23 @@ const PhotosPreview = ({
         <li className={thumbClassName} key={`${file?.preview}${index}`} onClick={e => e.stopPropagation()}>
           {file && (
             <ThumbCard
-              iconSize={thumbIconSize}
-              image={file}
-              index={index}
-              mainPhotoLabel={mainPhotoLabel}
               callbackDeleteItem={_deleteItem}
               callbackRetryUpload={_retryUpload}
               callbackRotateItem={_rotateItem}
               content={content}
-              rotateIcon={rotateIcon()}
+              deleteButtonAriaLabel={deleteButtonAriaLabel}
               deleteIcon={deleteIcon()}
               dragIcon={dragIcon()}
-              retryIcon={retryIcon()}
-              rejectPhotosIcon={rejectPhotosIcon()}
+              iconSize={thumbIconSize}
+              image={file}
+              index={index}
+              mainPhotoLabel={mainPhotoLabel}
               outputImageAspectRatioDisabled={outputImageAspectRatioDisabled}
+              rejectPhotosIcon={rejectPhotosIcon()}
+              retryButtonAriaLabel={retryButtonAriaLabel}
+              retryIcon={retryIcon()}
+              rotateButtonAriaLabel={rotateButtonAriaLabel}
+              rotateIcon={rotateIcon()}
               viewType={viewType}
             />
           )}
@@ -193,12 +201,15 @@ const PhotosPreview = ({
 
   return (
     <ReactSortable
+      // This is a workaround to pass aria-label as prop to ReactSortable custom tag component,
+      // since it does not support it directly.
+      id={ariaLabel}
       className={previewCardClass}
       handle=".sui-MoleculePhotoUploader-thumbCard-imageContainer"
       ghostClass={`${THUMB_CLASS_NAME}--ghost`}
       dragClass={`${THUMB_CLASS_NAME}--drag`}
       chosenClass={`${THUMB_CLASS_NAME}--chosen`}
-      tag="ul"
+      tag={PhotosPreviewCustomTagComponent}
       list={files}
       setList={(newList, sortable) => {
         if (sortable) {
@@ -227,17 +238,19 @@ PhotosPreview.displayName = 'PhotosPreview'
 
 PhotosPreview.propTypes = {
   _callbackPhotosUploaded: PropTypes.func.isRequired,
-  _onSortPhotoStart: PropTypes.func.isRequired,
   _onSortPhotoEnd: PropTypes.func.isRequired,
+  _onSortPhotoStart: PropTypes.func.isRequired,
   _scrollToBottom: PropTypes.func.isRequired,
   addMorePhotosIcon: PropTypes.node.isRequired,
   addPhotoTextSkeleton: PropTypes.string.isRequired,
+  ariaLabel: PropTypes.string.isRequired,
   callbackUploadPhoto: PropTypes.func,
   content: PropTypes.func,
   defaultFormatToBase64Options: PropTypes.object.isRequired,
+  deleteButtonAriaLabel: PropTypes.string.isRequired,
   deleteIcon: PropTypes.node.isRequired,
-  dragIcon: PropTypes.node,
   dragDelay: PropTypes.number.isRequired,
+  dragIcon: PropTypes.node,
   errorInitialPhotoDownloadErrorText: PropTypes.string.isRequired,
   files: PropTypes.array.isRequired,
   inputId: PropTypes.string.isRequired,
@@ -245,9 +258,11 @@ PhotosPreview.propTypes = {
   mainPhotoLabel: PropTypes.string.isRequired,
   outputImageAspectRatioDisabled: PropTypes.isRequired,
   rejectPhotosIcon: PropTypes.node.isRequired,
+  retryButtonAriaLabel: PropTypes.string.isRequired,
+  retryIcon: PropTypes.node.isRequired,
+  rotateButtonAriaLabel: PropTypes.string.isRequired,
   rotateIcon: PropTypes.node.isRequired,
   rotationDirection: PropTypes.oneOf(Object.values(ROTATION_DIRECTION)),
-  retryIcon: PropTypes.node.isRequired,
   setFiles: PropTypes.func.isRequired,
   setIsLoading: PropTypes.func.isRequired,
   setNotificationError: PropTypes.func.isRequired,
@@ -256,3 +271,17 @@ PhotosPreview.propTypes = {
 }
 
 export default PhotosPreview
+
+const PhotosPreviewCustomTagComponent = forwardRef(({id: ariaLabel, children, className}, ref) => {
+  return (
+    <ul className={className} aria-label={ariaLabel} ref={ref}>
+      {children}
+    </ul>
+  )
+})
+PhotosPreviewCustomTagComponent.displayName = 'PhotosPreviewCustomTagComponent'
+PhotosPreviewCustomTagComponent.propTypes = {
+  id: PropTypes.string,
+  children: PropTypes.node,
+  className: PropTypes.string
+}

--- a/components/molecule/photoUploader/src/SkeletonCard/index.js
+++ b/components/molecule/photoUploader/src/SkeletonCard/index.js
@@ -7,12 +7,14 @@ import {SKELETON_CLASS_NAME} from './config.js'
 const SkeletonCard = ({icon, inputId, text}) => {
   return (
     <li className={SKELETON_CLASS_NAME}>
-      <div className={`${SKELETON_CLASS_NAME}-icon`} aria-hidden>
-        <AtomIcon size={ATOM_ICON_SIZES.medium}>{icon}</AtomIcon>
-      </div>
-      <label className={`${SKELETON_CLASS_NAME}-text`} htmlFor={inputId}>
-        {text}
-      </label>
+      <button className={`${SKELETON_CLASS_NAME}Button`} type="button">
+        <div className={`${SKELETON_CLASS_NAME}-icon`} aria-hidden>
+          <AtomIcon size={ATOM_ICON_SIZES.medium}>{icon}</AtomIcon>
+        </div>
+        <label className={`${SKELETON_CLASS_NAME}-text`} htmlFor={inputId} onClick={ev => ev.preventDefault()}>
+          {text}
+        </label>
+      </button>
     </li>
   )
 }

--- a/components/molecule/photoUploader/src/ThumbCard/index.js
+++ b/components/molecule/photoUploader/src/ThumbCard/index.js
@@ -1,7 +1,8 @@
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 
-import AtomIcon, {ATOM_ICON_SIZES} from '@s-ui/react-atom-icon'
+import AtomButton, {atomButtonDesigns, atomButtonSizes} from '@s-ui/react-atom-button'
+import AtomIcon, {ATOM_ICON_COLORS, ATOM_ICON_SIZES} from '@s-ui/react-atom-icon'
 
 import {DEFAULT_VIEW_TYPE, VIEW_TYPE} from './../config.js'
 import {
@@ -14,26 +15,29 @@ import {
 } from './config.js'
 
 const ThumbCard = ({
-  iconSize = ATOM_ICON_SIZES.small,
   callbackDeleteItem,
   callbackRetryUpload,
   callbackRotateItem,
   content: Content = () => null,
+  deleteButtonAriaLabel,
   deleteIcon,
   dragIcon,
-  index,
+  iconSize = ATOM_ICON_SIZES.small,
   image,
+  index,
   mainPhotoLabel,
   outputImageAspectRatioDisabled,
   rejectPhotosIcon,
+  retryButtonAriaLabel,
   retryIcon,
+  rotateButtonAriaLabel,
   rotateIcon,
   viewType
 }) => {
   const hasErrors = image.hasErrors
 
   const isDefaultView = viewType === DEFAULT_VIEW_TYPE
-  const isListtView = viewType === VIEW_TYPE.LIST
+  const isListView = viewType === VIEW_TYPE.LIST
 
   const counterClass = cx(`${THUMB_CARD_CLASS_NAME}-counter`, {
     [`${THUMB_CARD_CLASS_NAME}-mainCounter`]: index === 0 && isDefaultView
@@ -43,9 +47,11 @@ const ThumbCard = ({
     [`${IMAGE_THUMB_CARD_CLASS_NAME}--ratioDisabled`]: outputImageAspectRatioDisabled
   })
 
+  const thumbCardLabel = index === 0 && isDefaultView ? mainPhotoLabel : index + 1
+
   return (
     <div className={THUMB_CARD_CLASS_NAME}>
-      <div className={counterClass}>{index === 0 && isDefaultView ? mainPhotoLabel : index + 1}</div>
+      <div className={counterClass}>{thumbCardLabel}</div>
       <div className={CONTAINER_THUMB_CARD_CLASS_NAME}>
         {hasErrors ? (
           <div className={`${ICON_THUMB_CARD_CLASS_NAME}`}>
@@ -53,23 +59,65 @@ const ThumbCard = ({
           </div>
         ) : (
           <>
-            {isListtView && <AtomIcon size={iconSize}>{dragIcon}</AtomIcon>}
+            {isListView && <AtomIcon size={iconSize}>{dragIcon}</AtomIcon>}
             <img src={image.preview} className={imageThumbClass} />
           </>
         )}
       </div>
       <Content file={image} index={index} />
       <div className={ACTION_THUMB_CARD_CLASS_NAME}>
-        <div className={BUTTON_THUMB_CARD_CLASS_NAME} onClick={() => callbackDeleteItem(index)}>
-          <AtomIcon size={iconSize}>{deleteIcon}</AtomIcon>
+        <div className={BUTTON_THUMB_CARD_CLASS_NAME}>
+          <AtomButton
+            aria-label={`${deleteButtonAriaLabel} ${thumbCardLabel}`}
+            design={atomButtonDesigns.LINK}
+            fullWidth
+            onClick={() => callbackDeleteItem(index)}
+            size={atomButtonSizes.SMALL}
+            tabIndex="0"
+            type="button"
+          >
+            <div className={`${BUTTON_THUMB_CARD_CLASS_NAME}Icon`}>
+              <AtomIcon color={ATOM_ICON_COLORS.currentColor} size={iconSize}>
+                {deleteIcon}
+              </AtomIcon>
+            </div>
+          </AtomButton>
         </div>
         {hasErrors ? (
-          <div className={BUTTON_THUMB_CARD_CLASS_NAME} onClick={e => callbackRetryUpload(index)}>
-            <AtomIcon size={iconSize}>{retryIcon}</AtomIcon>
+          <div className={BUTTON_THUMB_CARD_CLASS_NAME}>
+            <AtomButton
+              aria-label={`${retryButtonAriaLabel} ${thumbCardLabel}`}
+              design={atomButtonDesigns.LINK}
+              fullWidth
+              onClick={() => callbackRetryUpload(index)}
+              size={atomButtonSizes.SMALL}
+              tabIndex="0"
+              type="button"
+            >
+              <div className={`${BUTTON_THUMB_CARD_CLASS_NAME}Icon`}>
+                <AtomIcon color={ATOM_ICON_COLORS.currentColor} size={iconSize}>
+                  {retryIcon}
+                </AtomIcon>
+              </div>
+            </AtomButton>
           </div>
         ) : (
-          <div className={BUTTON_THUMB_CARD_CLASS_NAME} onClick={e => callbackRotateItem(index)}>
-            <AtomIcon size={iconSize}>{rotateIcon}</AtomIcon>
+          <div className={BUTTON_THUMB_CARD_CLASS_NAME}>
+            <AtomButton
+              aria-label={`${rotateButtonAriaLabel} ${thumbCardLabel}`}
+              design={atomButtonDesigns.LINK}
+              fullWidth
+              onClick={() => callbackRotateItem(index)}
+              size={atomButtonSizes.SMALL}
+              tabIndex="0"
+              type="button"
+            >
+              <div className={`${BUTTON_THUMB_CARD_CLASS_NAME}Icon`}>
+                <AtomIcon color={ATOM_ICON_COLORS.currentColor} size={iconSize}>
+                  {rotateIcon}
+                </AtomIcon>
+              </div>
+            </AtomButton>
           </div>
         )}
       </div>
@@ -80,19 +128,22 @@ const ThumbCard = ({
 ThumbCard.displayName = 'ThumbCard'
 
 ThumbCard.propTypes = {
-  iconSize: PropTypes.oneOf(Object.keys(ATOM_ICON_SIZES)),
   callbackDeleteItem: PropTypes.func,
   callbackRetryUpload: PropTypes.func,
   callbackRotateItem: PropTypes.func,
   content: PropTypes.func,
+  deleteButtonAriaLabel: PropTypes.string.isRequired,
   deleteIcon: PropTypes.node.isRequired,
   dragIcon: PropTypes.node.isRequired,
-  index: PropTypes.number,
+  iconSize: PropTypes.oneOf(Object.keys(ATOM_ICON_SIZES)),
   image: PropTypes.object.isRequired,
+  index: PropTypes.number,
   mainPhotoLabel: PropTypes.string,
   outputImageAspectRatioDisabled: PropTypes.bool,
   rejectPhotosIcon: PropTypes.node.isRequired,
+  retryButtonAriaLabel: PropTypes.string.isRequired,
   retryIcon: PropTypes.node.isRequired,
+  rotateButtonAriaLabel: PropTypes.string.isRequired,
   rotateIcon: PropTypes.node.isRequired,
   viewType: PropTypes.oneOf(Object.keys(VIEW_TYPE))
 }

--- a/components/molecule/photoUploader/src/index.js
+++ b/components/molecule/photoUploader/src/index.js
@@ -53,6 +53,7 @@ const MoleculePhotoUploader = forwardRef(
       callbackPhotosUploaded = noop,
       callbackUploadPhoto,
       content,
+      deleteButtonAriaLabel = '',
       deleteIcon,
       dragIcon = noop,
       disableScrollToBottom = false,
@@ -85,8 +86,11 @@ const MoleculePhotoUploader = forwardRef(
       onSortPhotoEnd = noop,
       outputImageAspectRatio = DEFAULT_IMAGE_ASPECT_RATIO,
       outputImageAspectRatioDisabled = false,
+      photosPreviewAriaLabel,
       rejectPhotosIcon,
+      retryButtonAriaLabel = '',
       retryIcon,
+      rotateButtonAriaLabel = '',
       rotateIcon,
       rotationDirection = ROTATION_DIRECTION.counterclockwise,
       thumbIconSize,
@@ -295,18 +299,20 @@ const MoleculePhotoUploader = forwardRef(
             )}
             {!isPhotoUploaderEmpty && (
               <PhotosPreview
+                _callbackPhotosUploaded={_callbackPhotosUploaded}
                 _onSortPhotoEnd={_onSortPhotoEnd}
                 _onSortPhotoStart={_onSortPhotoStart}
-                _callbackPhotosUploaded={_callbackPhotosUploaded}
                 _scrollToBottom={_scrollToBottom}
                 addMorePhotosIcon={addMorePhotosIcon}
                 addPhotoTextSkeleton={addPhotoTextSkeleton}
+                ariaLabel={photosPreviewAriaLabel ?? addPhotoTextButton}
                 callbackUploadPhoto={callbackUploadPhoto}
                 content={content}
                 defaultFormatToBase64Options={DEFAULT_FORMAT_TO_BASE_64_OPTIONS}
+                deleteButtonAriaLabel={deleteButtonAriaLabel}
                 deleteIcon={deleteIcon}
-                dragIcon={dragIcon}
                 dragDelay={dragDelay}
+                dragIcon={dragIcon}
                 errorInitialPhotoDownloadErrorText={errorInitialPhotoDownloadErrorText}
                 files={files}
                 inputId={id}
@@ -314,9 +320,11 @@ const MoleculePhotoUploader = forwardRef(
                 mainPhotoLabel={mainPhotoLabel}
                 outputImageAspectRatioDisabled={outputImageAspectRatioDisabled}
                 rejectPhotosIcon={rejectPhotosIcon}
+                retryButtonAriaLabel={retryButtonAriaLabel}
+                retryIcon={retryIcon}
+                rotateButtonAriaLabel={rotateButtonAriaLabel}
                 rotateIcon={rotateIcon}
                 rotationDirection={rotationDirection}
-                retryIcon={retryIcon}
                 setFiles={setFiles}
                 setIsLoading={setIsLoading}
                 setNotificationError={setNotificationError}
@@ -410,6 +418,11 @@ MoleculePhotoUploader.propTypes = {
 
   /** Component to render inside content space */
   content: PropTypes.elementType,
+
+  /**
+   * Aria label for the delete button on thumbcards
+   */
+  deleteButtonAriaLabel: PropTypes.string,
 
   /** Icon placed in the button that deletes image */
   deleteIcon: PropTypes.func.isRequired,
@@ -523,11 +536,24 @@ MoleculePhotoUploader.propTypes = {
   /** Disable cropping funcionality */
   outputImageAspectRatioDisabled: PropTypes.bool,
 
+  /** Aria label for the photos preview */
+  photosPreviewAriaLabel: PropTypes.string,
+
   /** Icon showed at the dropzone when an user drags (before drop!) not allowed files  */
   rejectPhotosIcon: PropTypes.func.isRequired,
 
+  /**
+   * Aria label for the retry button on thumbcards
+   */
+  retryButtonAriaLabel: PropTypes.string,
+
   /** Icon placed in the button that retry download initial image, when it fails */
   retryIcon: PropTypes.func.isRequired,
+
+  /**
+   * Aria label for the rotate button on thumbcards
+   */
+  rotateButtonAriaLabel: PropTypes.string,
 
   /** Icon placed in the button that rotate image */
   rotateIcon: PropTypes.func.isRequired,

--- a/components/molecule/photoUploader/src/styles/index.scss
+++ b/components/molecule/photoUploader/src/styles/index.scss
@@ -310,16 +310,26 @@ $skeleton-class: '#{$base-class}-skeleton';
         border-radius: 0 0 $bdrs-photo-uploader-thumb-card 0;
       }
 
+      &Icon {
+        color: $c-photo-uploader-action-buttons;
+      }
+
       &:hover {
         @include media-breakpoint-up(m) {
           background: $bg-photo-uploader-action-buttons-hover;
-          color: $c-photo-uploader-action-buttons-hover;
+
+          #{$thumb-class}Card-buttonIcon {
+            color: $c-photo-uploader-action-buttons-hover;
+          }
         }
       }
 
       &:active {
         background: $bg-photo-uploader-action-buttons-hover;
-        color: $c-photo-uploader-action-buttons-hover;
+
+        #{$thumb-class}Card-buttonIcon {
+          color: $c-photo-uploader-action-buttons-hover;
+        }
       }
 
       &:last-child {
@@ -355,31 +365,52 @@ $skeleton-class: '#{$base-class}-skeleton';
 }
 
 #{$skeleton-class} {
-  align-items: center;
   background-color: $bg-photo-uploader-skeleton;
-  border: $bd-photo-uploader;
   border-radius: $bdrs-photo-uploader-skeleton;
-  color: $c-photo-uploader-skeleton;
-  cursor: pointer;
   display: flex;
-  flex-direction: column;
-  font-weight: $fw-semi-bold;
-  justify-content: center;
-  overflow: hidden;
   width: $w-photo-uploader-skeleton;
+
+  &Button {
+    background-color: transparent;
+    border: $bd-photo-uploader;
+    border-radius: $bdrs-photo-uploader-skeleton;
+    color: $c-photo-uploader-skeleton;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    font-weight: $fw-semi-bold;
+    height: 100%;
+    justify-content: center;
+    width: 100%;
+
+    &:hover {
+      color: $c-photo-uploader-skeleton-hover;
+    }
+
+    &:active {
+      color: $c-photo-uploader-skeleton-hover;
+    }
+
+    &:focus-visible {
+      outline: 2px solid transparentize($c-primary, 0.2);
+      outline-offset: 2px;
+    }
+  }
 
   @include media-breakpoint-up(m) {
     width: $w-photo-uploader-skeleton-desktop;
   }
 
-  &:hover {
+  &:hover,
+  &:hover #{$skeleton-class}Button {
     @include media-breakpoint-up(m) {
       background: $bg-photo-uploader-skeleton-hover;
       color: $c-photo-uploader-skeleton-hover;
     }
   }
 
-  &:active {
+  &:active,
+  &:active #{$skeleton-class}Button {
     background: $bg-photo-uploader-skeleton-hover;
     color: $c-photo-uploader-skeleton-hover;
   }

--- a/components/molecule/photoUploader/src/styles/settings.scss
+++ b/components/molecule/photoUploader/src/styles/settings.scss
@@ -40,7 +40,7 @@ $gg-photo-uploader-thumb-image: $m-m !default;
 $gg-photo-uploader-thumb-image-desktop: $gg-photo-uploader-thumb-image !default;
 $gtc-photo-uploader-thumb-image: 45% !default;
 $jc-photo-uploader: center !default;
-$p-photo-uploader-action-buttons: $p-m 0 !default;
+$p-photo-uploader-action-buttons: $p-s 0 !default;
 $p-photo-uploader-desktop: $p-xl !default;
 $p-photo-uploader: $p-m !default;
 $s-photo-uploader-thumb-icons: 16px !default;


### PR DESCRIPTION
## Molecule / PhotoUploader
#### `🔍 Show`

![rurura](https://github.com/user-attachments/assets/d3c24e21-c62e-4012-9f7d-0326b6871280)

### Description, Motivation, and Context
This PR adds keyboard navigation and screen readability to the photo uploader component.

### Types of changes

- [x] 🦾 a11y
- [x] ✨ New feature (non-breaking change which adds functionality)