### PR TITLE
feat(components/molecule/dropdownOption): remove styles for focused element

### DIFF
--- a/components/molecule/dropdownOption/src/styles/index.scss
+++ b/components/molecule/dropdownOption/src/styles/index.scss
@@ -84,8 +84,7 @@ $base-class: '.sui-MoleculeDropdownOption';
     cursor: default;
   }
 
-  &:hover,
-  &:focus {
+  &:hover {
     background-color: $bgc-dropdown-option-hover;
     color: $c-dropdown-option-hover;
     cursor: pointer;


### PR DESCRIPTION
## Category/Component
`❓ Ask`

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
The default styles for the first element on a dropdown looks the same as if it was on hover.
This `PR` leaves the first element, even if it is on focused state by the browser, unstyled.  

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [x] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations

**Before:**
<img width="585" height="296" alt="image" src="https://github.com/user-attachments/assets/89bf68c8-c815-48cd-b22f-19cd256355df" />

**After:**
<img width="515" height="301" alt="image" src="https://github.com/user-attachments/assets/46f65122-f96f-4ad4-a2b0-7f22cd3fe494" />
