### PR TITLE
feat(components/molecule/buttonGroup): split props between own and child

### DIFF
--- a/components/molecule/buttonGroup/src/index.js
+++ b/components/molecule/buttonGroup/src/index.js
@@ -8,7 +8,7 @@ import Injector from '@s-ui/react-primitive-injector'
 import Poly from '@s-ui/react-primitive-polymorphic-element'
 
 import {DEFAULT_COLUMNS, DISPLAY, SPACED} from './config.js'
-import {BASE_CLASS} from './settings.js'
+import {BASE_CLASS, divideProps} from './settings.js'
 
 const getGroupPosition =
   ({groupPositions, numChildren, spaced, shape}) =>
@@ -31,6 +31,8 @@ const MoleculeButtonGroup = ({
   design,
   display,
   negative,
+  role,
+  className,
   groupPositions = {
     FIRST: 'first',
     MIDDLE: 'middle',
@@ -41,7 +43,7 @@ const MoleculeButtonGroup = ({
   spaced,
   isVertical,
   shape,
-  ...props
+  ...rest
 }) => {
   const numChildren = children.length
 
@@ -70,6 +72,8 @@ const MoleculeButtonGroup = ({
   const CLASS_DISPLAY = getClassDisplay({display})
   const CLASS_DISPLAY_COLUMNS = getClassDisplayColumns({display, columns})
 
+  const [ownProps, childProps] = divideProps(rest)
+
   const extendedChildren = Children.toArray(children)
     .filter(Boolean)
     .map((child, index) => {
@@ -77,7 +81,7 @@ const MoleculeButtonGroup = ({
 
       return (
         <Injector
-          {...props}
+          {...childProps}
           negative={negative}
           size={size}
           design={design}
@@ -99,8 +103,11 @@ const MoleculeButtonGroup = ({
         display && CLASS_DISPLAY,
         display && CLASS_DISPLAY_COLUMNS,
         spaced && CLASS_SPACED,
-        isVertical && `${BASE_CLASS}--vertical`
+        isVertical && `${BASE_CLASS}--vertical`,
+        className
       )}
+      role={{role}}
+      {...ownProps}
     >
       {extendedChildren}
     </Poly>
@@ -157,7 +164,13 @@ MoleculeButtonGroup.propTypes = {
   isVertical: PropTypes.bool,
 
   /** Shape of button */
-  shape: PropTypes.oneOf(Object.values(atomButtonShapes))
+  shape: PropTypes.oneOf(Object.values(atomButtonShapes)),
+
+  /** Additional classes */
+  className: PropTypes.string,
+
+  /** The HTML role **/
+  role: PropTypes.string
 }
 
 export default MoleculeButtonGroup

--- a/components/molecule/buttonGroup/src/settings.js
+++ b/components/molecule/buttonGroup/src/settings.js
@@ -1,1 +1,14 @@
 export const BASE_CLASS = 'sui-MoleculeButtonGroup'
+
+export const divideProps = props =>
+  Object.entries(props).reduce(
+    ([filtered, result], [currKey, currVal]) => {
+      if (currKey.startsWith('data-') || currKey.startsWith('aria-') || currKey === 'role') {
+        filtered[currKey] = currVal
+      } else {
+        result[currKey] = currVal
+      }
+      return [filtered, result]
+    },
+    [{}, {}]
+  )

--- a/components/molecule/buttonGroup/test/index.test.js
+++ b/components/molecule/buttonGroup/test/index.test.js
@@ -80,7 +80,7 @@ describe(json.name, () => {
       expect(container.innerHTML).to.not.have.lengthOf(0)
     })
 
-    it.skip('should NOT extend classNames', () => {
+    it.skip('should extend classNames', () => {
       // Given
       const props = {
         children: [<AtomButton key={0}>A</AtomButton>, <AtomButton key={1}>B</AtomButton>],
@@ -93,7 +93,39 @@ describe(json.name, () => {
       const findClassName = findSentence(props.className)
 
       // Then
-      expect(findClassName(container.innerHTML)).to.be.null
+      expect(findClassName(container.innerHTML)).to.not.be.null
+    })
+
+    it('should have data attributes', () => {
+      // Given
+      const props = {
+        'data-attribute': 'data-attribute',
+        children: [<AtomButton key={0}>A</AtomButton>, <AtomButton key={1}>B</AtomButton>],
+        className: 'extended-classNames'
+      }
+
+      // When
+      const {container} = setup(props)
+      const element = container.querySelector('[data-attribute]')
+
+      // Then
+      expect(element).to.not.be.null
+    })
+
+    it('should have aria attributes', () => {
+      // Given
+      const props = {
+        'aria-attribute': 'aria-attribute',
+        children: [<AtomButton key={0}>A</AtomButton>, <AtomButton key={1}>B</AtomButton>],
+        className: 'extended-classNames'
+      }
+
+      // When
+      const {container} = setup(props)
+      const element = container.querySelector('[aria-attribute]')
+
+      // Then
+      expect(element).to.not.be.null
     })
   })
 


### PR DESCRIPTION
## Molecule/Buttongroup
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
