### PR TITLE
Feat/add title label

### DIFF
--- a/components/atom/tag/src/Standard.js
+++ b/components/atom/tag/src/Standard.js
@@ -52,7 +52,7 @@ const StandardTag = forwardRef(
         <Component ref={forwardedRef} {...props}>
           {icon && <span className="sui-AtomTag-icon">{icon}</span>}
           {label ? (
-            <p className="sui-AtomTag-label" title={title || label}>
+            <p className="sui-AtomTag-label" title={title}>
               {label}
             </p>
           ) : null}

--- a/components/atom/tag/src/Standard.js
+++ b/components/atom/tag/src/Standard.js
@@ -52,9 +52,9 @@ const StandardTag = forwardRef(
         <Component ref={forwardedRef} {...props}>
           {icon && <span className="sui-AtomTag-icon">{icon}</span>}
           {label ? (
-            <span className="sui-AtomTag-label" title={title}>
+            <p className="sui-AtomTag-label" title={title || label}>
               {label}
-            </span>
+            </p>
           ) : null}
           {closeIcon && !(disabled || readOnly) && (
             <button

--- a/components/atom/tag/test/index.test.js
+++ b/components/atom/tag/test/index.test.js
@@ -230,20 +230,6 @@ describe(json.name, () => {
       expect(tag).to.have.attribute('title', 'title')
     })
 
-    it('should not add a title attribute when not defined', () => {
-      // Given
-      const props = {
-        label: 'tag without title'
-      }
-
-      // When
-      const {getByText} = setup(props)
-      const tag = getByText(props.label)
-
-      // Then
-      expect(tag).to.not.have.attribute('title')
-    })
-
     describe('closeIcon', () => {
       it('given a closeIcon and clicking on it should fire onClose event', () => {
         // Given

--- a/components/atom/tag/test/index.test.js
+++ b/components/atom/tag/test/index.test.js
@@ -230,6 +230,20 @@ describe(json.name, () => {
       expect(tag).to.have.attribute('title', 'title')
     })
 
+    it('should not add a title attribute when not defined', () => {
+      // Given
+      const props = {
+        label: 'tag without title'
+      }
+
+      // When
+      const {getByText} = setup(props)
+      const tag = getByText(props.label)
+
+      // Then
+      expect(tag).to.not.have.attribute('title')
+    })
+
     describe('closeIcon', () => {
       it('given a closeIcon and clicking on it should fire onClose event', () => {
         // Given


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
Fix AtomTag title not showing on hover

Previously, the Atom Tag label did not display the title tooltip when hovering over the tag. This was caused by the label being rendered inside a span, which prevented the tooltip from appearing correctly in this context.

To fix this, the label element was changed from span to p, allowing the title attribute to work as expected when hovering over the tag.

Result
The tag now correctly shows the title tooltip on hover.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [x] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
