### PR TITLE
feat(components/atom/progressBar): make borderless work for atom progressBar

### DIFF
--- a/components/atom/progressBar/src/ProgressBarLine/index.scss
+++ b/components/atom/progressBar/src/ProgressBarLine/index.scss
@@ -17,16 +17,13 @@ $base-class-line: '#{$base-class}Line';
       border: $bd-line-progress-container--success;
     }
 
-    &--borderless {
-      border: none;
-    }
-
     background: $bg-progress-bar;
     border: $bd-line-progress-container;
     border-radius: $bdrs-progress-container;
     height: $h-progress-bar; /* Can be anything */
     position: relative;
     box-sizing: border-box;
+
     &--size {
       @each $size-key, $size-value in $size-atom-line-progress-bar {
         &-#{$size-key} {
@@ -34,6 +31,7 @@ $base-class-line: '#{$base-class}Line';
         }
       }
     }
+
     &--color {
       @each $colorName, $colorValue in $c-progress-bar-fill-array {
         &-#{$colorName} {
@@ -41,6 +39,10 @@ $base-class-line: '#{$base-class}Line';
           border-color: color-mix(in srgb, $bc-progress-bar, $colorValue 16%);
         }
       }
+    }
+
+    &--borderless {
+      border: none;
     }
   }
 


### PR DESCRIPTION
## Category/Component
<!-- https://martinfowler.com/articles/ship-show-ask.html -->
<!-- Uncomment what you need -->
<!-- #### `🚢 Ship` <!-- (should never be used for PR) -->
<!-- #### `🔍 Show` -->
<!-- #### `❓ Ask` -->

<!-- https://github.com/SUI-Components/sui-components/issues -->
**TASK**: <!--- #issueID -->
`isBorderless` prop was not working properly because of how the border value was set on the component styles.

### Description, Motivation and Context
Changed the order in which the `--borderless` modifier is loaded so that it works as expected.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
- [ ] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
