### PR TITLE
Feat/add right icon multiselection autosuggest

### DIFF
--- a/components/molecule/autosuggest/README.md
+++ b/components/molecule/autosuggest/README.md
@@ -81,6 +81,47 @@ const suggestions = ['John','Johnny']
 </MoleculeAutosuggest>
 ```
 
+#### With Right Icon
+You can add a right icon to the multiselection input:
+```js
+<MoleculeAutosuggest
+  value={'Jo'}
+  placeholder="Select some options..."
+  iconCloseTag={<IconCloseTag />}
+  iconClear={<IconClear />}
+  rightIcon={<IconInfo />}
+  multiselection
+>
+  {suggestions.map((suggestion, i) => (
+    <MoleculeAutosuggestOption key={i} value={suggestion}>
+      {option}
+    </MoleculeAutosuggestOption>
+  ))}
+</MoleculeAutosuggest>
+```
+
+#### With Right Icon and Click Handler
+The right icon can be interactive with an `onClickRightIcon` callback:
+```js
+<MoleculeAutosuggest
+  value={'Jo'}
+  placeholder="Select some options..."
+  iconCloseTag={<IconCloseTag />}
+  iconClear={<IconClear />}
+  rightIcon={<IconSearch />}
+  onClickRightIcon={(ev, {value}) => {
+    console.log('Right icon clicked with value:', value)
+  }}
+  multiselection
+>
+  {suggestions.map((suggestion, i) => (
+    <MoleculeAutosuggestOption key={i} value={suggestion}>
+      {option}
+    </MoleculeAutosuggestOption>
+  ))}
+</MoleculeAutosuggest>
+```
+
 ### Managing State
 
 #### Custom component from `MoleculeAutosuggest` that handle State

--- a/components/molecule/autosuggest/demo/ArticleMultipleSelection/index.js
+++ b/components/molecule/autosuggest/demo/ArticleMultipleSelection/index.js
@@ -40,6 +40,17 @@ const ArticleMultipleSelection = () => {
         multiselection
         disabled
       />
+      <H3>With Right Icon and onClick handler</H3>
+      <MoleculeAutosuggestWithStateTags
+        placeholder="Type a Country name..."
+        onChangeTags={(_, {tags, ...args}) => console.log('onChangeTags', {tags, ...args})}
+        iconCloseTag={iconClose}
+        rightIcon={iconSearch}
+        onClickRightIcon={(ev, args) => {
+          console.log('Right icon clicked!', args)
+        }}
+        multiselection
+      />
     </Article>
   )
 }

--- a/components/molecule/autosuggest/demo/ArticleMultipleSelection/index.js
+++ b/components/molecule/autosuggest/demo/ArticleMultipleSelection/index.js
@@ -2,7 +2,7 @@
 import {Article, Code, H2, H3, Paragraph} from '@s-ui/documentation-library'
 
 import {MoleculeAutosuggestWithStateTags} from '../config.js'
-import {iconClose} from '../Icons/index.js'
+import {iconClose, iconSearch} from '../Icons/index.js'
 
 const ArticleMultipleSelection = () => {
   return (

--- a/components/molecule/autosuggest/demo/index.js
+++ b/components/molecule/autosuggest/demo/index.js
@@ -1,60 +1,37 @@
-/* eslint-disable  no-console */
-import {Article, Code, H2, H3, Paragraph} from '@s-ui/documentation-library'
+import {Code, H1, Paragraph} from '@s-ui/documentation-library'
 
-import {MoleculeAutosuggestWithStateTags} from '../config.js'
-import {iconClose, iconSearch} from '../Icons/index.js'
+import ArticleArrayObjects from './ArticleArrayObjects/index.js'
+import ArticleDependantSelection from './ArticleDependantSelection/index.js'
+import ArticleIsOpenProp from './ArticleIsOpenProp/index.js'
+import ArticleMultipleSelection from './ArticleMultipleSelection/index.js'
+import ArticleSingleSelection from './ArticleSingleSelection/index.js'
 
-const ArticleMultipleSelection = () => {
-  return (
-    <Article>
-      <H2>Multiple Selection</H2>
+import './index.scss'
+
+const Demo = () => (
+  <div className="sui-StudioPreview">
+    <div className="sui-StudioPreview-content sui-StudioDemo-preview">
+      <H1>Autosuggest</H1>
       <Paragraph>
-        This component allows you to add new options (such as tags) even if they are not available among the available
-        options of <Code>DropdownList</Code>
+        This component should only be used when the input is writable (resulting in a search of the{' '}
+        <Code>DropdownList</Code> options)
       </Paragraph>
-      <H3>with Placeholder</H3>
-      <MoleculeAutosuggestWithStateTags
-        placeholder="Type a Country name..."
-        onChangeTags={(_, {tags, ...args}) => console.log('onChangeTags', {tags, ...args})}
-        onClear={() => console.log('Clear pressed')}
-        iconCloseTag={iconClose}
-        iconClear={iconClose}
-        multiselection
-      />
-      <H3>With preselected Value</H3>
-      <MoleculeAutosuggestWithStateTags
-        tags={['India', 'Luxembourg']}
-        onChangeTags={(_, {tags, ...args}) => console.log('onChangeTags', {tags, ...args})}
-        onClear={() => console.log('Clear pressed')}
-        iconCloseTag={iconClose}
-        iconClear={iconClose}
-        multiselection
-      />
-      <H3>Disabled</H3>
-      <MoleculeAutosuggestWithStateTags
-        tags={['India', 'Luxembourg']}
-        onChangeTags={(_, {tags, ...args}) => console.log('onChangeTags', {tags, ...args})}
-        onClear={() => console.log('Clear pressed')}
-        iconCloseTag={iconClose}
-        iconClear={iconClose}
-        multiselection
-        disabled
-      />
-      <H3>With Right Icon and onClick handler</H3>
-      <MoleculeAutosuggestWithStateTags
-        placeholder="Type a Country name..."
-        onChangeTags={(_, {tags, ...args}) => console.log('onChangeTags', {tags, ...args})}
-        iconCloseTag={iconClose}
-        rightIcon={iconSearch}
-        onClickRightIcon={(ev, args) => {
-          console.log('Right icon clicked!', args)
-        }}
-        multiselection
-      />
-    </Article>
-  )
-}
+      <Paragraph>
+        In this demo, we only use the default size of <Code>DropdownList</Code> and basic options of{' '}
+        <Code>DropdownOption</Code> components. Keep in mind, those two components has more possibilities if you need
+        it.
+      </Paragraph>
+      <ArticleSingleSelection />
+      <br />
+      <ArticleMultipleSelection />
+      <br />
+      <ArticleDependantSelection />
+      <br />
+      <ArticleIsOpenProp />
+      <br />
+      <ArticleArrayObjects />
+    </div>
+  </div>
+)
 
-ArticleMultipleSelection.propTypes = {}
-
-export default ArticleMultipleSelection
+export default Demo

--- a/components/molecule/autosuggest/demo/index.js
+++ b/components/molecule/autosuggest/demo/index.js
@@ -1,37 +1,60 @@
-import {Code, H1, Paragraph} from '@s-ui/documentation-library'
+/* eslint-disable  no-console */
+import {Article, Code, H2, H3, Paragraph} from '@s-ui/documentation-library'
 
-import ArticleArrayObjects from './ArticleArrayObjects/index.js'
-import ArticleDependantSelection from './ArticleDependantSelection/index.js'
-import ArticleIsOpenProp from './ArticleIsOpenProp/index.js'
-import ArticleMultipleSelection from './ArticleMultipleSelection/index.js'
-import ArticleSingleSelection from './ArticleSingleSelection/index.js'
+import {MoleculeAutosuggestWithStateTags} from '../config.js'
+import {iconClose, iconSearch} from '../Icons/index.js'
 
-import './index.scss'
-
-const Demo = () => (
-  <div className="sui-StudioPreview">
-    <div className="sui-StudioPreview-content sui-StudioDemo-preview">
-      <H1>Autosuggest</H1>
+const ArticleMultipleSelection = () => {
+  return (
+    <Article>
+      <H2>Multiple Selection</H2>
       <Paragraph>
-        This component should only be used when the input is writable (resulting in a search of the{' '}
-        <Code>DropdownList</Code> options)
+        This component allows you to add new options (such as tags) even if they are not available among the available
+        options of <Code>DropdownList</Code>
       </Paragraph>
-      <Paragraph>
-        In this demo, we only use the default size of <Code>DropdownList</Code> and basic options of{' '}
-        <Code>DropdownOption</Code> components. Keep in mind, those two components has more possibilities if you need
-        it.
-      </Paragraph>
-      <ArticleSingleSelection />
-      <br />
-      <ArticleMultipleSelection />
-      <br />
-      <ArticleDependantSelection />
-      <br />
-      <ArticleIsOpenProp />
-      <br />
-      <ArticleArrayObjects />
-    </div>
-  </div>
-)
+      <H3>with Placeholder</H3>
+      <MoleculeAutosuggestWithStateTags
+        placeholder="Type a Country name..."
+        onChangeTags={(_, {tags, ...args}) => console.log('onChangeTags', {tags, ...args})}
+        onClear={() => console.log('Clear pressed')}
+        iconCloseTag={iconClose}
+        iconClear={iconClose}
+        multiselection
+      />
+      <H3>With preselected Value</H3>
+      <MoleculeAutosuggestWithStateTags
+        tags={['India', 'Luxembourg']}
+        onChangeTags={(_, {tags, ...args}) => console.log('onChangeTags', {tags, ...args})}
+        onClear={() => console.log('Clear pressed')}
+        iconCloseTag={iconClose}
+        iconClear={iconClose}
+        multiselection
+      />
+      <H3>Disabled</H3>
+      <MoleculeAutosuggestWithStateTags
+        tags={['India', 'Luxembourg']}
+        onChangeTags={(_, {tags, ...args}) => console.log('onChangeTags', {tags, ...args})}
+        onClear={() => console.log('Clear pressed')}
+        iconCloseTag={iconClose}
+        iconClear={iconClose}
+        multiselection
+        disabled
+      />
+      <H3>With Right Icon and onClick handler</H3>
+      <MoleculeAutosuggestWithStateTags
+        placeholder="Type a Country name..."
+        onChangeTags={(_, {tags, ...args}) => console.log('onChangeTags', {tags, ...args})}
+        iconCloseTag={iconClose}
+        rightIcon={iconSearch}
+        onClickRightIcon={(ev, args) => {
+          console.log('Right icon clicked!', args)
+        }}
+        multiselection
+      />
+    </Article>
+  )
+}
 
-export default Demo
+ArticleMultipleSelection.propTypes = {}
+
+export default ArticleMultipleSelection

--- a/components/molecule/autosuggest/src/components/MultipleSelection/index.js
+++ b/components/molecule/autosuggest/src/components/MultipleSelection/index.js
@@ -27,12 +27,14 @@ const MoleculeAutosuggestFieldMultiSelection = ({
   onChange,
   onChangeTags,
   onClear,
+  onClickRightIcon,
   onInputKeyDown,
   onSelect,
   onKeyDown,
   onToggle,
   placeholder,
   required,
+  rightIcon,
   shape,
   size,
   tabIndex,
@@ -94,6 +96,10 @@ const MoleculeAutosuggestFieldMultiSelection = ({
     }
   }
 
+  const handleRightClick = (ev, args = {}) => {
+    typeof onClickRightIcon === 'function' && onClickRightIcon(ev, {...args, value})
+  }
+
   return (
     <>
       <InputWithClearUI
@@ -114,9 +120,11 @@ const MoleculeAutosuggestFieldMultiSelection = ({
         onChangeTags={handleChangeTags}
         onClick={onToggle}
         onClickClear={handleClear}
+        onClickRightIcon={handleRightClick}
         onKeyDown={onInputKeyDown}
         placeholder={!tags.length ? placeholder : ''}
         required={required}
+        rightIcon={rightIcon}
         shape={shape}
         tabIndex={tabIndex}
         tags={tags}

--- a/components/molecule/autosuggest/test/index.test.js
+++ b/components/molecule/autosuggest/test/index.test.js
@@ -383,6 +383,42 @@ describe(json.name, () => {
           await waitFor(() => expect(sinon.assert.called(onBlurSpy)))
         })
       })
+
+      describe('rightIcon', () => {
+        it('should render rightIcon when provided in multiselection mode', () => {
+          // Given
+          const testID = 'right-icon-test'
+          const props = {
+            multiselection: true,
+            rightIcon: <svg data-testid={testID} />
+          }
+
+          // When
+          const {getByTestId} = setup(props)
+
+          // Then
+          expect(() => getByTestId(testID)).to.not.throw()
+        })
+
+        it('should call onClickRightIcon handler when rightIcon is clicked in multiselection mode', () => {
+          // Given
+          const onClickRightIconSpy = sinon.spy()
+          const testID = 'right-icon-test'
+          const props = {
+            multiselection: true,
+            rightIcon: <svg data-testid={testID} />,
+            onClickRightIcon: onClickRightIconSpy
+          }
+
+          // When
+          const {getByTestId} = setup(props)
+          const rightIconElement = getByTestId(testID)
+          fireEvent.click(rightIconElement)
+
+          // Then
+          sinon.assert.calledOnce(onClickRightIconSpy)
+        })
+      })
     })
   })
 


### PR DESCRIPTION
  ## molecule/autosuggest
  <!-- https://martinfowler.com/articles/ship-show-ask.html -->
  <!-- Uncomment what you need -->
  <!-- #### `🔍 Show` -->

  <!-- https://github.com/SUI-Components/sui-components/issues -->
  **TASK**: <!--- #issueID -->

  ### Description, Motivation and Context

  This PR adds support for `rightIcon` and `onClickRightIcon` props to the multiselection mode of the MoleculeAutosuggest component.

  **Changes:**
  - Added `rightIcon` prop to display a custom icon on the right side of the multiselection input
  - Added `onClickRightIcon` callback prop to handle click events on the right icon
  - Implemented `handleRightClick` handler that passes event and current value to the callback
  - Added demo example showing the rightIcon with interactive onClick handler
  - Updated README documentation with usage examples for the new props
  - Added tests to verify rightIcon rendering and onClick behavior in multiselection mode

  **Motivation:**
  This enhancement provides more flexibility for multiselection inputs, allowing developers to add custom actions via a right icon (e.g.,
  search, submit, info tooltips) similar to what's already available in single selection mode.

  ### Types of changes
  <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

  - [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
  - [x] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] 🧾 Documentation
  - [x] 📷 Demo
  - [x] 🧪 Test
  - [ ] 🧠 Refactor
  - [ ] 💄 Styles
  - [ ] 🛠️ Tool

  ### Screenshots - Animations
  <!-- Adding images or gif animations of your changes improves the understanding of your changes -->

