### PR TITLE
feat(components/atom/videoPlayer): use static imports for vite compatibility

### DIFF
--- a/components/atom/videoPlayer/src/hooks/useVideoPlayer.js
+++ b/components/atom/videoPlayer/src/hooks/useVideoPlayer.js
@@ -2,13 +2,40 @@ import {lazy} from 'react'
 
 import {UNKNOWN} from '../settings/index.js'
 import useDetectVideoType from './useDetectVideoType.js'
+
+// Static imports for Vite compatibility (instead of dynamic template strings)
+const HLSPlayer = lazy(() => import('../components/HLSPlayer.js'))
+const NativePlayer = lazy(() => import('../components/NativePlayer.js'))
+const VimeoPlayer = lazy(() => import('../components/VimeoPlayer.js'))
+const YouTubePlayer = lazy(() => import('../components/YouTubePlayer.js'))
+
+// Map player component names to actual components
+const PLAYER_COMPONENTS = {
+  HLSPlayer,
+  NativePlayer,
+  VimeoPlayer,
+  YouTubePlayer
+}
+
 const useVideoPlayer = props => {
   const {src} = props
   const {detectVideoType} = useDetectVideoType()
   const videoType = detectVideoType(src)
-  if (videoType === UNKNOWN) return ['p', {...props, children: 'Not supported media type'}]
 
-  return [lazy(() => import(`../components/${videoType.PLAYER_COMPONENT}.js`)), props]
+  if (videoType === UNKNOWN) {
+    return ['p', {...props, children: 'Not supported media type'}]
+  }
+
+  // Get the component from the map instead of using dynamic import
+  const Component = PLAYER_COMPONENTS[videoType.PLAYER_COMPONENT]
+
+  if (!Component) {
+    console.error(`[useVideoPlayer] Unknown player component: ${videoType.PLAYER_COMPONENT}`)
+
+    return ['p', {...props, children: 'Not supported media type'}]
+  }
+
+  return [Component, props]
 }
 
 export default useVideoPlayer

--- a/components/atom/videoPlayer/src/index.js
+++ b/components/atom/videoPlayer/src/index.js
@@ -1,4 +1,4 @@
-import {createRef, forwardRef, Suspense, useRef} from 'react'
+import {createRef, forwardRef, Suspense, useEffect, useRef, useState} from 'react'
 
 import PropTypes from 'prop-types'
 
@@ -34,6 +34,13 @@ const AtomVideoPlayer = forwardRef(
     },
     forwardedRef = createRef()
   ) => {
+    // SSR-safe: Only render on client-side to avoid Suspense issues
+    const [isClient, setIsClient] = useState(false)
+
+    useEffect(() => {
+      setIsClient(true)
+    }, [])
+
     const [Component, props] = useVideoPlayer({
       autoPlay,
       controls,
@@ -57,6 +64,15 @@ const AtomVideoPlayer = forwardRef(
 
     const needsToRenderFallbackComponent =
       fallbackWhileNotOnViewport === true && autoPlay === AUTOPLAY.ON_VIEWPORT && !autoPlayState
+
+    // Don't render during SSR - only on client
+    if (!isClient) {
+      return (
+        <div ref={componentRef} className={BASE_CLASS}>
+          {fallbackComponent}
+        </div>
+      )
+    }
 
     return (
       <div ref={componentRef} className={BASE_CLASS}>


### PR DESCRIPTION
## Category/Component
#### `🔍 Show`

### Description, Motivation and Context

#### Fix SSR suspension and Vite compatibility issues

##### Changes

- **SSR-safe rendering**: Added client-only rendering guard to prevent Suspense errors during server-side rendering
- **Vite compatibility**: Replaced dynamic template string imports with static imports to fix Vite bundling issues

##### Technical Details

**Before:**
- `lazy(() => import('../components/${videoType.PLAYER_COMPONENT}.js'))` - Dynamic imports with template strings (Vite can't analyze)
- `<Suspense>` caused suspension errors during SSR

**After:**
- Static imports mapped to a `PLAYER_COMPONENTS` object
- Component only renders on client-side after hydration
- Fallback component shown during SSR

##### Backwards Compatibility

✅ Fully backwards compatible - no breaking changes to public API

---

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [x] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool