### PR TITLE
feat(Root): pass down disabled prop to molecule select field

### DIFF
--- a/components/molecule/selectField/src/index.js
+++ b/components/molecule/selectField/src/index.js
@@ -19,6 +19,7 @@ const MoleculeSelectField = ({
   alertText,
   onChange: handleChange,
   className,
+  disabled,
   ...props
 }) => {
   const refSelect = useRef()
@@ -33,6 +34,7 @@ const MoleculeSelectField = ({
 
   return (
     <MoleculeField
+      disabled={disabled}
       errorText={errorText}
       helpText={helpText}
       inline={inline}
@@ -46,6 +48,7 @@ const MoleculeSelectField = ({
     >
       <MoleculeSelect
         className={className}
+        disabled={disabled}
         errorState={errorState}
         refMoleculeSelect={refSelect}
         state={selectState}
@@ -66,6 +69,9 @@ MoleculeSelectField.propTypes = {
 
   /** className */
   className: PropTypes.string,
+
+  /** Boolean to decide if element is disabled */
+  disabled: PropTypes.bool,
 
   /** Error message to display when error state  */
   errorText: PropTypes.string,


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
`disabled` prop was not being passed down to `molecule/field` and so the `atom/label` component was not properly styling the label. With this change, the opacity can be customised by setting the `$o-atom-label-disabled`. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations

Before:
<img width="403" height="199" alt="image" src="https://github.com/user-attachments/assets/6d2d3599-b7c4-4a58-8ba8-c6e7a8ea12ab" />

After:
<img width="400" height="194" alt="image" src="https://github.com/user-attachments/assets/4ada591a-aa80-46f6-bb50-0e4273fc916a" />

