### PR TITLE
feat(components/atom/input): add aria-label to password toggle button

### DIFF
--- a/components/atom/input/src/Password/index.js
+++ b/components/atom/input/src/Password/index.js
@@ -10,7 +10,7 @@ import Input from '../Input/index.js'
 import {BASE_CLASS_PASSWORD, BASE_CLASS_PASSWORD_TOGGLE_BUTTON, PASSWORD, TEXT} from './config.js'
 
 const Password = forwardRef(
-  ({onChange, shape, pwShowLabel, pwHideLabel, value, defaultValue = '', ...props}, forwardedRef) => {
+  ({onChange, shape, pwShowLabel, pwHideLabel, toggleAriaLabel, value, defaultValue = '', ...props}, forwardedRef) => {
     const [type, setType] = useState(PASSWORD)
     const [innerValue, setInnerValue] = useControlledState(value, defaultValue)
 
@@ -39,6 +39,7 @@ const Password = forwardRef(
           onClick={toggle}
           type="button"
           aria-pressed={type !== PASSWORD}
+          aria-label={toggleAriaLabel}
           className={cx(
             BASE_CLASS_PASSWORD_TOGGLE_BUTTON,
             shape && `${BASE_CLASS_PASSWORD_TOGGLE_BUTTON}-shape-${shape}`
@@ -56,6 +57,8 @@ Password.propTypes = {
   pwShowLabel: PropTypes.node,
   /* Text to be shown to hide the password on click */
   pwHideLabel: PropTypes.node,
+  /* Aria label for the toggle button */
+  toggleAriaLabel: PropTypes.string,
   /* Event launched on every input change */
   onChange: PropTypes.func,
   /* The name of the control */


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
#### `🔍 Show`
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
This PR adds missing `aria-label` attribute to password toggle button.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool
